### PR TITLE
🔧 zv: Downgrade semver-checks' struct_missing lint to a warning

### DIFF
--- a/zvariant/Cargo.toml
+++ b/zvariant/Cargo.toml
@@ -71,3 +71,12 @@ targets = [
 
 [lints]
 workspace = true
+
+# `Str` is a cross-crate re-export (of `zcheapstr::CheapStr`), which
+# cargo-semver-checks cannot resolve, making it incorrectly flag the struct as
+# removed and `release-plz update` in turn bump the major version.
+# FIXME: Drop this after the first post-split zvariant release, or once
+# cargo-semver-checks handles cross-crate items:
+# https://github.com/obi1kenobi/cargo-semver-checks/issues/638
+[package.metadata.cargo-semver-checks.lints]
+struct_missing = "warn"


### PR DESCRIPTION
`Str` is a cross-crate re-export (of zcheapstr's `CheapStr`), which cargo-semver-checks cannot resolve ([obi1kenobi/cargo-semver-checks#638](https://github.com/obi1kenobi/cargo-semver-checks/issues/638)), making it incorrectly flag the struct as removed — and `release-plz update` would in turn bump zvariant's major version.

With this override, `cargo semver-checks check-release -p zvariant` reports "no semver update required" (verified locally with v0.50.0, the version CI uses), with the false positive still visible as a warning rather than silently ignored.

This can be dropped after the first post-split zvariant release, since the crates.io baseline will then contain the re-export as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019xECEroGmP6ah6iZKukUBT

---
_Generated by [Claude Code](https://claude.ai/code/session_019xECEroGmP6ah6iZKukUBT)_