### PR TITLE
🚑️  zb: Fix sendmsg for iOS and other apple OS

### DIFF
--- a/zbus/src/connection/socket/unix.rs
+++ b/zbus/src/connection/socket/unix.rs
@@ -326,9 +326,23 @@ fn fd_sendmsg(fd: BorrowedFd<'_>, buffer: &[u8], fds: &[BorrowedFd<'_>]) -> std:
         ));
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "redox")))]
+    #[cfg(not(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "visionos",
+        target_os = "watchos",
+        target_os = "redox"
+    )))]
     let flags = SendFlags::NOSIGNAL;
-    #[cfg(any(target_os = "macos", target_os = "redox"))]
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "visionos",
+        target_os = "watchos",
+        target_os = "redox"
+    ))]
     let flags = SendFlags::empty();
 
     let sent = sendmsg(fd, &iov, &mut ancillary, flags)?;


### PR DESCRIPTION
Since https://github.com/z-galaxy/zbus/pull/1660 `zbus` is unable to build for iOS.

```console
$ cargo check --target=aarch64-apple-ios
error[E0599]: no associated item named `NOSIGNAL` found for struct `SendFlags` in the current scope
   --> zbus/src/connection/socket/unix.rs:330:28
    |
330 |     let flags = SendFlags::NOSIGNAL;
    |                            ^^^^^^^^ associated item not found in `SendFlags`
```