### PR TITLE
🔧 Support skipping the changelog via a commit trailer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,9 @@ zbus/src/
 - **Changelog**: `CHANGELOG.md` files are managed by [release-plz] — do **not** hand-edit
   them. Write a good commit message (conventional-commits-ish) and release-plz will
   generate the entry at release time.
+- **Changelog-skip trailer**: end a commit message with a `Changelog: skip` git trailer to
+  keep it out of the user-facing changelog (use for AI-workflow artifacts such as design docs
+  and implementation plans).
 - **Testing**: Integration tests require D-Bus session bus
 - **Cross-platform**: Validate changes work on Linux, Windows, macOS
 - **Dependencies**: Check compatibility with async runtimes and optional features

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -53,11 +53,16 @@ commit_preprocessors = [
     # Matches: "Fixes #123", "Closes issue #123", "Resolves bug #123", etc.
     # Appends issue ref with "||" delimiter so template can insert period before it.
     { pattern = ".*", replace_command = "sh -c 'title=$(cat); ref=$(git log -1 --format=%b $COMMIT_SHA 2>/dev/null | grep -oE \"(Fixes|Closes|Resolves).*#[0-9]+\" | grep -oE \"#[0-9]+\" | head -1); if [ -n \"$ref\" ]; then printf \"%s||%s\\n\" \"$title\" \"$ref\"; else printf \"%s\\n\" \"$title\"; fi'" },
+    # Replace the message of commits carrying a "Changelog: skip" git trailer with a sentinel
+    # that the first commit parser below drops (e.g. AI-workflow design docs and plans).
+    { pattern = ".*", replace_command = "sh -c 'title=$(cat); if git log -1 --format=\"%(trailers:key=Changelog,valueonly)\" $COMMIT_SHA 2>/dev/null | grep -qix skip; then echo changelog-skip; else printf \"%s\\n\" \"$title\"; fi'" },
 ]
 
 # Categorize commits based on gimoji emojis.
 # See: https://zeenix.github.io/gimoji/
 commit_parsers = [
+    # Skip commits carrying a "Changelog: skip" trailer (see the preprocessor above).
+    { message = "^changelog-skip$", skip = true },
     # Skip merge commits, release commits, and empty commits (just emojis).
     { message = "^[Mm]erge", skip = true },
     { message = "^🔖", skip = true },


### PR DESCRIPTION
Commits for AI-workflow artifacts (design docs, implementation plans) don't belong in the
user-facing changelog and currently have to be pruned by hand at release time. This adds
support for ending a commit message with a `Changelog: skip` git trailer to drop it from the
generated `CHANGELOG.md`, and documents the convention in `AGENTS.md`.

git-cliff's commit parsers only see conventional-commit parts, which gimoji commits don't
have, so the trailer is detected via `git log` in a preprocessor and the message replaced
with a sentinel (`changelog-skip`) that a parser then drops. Path-based filtering
(`exclude_paths`) is not available in the released `release-plz`/`git-cliff`.

Usage: append a trailer to the end of a commit message, e.g. `Changelog: skip`.

Verified locally with `release-plz update` on three scratch commits appended to
`zbus/README.md` (`📝 Skip me A` with a real `Changelog: skip` trailer, `📝 Keep me B` with
the phrase only in prose, `📝 Keep me C` with no body). The resulting `zbus/CHANGELOG.md` diff:

```
## 5.19.1 - 2026-08-10

### Documentation
- 📝 Keep me C.
- 📝 Keep me B.
```

"Skip me A" is absent while "Keep me B" and "Keep me C" are both present, as expected.

Generated by Claude Fable 5 (claude-fable-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vw5uRE2AL6ddxgwqoPTxVr

