### PR TITLE
🔖 zv,zd,zu: New releases to deprecate GVariant API

### DIFF
--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -51,7 +51,7 @@ async-fs = []
 zbus_macros = { path = "../zbus_macros", version = "5.19.0" }
 zvariant = { path = "../zvariant", features = [
     "enumflags2",
-], version = "5.14.0" }
+], version = "5.15.0" }
 zbus_names = { path = "../zbus_names", version = "4.3.4" }
 
 serde.workspace = true

--- a/zbus_macros/Cargo.toml
+++ b/zbus_macros/Cargo.toml
@@ -33,7 +33,7 @@ syn = { workspace = true, features = ["extra-traits", "fold", "full"] }
 quote.workspace = true
 proc-macro-crate.workspace = true
 
-zvariant = { path = "../zvariant", version = "5.14.0" }
+zvariant = { path = "../zvariant", version = "5.15.0" }
 zbus_names = { path = "../zbus_names", version = "4.3.4" }
 zvariant_utils = { path = "../zvariant_utils", version = "4.1.0" }
 

--- a/zbus_names/Cargo.toml
+++ b/zbus_names/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 [dependencies]
 zvariant = { path = "../zvariant", features = [
     "enumflags2",
-], version = "5.13.1" }
+], version = "5.15.0" }
 
 serde.workspace = true
 winnow.workspace = true

--- a/zbus_xml/Cargo.toml
+++ b/zbus_xml/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 
 [dependencies]
 serde.workspace = true
-zvariant = { path = "../zvariant", version = "5.14.0" }
+zvariant = { path = "../zvariant", version = "5.15.0" }
 zbus_names = { path = "../zbus_names", version = "4.3.4" }
 winnow.workspace = true
 

--- a/zvariant/CHANGELOG.md
+++ b/zvariant/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 5.15.0 - 2026-08-18
+
+### CI
+- 💚 Work around nightly rustfmt macro mangling.
+
+### Deprecated
+- 🗑️ Deprecate GVariant support in zvariant.
+
+### Documentation
+- 📝 Point GVariant users to the zgvariant crate.
+
+### Fixed
+- 🐛 Support zvariant_utils/gvariant being enabled externally. #1910
+
+### Removed
+- 🔥 Remove the gvariant fuzz target.
+- 🔥 Remove gvariant benches, ostree tests and test data.
+
 ## 5.14.0 - 2026-08-09
 
 ### Changed

--- a/zvariant_derive/CHANGELOG.md
+++ b/zvariant_derive/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 5.15.0 - 2026-08-18
+
+### Changed
+- ♻️ Move Value & Dict derive codegen to zvariant_utils.
+- ♻️ Move Type derive & signature! codegen to zvariant_utils.
+
 ## 5.14.0 - 2026-08-09
 
 ### Other

--- a/zvariant_derive/Cargo.toml
+++ b/zvariant_derive/Cargo.toml
@@ -25,7 +25,7 @@ proc-macro2.workspace = true
 syn.workspace = true
 quote.workspace = true
 proc-macro-crate.workspace = true
-zvariant_utils = { path = "../zvariant_utils", version = "4.1.0" }
+zvariant_utils = { path = "../zvariant_utils", version = "4.2.0" }
 
 [dev-dependencies]
 zvariant = { workspace = true, features = ["enumflags2"] }

--- a/zvariant_utils/CHANGELOG.md
+++ b/zvariant_utils/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.2.0 - 2026-08-18
+
+### Deprecated
+- 🗑️ Deprecate GVariant support in zvariant.
+
+### Fixed
+- 🐛 Support zvariant_utils/gvariant being enabled externally. #1910
+
 ## 4.1.0 - 2026-08-16
 
 ### Added


### PR DESCRIPTION
- **⬆️  zb,zm,zx: Bump zvariant to 5.15**
- **🔖 zv,zd,zu: New releases to deprecate GVariant API**

<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/z-galaxy/zbus/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
