### PR TITLE
🐛 zv: Give fields with missing framing offsets their default value

### DIFF
--- a/zvariant/src/framing_offset_size.rs
+++ b/zvariant/src/framing_offset_size.rs
@@ -48,7 +48,8 @@ impl FramingOffsetSize {
     }
 
     pub fn read_last_offset_from_buffer(self, buffer: &[u8]) -> usize {
-        if buffer.is_empty() {
+        // The buffer must be able to hold a whole offset, otherwise `end - N` below underflows.
+        if buffer.len() < self as usize {
             return 0;
         }
 
@@ -89,6 +90,28 @@ impl FramingOffsetSize {
 #[cfg(test)]
 mod tests {
     use crate::framing_offset_size::FramingOffsetSize;
+
+    #[test]
+    fn read_last_offset_from_short_buffer() {
+        // A buffer too short to hold a whole offset must not panic.
+        let sizes = [
+            FramingOffsetSize::U8,
+            FramingOffsetSize::U16,
+            FramingOffsetSize::U32,
+            #[cfg(not(target_pointer_width = "32"))]
+            FramingOffsetSize::U64,
+        ];
+        for size in sizes {
+            for len in 0..(size as usize) {
+                assert_eq!(size.read_last_offset_from_buffer(&vec![0xff; len]), 0);
+            }
+            // One full offset is still read as before.
+            assert_eq!(
+                size.read_last_offset_from_buffer(&vec![0xff; size as usize]),
+                ((1u128 << (8 * size as u32)) - 1) as usize,
+            );
+        }
+    }
 
     #[test]
     fn framing_offset_size_bump() {

--- a/zvariant/src/gvariant/de.rs
+++ b/zvariant/src/gvariant/de.rs
@@ -734,20 +734,21 @@ impl<'d, 'de, 'sig, 'f, #[cfg(unix)] F: AsFd, #[cfg(not(unix))] F> SeqAccess<'de
         let element_end = if !field_signature.is_fixed_sized() {
             if self.field_idx == self.num_fields {
                 // This is the last item then and in GVariant format, we don't have offset for it
-                // even if it's non-fixed-sized.
-                self.end
+                // even if it's non-fixed-sized. The framing offsets can overlap the content, in
+                // which case there is nothing left for this item and it takes its default value.
+                self.end.max(self.de.0.pos)
+            } else if self.end < self.start + self.offset_size as usize {
+                // Not enough space left for this field's framing offset. Per §2.7.4 of the
+                // GVariant specification, an item whose framing offset is unavailable takes
+                // its default value, and an empty slice deserializes to the default of any
+                // non-fixed-sized type.
+                self.de.0.pos
             } else {
                 let end = self
                     .offset_size
                     .read_last_offset_from_buffer(subslice(self.de.0.bytes, self.start..self.end)?)
                     + self.start;
                 let offset_size = self.offset_size as usize;
-                if offset_size > self.end {
-                    return Err(serde::de::Error::invalid_length(
-                        offset_size,
-                        &format!("< {}", self.end).as_str(),
-                    ));
-                }
 
                 self.end -= offset_size;
                 self.offsets_len += offset_size;
@@ -911,5 +912,51 @@ impl<'de, 'd, 'sig, 'f, #[cfg(unix)] F: AsFd, #[cfg(not(unix))] F> EnumAccess<'d
         V: DeserializeSeed<'de>,
     {
         seed.deserialize(&mut *self.de).map(|v| (v, self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        LE, Value,
+        serialized::{Context, Data},
+    };
+
+    // §2.7.4 of the GVariant specification, "Insufficient Space for Structure Framing
+    // Offsets", with the example given there.
+    #[test]
+    fn missing_framing_offsets_yield_default_values() {
+        let ctxt = Context::new_gvariant(LE, 0);
+        let bytes = [0x03u8, 0x02, 0x01];
+        let data = Data::new(&bytes[..], ctxt);
+        let (decoded, _) = data
+            .deserialize::<(Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>)>()
+            .unwrap();
+
+        assert_eq!(decoded, (vec![3], vec![2], vec![1], vec![], vec![]));
+    }
+
+    // A struct with enough offset-less fields used to shrink the buffer below one offset
+    // and panic. Empty byte arrays cost no data bytes, so they get there quickest.
+    #[test]
+    fn struct_with_more_fields_than_offsets() {
+        let mut signature = String::from("(");
+        for _ in 0..130 {
+            signature.push_str("ay");
+        }
+        signature.push(')');
+
+        // 257 bytes of container, so framing offsets are two bytes wide.
+        let mut bytes = vec![0u8; 257];
+        bytes.push(0);
+        bytes.extend_from_slice(signature.as_bytes());
+
+        let ctxt = Context::new_gvariant(LE, 0);
+        let data = Data::new(&bytes[..], ctxt);
+        let (decoded, _) = data.deserialize::<Value<'_>>().unwrap();
+        let Value::Structure(s) = decoded else {
+            panic!("expected a structure");
+        };
+        assert_eq!(s.fields().len(), 130);
     }
 }


### PR DESCRIPTION
§2.7.4 of the GVariant specification says that when a structure has insufficient space for its
framing offsets, an item whose offset is unavailable takes its default value. zvariant errored out
instead — and could underflow before it got that far.

`StructureDeserializer` shrinks `self.end` by one offset per non-fixed-sized field, while the offset
size stays as computed in `new()` from the original container length, so the buffer can fall below
one offset while still non-empty. `read_last_offset_from_buffer` only checked for an empty buffer,
so `end - N` underflowed — in release builds an out-of-range slice index rather than a subtract
overflow, so it panicked either way. Empty byte arrays cost no data bytes, so enough of them get
there:

```rust
let mut sig = String::from("(");
for _ in 0..130 { sig.push_str("ay"); }
sig.push(')');

let mut buf = vec![0u8; 257];   // > u8::MAX, so offsets are 2 bytes wide
buf.push(0x00);                 // variant separator
buf.extend_from_slice(sig.as_bytes());

let _ = Data::new(&buf[..], Context::new_gvariant(LE, 0)).deserialize::<Value>();
```

```
panicked at zvariant/src/framing_offset_size.rs:58:58:
range start index 18446744073709551615 out of range for slice of length 1
```

Those fields now get an empty slice, which deserializes to the default of any non-fixed-sized type.
The spec's own example deserializes as documented, where before it was an error:

```
03 02 01  as  (ayayayayay)  ->  ([3], [2], [1], [], [])
```

That example is one of the two new tests; the other is the reproducer above.

I kept a short-buffer check in `read_last_offset_from_buffer` as well, so the primitive can't
underflow for a future caller — happy to drop it if you'd rather have just the one change.

`cargo test -p zvariant --all-features` and `--features ostree-tests` both pass;
`number::bool_value::bool_maybe_array_value` fails under `--all-features` on unmodified `main` too.
