### PR TITLE
💚 zv: Work around nightly rustfmt macro mangling

### DIFF
--- a/zvariant/src/de.rs
+++ b/zvariant/src/de.rs
@@ -157,20 +157,16 @@ impl<'de, #[cfg(unix)] F: AsFd, #[cfg(not(unix))] F> de::Deserializer<'de>
     deserialize_method!(deserialize_byte_buf());
     deserialize_method!(deserialize_option());
     deserialize_method!(deserialize_unit());
-    deserialize_method!(deserialize_unit_struct(n: &'static str));
-    deserialize_method!(deserialize_newtype_struct(n: &'static str));
+    // Brace-delimited invocations: the args are `name: type` pairs, which recent nightly rustfmt
+    // mis-parses as parenthesized generic arguments (dropping the names) in `!(...)` form.
+    deserialize_method! { deserialize_unit_struct(n: &'static str) }
+    deserialize_method! { deserialize_newtype_struct(n: &'static str) }
     deserialize_method!(deserialize_seq());
     deserialize_method!(deserialize_map());
-    deserialize_method!(deserialize_tuple(n: usize));
-    deserialize_method!(deserialize_tuple_struct(n: &'static str, l: usize));
-    deserialize_method!(deserialize_struct(
-        n: &'static str,
-        f: &'static [&'static str]
-    ));
-    deserialize_method!(deserialize_enum(
-        n: &'static str,
-        f: &'static [&'static str]
-    ));
+    deserialize_method! { deserialize_tuple(n: usize) }
+    deserialize_method! { deserialize_tuple_struct(n: &'static str, l: usize) }
+    deserialize_method! { deserialize_struct(n: &'static str, f: &'static [&'static str]) }
+    deserialize_method! { deserialize_enum(n: &'static str, f: &'static [&'static str]) }
     deserialize_method!(deserialize_identifier());
     deserialize_method!(deserialize_ignored_any());
 


### PR DESCRIPTION
The latest nightly rustfmt parses `method(n: usize)`-style macro arguments as parenthesized
generic arguments (`Fn`-sugar types) and re-emits them **without the parameter names**. For
`deserialize_method!` that rewrite would break the build: its matcher requires the
`ident: ty` pairs. So `cargo +nightly fmt` cannot simply be applied — its output doesn't
compile (looks like a rustfmt regression; nothing exactly matching found upstream, closest is
rust-lang/rustfmt#6418).

Instead, switch the arg-taking invocations to brace-delimited macro calls, which rustfmt's
expression/type formatting leaves alone (and which read naturally for item-generating macros).
Token stream is unchanged; `cargo check -p zvariant` and the full-workspace
`cargo +nightly fmt -- --check` both verified locally on the reproducing nightly
(1.99.0-nightly 2026-08-09).

Unblocks #1896, which is stacked on this PR.

Generated by Claude Fable 5 (claude-fable-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vw5uRE2AL6ddxgwqoPTxVr