### PR TITLE
⚡️ zb: Sort interfaces by name in managed objects

### DIFF
--- a/zbus/src/fdo/object_manager.rs
+++ b/zbus/src/fdo/object_manager.rs
@@ -3,7 +3,10 @@
 //! The D-Bus specification defines the message bus messages and some standard interfaces that may
 //! be useful across various D-Bus applications. This module provides their proxy.
 
-use std::{borrow::Cow, collections::HashMap};
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, HashMap},
+};
 use zbus_names::{InterfaceName, OwnedInterfaceName};
 use zvariant::{ObjectPath, OwnedObjectPath, OwnedValue, Value};
 
@@ -12,7 +15,7 @@ use crate::{Connection, ObjectServer, interface, message::Header, object_server:
 
 /// The type returned by the [`ObjectManagerProxy::get_managed_objects`] method.
 pub type ManagedObjects =
-    HashMap<OwnedObjectPath, HashMap<OwnedInterfaceName, HashMap<String, OwnedValue>>>;
+    HashMap<OwnedObjectPath, BTreeMap<OwnedInterfaceName, HashMap<String, OwnedValue>>>;
 
 /// Service-side [Object Manager][om] interface implementation.
 ///

--- a/zbus/src/object_server/node.rs
+++ b/zbus/src/object_server/node.rs
@@ -267,7 +267,7 @@ impl Node {
         // Recursively get all properties of all interfaces of descendants.
         let mut node_list: Vec<_> = self.children.values().collect();
         while let Some(node) = node_list.pop() {
-            let mut interfaces = HashMap::new();
+            let mut interfaces = BTreeMap::new();
             for iface_name in node
                 .interfaces
                 .keys()


### PR DESCRIPTION
For GetManagedObjects result, it would be more convenient if the interfaces on each object path represented are sorted by interface name instead of sent in random order.

This is not achieved by this change. While the interfaces are sorted in the ManagedObjects structure, the marshalling procedure, which is defined by the D-Bus spec, removes the order. The interfaces sent on the D-Bus are in random order.

This change likely results in slightly more efficent processing when building the temporary interfaces BTreeMap to create the ObjectManager struct.

The interfaces, being ordered in Node's interfaces attribute, are inserted in order into the temporary interfaces BTreeMap, so there is no cost involved in shuffling the keys for sorting during insertion.

The space allocation cost is probably a toss up.
