### PR TITLE
💥 zu: Bump version to 4.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "3.5.0"
+version = "4.0.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/zbus_macros/Cargo.toml
+++ b/zbus_macros/Cargo.toml
@@ -33,7 +33,7 @@ proc-macro-crate.workspace = true
 
 zvariant = { path = "../zvariant", version = "5.14.0" }
 zbus_names = { path = "../zbus_names", version = "4.3.4" }
-zvariant_utils = { path = "../zvariant_utils", version = "3.5.0" }
+zvariant_utils = { path = "../zvariant_utils", version = "4.0.0" }
 
 [dev-dependencies]
 zbus.workspace = true

--- a/zvariant/Cargo.toml
+++ b/zvariant/Cargo.toml
@@ -23,7 +23,7 @@ camino = ["dep:camino"]
 
 [dependencies]
 zvariant_derive = { path = "../zvariant_derive", version = "5.14.0" }
-zvariant_utils = { path = "../zvariant_utils", version = "3.5.0" }
+zvariant_utils = { path = "../zvariant_utils", version = "4.0.0" }
 zcheapstr.workspace = true
 endi.workspace = true
 serde.workspace = true

--- a/zvariant_derive/Cargo.toml
+++ b/zvariant_derive/Cargo.toml
@@ -25,7 +25,7 @@ proc-macro2.workspace = true
 syn.workspace = true
 quote.workspace = true
 proc-macro-crate.workspace = true
-zvariant_utils = { path = "../zvariant_utils", version = "3.5.0" }
+zvariant_utils = { path = "../zvariant_utils", version = "4.0.0" }
 
 [dev-dependencies]
 zvariant = { workspace = true, features = ["enumflags2"] }

--- a/zvariant_utils/CHANGELOG.md
+++ b/zvariant_utils/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.0.0 - 2026-08-09
+
+### Breaking
+- ⬆️ Update syn to v3. Syn types appear in this crate's public API, hence the major
+  version bump.
+
 ## 3.5.0 - 2026-07-07
 
 ### Fixed

--- a/zvariant_utils/Cargo.toml
+++ b/zvariant_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zvariant_utils"
-version = "3.5.0"
+version = "4.0.0"
 authors = [
     "Zeeshan Ali Khan <zeeshanak@gnome.org>",
     "turbocooler <turbocooler@cocaine.ninja>",


### PR DESCRIPTION
Fixes the `release-plz release` failure when publishing zvariant_derive.

The syn upgrade from v2 to v3 (bc6b5ac) was a **breaking change for zvariant_utils** — syn types (`Type`, `Meta`, `Attribute`) appear throughout its public API — but its version was never bumped along: the upgrade only touched the workspace manifest (syn is a workspace dependency), which release-plz doesn't attribute to member packages, so no bump and no semver check happened. Verified: crates.io's `zvariant_utils 3.5.0` requires `syn ^2.0.64`, while the workspace is on syn 3.

The release then fails at zvariant_derive: its packaging verify build resolves the published (syn-2-based) `zvariant_utils 3.5.0` against the workspace's syn 3, producing the mismatched-type errors for every syn type crossing the API boundary.

This bumps zvariant_utils to 4.0.0 (with a changelog entry), and updates the version requirement in zvariant, zvariant_derive and zbus_macros. With that, `release-plz release` publishes zvariant_utils 4.0.0 first (no tag exists for it) and the dependent crates' verify builds resolve it instead of 3.5.0. Locally verified: `cargo publish --dry-run -p zvariant_utils` packages and verify-builds clean; the dependents' verify can only be exercised once 4.0.0 is actually on crates.io, since their requirement now points at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019xECEroGmP6ah6iZKukUBT