### PR TITLE
Validate names in `Value`/`OwnedValue` conversions

### DIFF
--- a/zbus_names/src/error_name.rs
+++ b/zbus_names/src/error_name.rs
@@ -1,6 +1,6 @@
 use crate::{Error, Result, utils::define_name_type_impls};
 use serde::Serialize;
-use zvariant::{OwnedValue, Str, Type, Value};
+use zvariant::{Str, Type};
 
 /// String that identifies an [error name][en] on the bus.
 ///
@@ -30,13 +30,11 @@ use zvariant::{OwnedValue, Str, Type, Value};
 /// ```
 ///
 /// [en]: https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names-error
-#[derive(
-    Clone, Debug, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue,
-)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Type, PartialOrd, Ord)]
 pub struct ErrorName<'name>(Str<'name>);
 
 /// Owned sibling of [`ErrorName`].
-#[derive(Clone, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue)]
+#[derive(Clone, Hash, PartialEq, Eq, Serialize, Type, PartialOrd, Ord)]
 pub struct OwnedErrorName(#[serde(borrow)] ErrorName<'static>);
 
 define_name_type_impls! {

--- a/zbus_names/src/interface_name.rs
+++ b/zbus_names/src/interface_name.rs
@@ -1,6 +1,6 @@
 use crate::{Error, Result, utils::define_name_type_impls};
 use serde::Serialize;
-use zvariant::{OwnedValue, Str, Type, Value};
+use zvariant::{Str, Type};
 
 /// String that identifies an [interface name][in] on the bus.
 ///
@@ -28,13 +28,11 @@ use zvariant::{OwnedValue, Str, Type, Value};
 /// ```
 ///
 /// [in]: https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names-interface
-#[derive(
-    Clone, Debug, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue,
-)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Type, PartialOrd, Ord)]
 pub struct InterfaceName<'name>(Str<'name>);
 
 /// Owned sibling of [`InterfaceName`].
-#[derive(Clone, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue)]
+#[derive(Clone, Hash, PartialEq, Eq, Serialize, Type, PartialOrd, Ord)]
 pub struct OwnedInterfaceName(#[serde(borrow)] InterfaceName<'static>);
 
 define_name_type_impls! {

--- a/zbus_names/src/member_name.rs
+++ b/zbus_names/src/member_name.rs
@@ -1,6 +1,6 @@
 use crate::{Error, Result, utils::define_name_type_impls};
 use serde::Serialize;
-use zvariant::{OwnedValue, Str, Type, Value};
+use zvariant::{Str, Type};
 
 /// String that identifies an [member (method or signal) name][in] on the bus.
 ///
@@ -26,13 +26,11 @@ use zvariant::{OwnedValue, Str, Type, Value};
 /// ```
 ///
 /// [in]: https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names-member
-#[derive(
-    Clone, Debug, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue,
-)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Type, PartialOrd, Ord)]
 pub struct MemberName<'name>(Str<'name>);
 
 /// Owned sibling of [`MemberName`].
-#[derive(Clone, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue)]
+#[derive(Clone, Hash, PartialEq, Eq, Serialize, Type, PartialOrd, Ord)]
 pub struct OwnedMemberName(#[serde(borrow)] MemberName<'static>);
 
 define_name_type_impls! {

--- a/zbus_names/src/property_name.rs
+++ b/zbus_names/src/property_name.rs
@@ -1,6 +1,6 @@
 use crate::{Error, Result, utils::define_name_type_impls};
 use serde::Serialize;
-use zvariant::{OwnedValue, Str, Type, Value};
+use zvariant::{Str, Type};
 
 /// String that identifies a [property][pn] name on the bus.
 ///
@@ -21,13 +21,11 @@ use zvariant::{OwnedValue, Str, Type, Value};
 /// ```
 ///
 /// [pn]: https://dbus.freedesktop.org/doc/dbus-specification.html#standard-interfaces-properties
-#[derive(
-    Clone, Debug, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue,
-)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Type, PartialOrd, Ord)]
 pub struct PropertyName<'name>(Str<'name>);
 
 /// Owned sibling of [`PropertyName`].
-#[derive(Clone, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue)]
+#[derive(Clone, Hash, PartialEq, Eq, Serialize, Type, PartialOrd, Ord)]
 pub struct OwnedPropertyName(#[serde(borrow)] PropertyName<'static>);
 
 define_name_type_impls! {

--- a/zbus_names/src/unique_name.rs
+++ b/zbus_names/src/unique_name.rs
@@ -1,6 +1,6 @@
 use crate::{Error, Result, utils::define_name_type_impls};
 use serde::Serialize;
-use zvariant::{OwnedValue, Str, Type, Value};
+use zvariant::{Str, Type};
 
 /// String that identifies a [unique bus name][ubn].
 ///
@@ -25,13 +25,11 @@ use zvariant::{OwnedValue, Str, Type, Value};
 /// ```
 ///
 /// [ubn]: https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names-bus
-#[derive(
-    Clone, Debug, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue,
-)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Type, PartialOrd, Ord)]
 pub struct UniqueName<'name>(pub(crate) Str<'name>);
 
 /// Owned sibling of [`UniqueName`].
-#[derive(Clone, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue)]
+#[derive(Clone, Hash, PartialEq, Eq, Serialize, Type, PartialOrd, Ord)]
 pub struct OwnedUniqueName(#[serde(borrow)] UniqueName<'static>);
 
 define_name_type_impls! {
@@ -76,4 +74,92 @@ pub(crate) fn validate_bytes(bytes: &[u8]) -> std::result::Result<(), ()> {
 
         Ok(())
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zvariant::{OwnedValue, Value};
+
+    #[test]
+    fn value_conversion_rejects_empty_name() {
+        let value = Value::from("");
+        UniqueName::try_from(value).unwrap_err();
+        OwnedUniqueName::try_from(Value::from("")).unwrap_err();
+        OwnedUniqueName::try_from(OwnedValue::from(zvariant::Str::from(""))).unwrap_err();
+    }
+
+    #[test]
+    fn optional_value_conversion_maps_empty_name_to_none() {
+        use zvariant::Optional;
+
+        // An empty string is the D-Bus sentinel for "no name" and must map to `None`
+        // rather than fail validation.
+        let opt = Optional::<UniqueName<'_>>::try_from(Value::from("")).unwrap();
+        assert_eq!(Option::from(opt), None::<UniqueName<'_>>);
+
+        let opt = Optional::<UniqueName<'_>>::try_from(Value::from(":1.23")).unwrap();
+        assert_eq!(opt.as_ref().unwrap().as_str(), ":1.23");
+
+        // Non-empty invalid names must still be rejected.
+        Optional::<UniqueName<'_>>::try_from(Value::from("not a unique name")).unwrap_err();
+    }
+
+    #[test]
+    fn optional_owned_value_conversion_maps_empty_name_to_none() {
+        use zvariant::Optional;
+
+        // The path proxy property getters take: `TryFrom<OwnedValue>` on an owned type.
+        let owned = OwnedValue::from(zvariant::Str::from(""));
+        let opt = Optional::<OwnedUniqueName>::try_from(owned).unwrap();
+        assert!(Option::<OwnedUniqueName>::from(opt).is_none());
+
+        let owned = OwnedValue::from(zvariant::Str::from(":1.23"));
+        let opt = Optional::<OwnedUniqueName>::try_from(owned).unwrap();
+        assert_eq!(
+            Option::<OwnedUniqueName>::from(opt).unwrap().as_str(),
+            ":1.23"
+        );
+    }
+
+    #[test]
+    fn optional_name_wire_round_trip() {
+        use zvariant::{LE, Optional, serialized::Context, to_bytes};
+
+        let ctxt = Context::new_dbus(LE, 0);
+
+        // `NameOwnerChanged`-style: empty string on the wire means "no name".
+        let encoded = to_bytes(ctxt, &Optional::<UniqueName<'_>>::default()).unwrap();
+        let opt: Optional<UniqueName<'_>> = encoded.deserialize().unwrap().0;
+        assert!(Option::<UniqueName<'_>>::from(opt).is_none());
+
+        let name = UniqueName::try_from(":1.23").unwrap();
+        let encoded = to_bytes(ctxt, &Optional::from(Some(name.clone()))).unwrap();
+        let opt: Optional<UniqueName<'_>> = encoded.deserialize().unwrap().0;
+        assert_eq!(Option::from(opt), Some(name));
+
+        // Invalid non-empty names on the wire must still be rejected.
+        let encoded = to_bytes(ctxt, &"not a unique name").unwrap();
+        encoded
+            .deserialize::<Optional<UniqueName<'_>>>()
+            .unwrap_err();
+    }
+
+    #[test]
+    fn value_conversion_round_trips_valid_name() {
+        let name = UniqueName::try_from(":1.23").unwrap();
+        let value = Value::from(name.clone());
+        let parsed = UniqueName::try_from(value).unwrap();
+        assert_eq!(parsed, name);
+
+        let owned = OwnedValue::try_from(name.clone()).unwrap();
+        assert_eq!(UniqueName::try_from(owned).unwrap(), name);
+
+        let owned_name = OwnedUniqueName::from(name.clone());
+        let value: Value<'static> = Value::from(owned_name.clone());
+        assert_eq!(OwnedUniqueName::try_from(value).unwrap(), owned_name);
+
+        let owned = OwnedValue::try_from(owned_name.clone()).unwrap();
+        assert_eq!(OwnedUniqueName::try_from(owned).unwrap(), owned_name);
+    }
 }

--- a/zbus_names/src/utils.rs
+++ b/zbus_names/src/utils.rs
@@ -245,6 +245,38 @@ macro_rules! define_name_type_impls {
             }
         }
 
+        impl<'s> TryFrom<zvariant::Value<'s>> for $name<'s> {
+            type Error = zvariant::Error;
+
+            fn try_from(value: zvariant::Value<'s>) -> zvariant::Result<Self> {
+                let s = zvariant::Str::try_from(value)?;
+                Self::try_from(s).map_err(|e| zvariant::Error::Message(e.to_string()))
+            }
+        }
+
+        impl<'s> From<$name<'s>> for zvariant::Value<'s> {
+            fn from(name: $name<'s>) -> Self {
+                name.0.into()
+            }
+        }
+
+        impl TryFrom<zvariant::OwnedValue> for $name<'_> {
+            type Error = zvariant::Error;
+
+            fn try_from(value: zvariant::OwnedValue) -> zvariant::Result<Self> {
+                let s = zvariant::Str::try_from(value)?;
+                Self::try_from(s).map_err(|e| zvariant::Error::Message(e.to_string()))
+            }
+        }
+
+        impl TryFrom<$name<'_>> for zvariant::OwnedValue {
+            type Error = zvariant::Error;
+
+            fn try_from(name: $name<'_>) -> zvariant::Result<Self> {
+                Ok(name.0.into())
+            }
+        }
+
         // === Owned type impls ===
 
         // impl_str_basic for owned type
@@ -364,6 +396,36 @@ macro_rules! define_name_type_impls {
 
             fn null_value() -> Self::NoneType {
                 $name::null_value()
+            }
+        }
+
+        impl TryFrom<zvariant::Value<'static>> for $owned_name {
+            type Error = zvariant::Error;
+
+            fn try_from(value: zvariant::Value<'static>) -> zvariant::Result<Self> {
+                <$name<'static>>::try_from(value).map(Self::from)
+            }
+        }
+
+        impl From<$owned_name> for zvariant::Value<'_> {
+            fn from(name: $owned_name) -> Self {
+                name.0.into()
+            }
+        }
+
+        impl TryFrom<zvariant::OwnedValue> for $owned_name {
+            type Error = zvariant::Error;
+
+            fn try_from(value: zvariant::OwnedValue) -> zvariant::Result<Self> {
+                <$name<'static>>::try_from(value).map(Self::from)
+            }
+        }
+
+        impl TryFrom<$owned_name> for zvariant::OwnedValue {
+            type Error = zvariant::Error;
+
+            fn try_from(name: $owned_name) -> zvariant::Result<Self> {
+                name.0.try_into()
             }
         }
     };

--- a/zbus_names/src/well_known_name.rs
+++ b/zbus_names/src/well_known_name.rs
@@ -1,6 +1,6 @@
 use crate::{Error, Result, utils::define_name_type_impls};
 use serde::Serialize;
-use zvariant::{OwnedValue, Str, Type, Value};
+use zvariant::{Str, Type};
 
 /// String that identifies a [well-known bus name][wbn].
 ///
@@ -26,13 +26,11 @@ use zvariant::{OwnedValue, Str, Type, Value};
 /// ```
 ///
 /// [wbn]: https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names-bus
-#[derive(
-    Clone, Debug, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue,
-)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Type, PartialOrd, Ord)]
 pub struct WellKnownName<'name>(pub(crate) Str<'name>);
 
 /// Owned sibling of [`WellKnownName`].
-#[derive(Clone, Hash, PartialEq, Eq, Serialize, Type, Value, PartialOrd, Ord, OwnedValue)]
+#[derive(Clone, Hash, PartialEq, Eq, Serialize, Type, PartialOrd, Ord)]
 pub struct OwnedWellKnownName(#[serde(borrow)] WellKnownName<'static>);
 
 define_name_type_impls! {

--- a/zvariant/src/from_value.rs
+++ b/zvariant/src/from_value.rs
@@ -199,19 +199,22 @@ where
 
 impl<'a, T> TryFrom<Value<'a>> for Optional<T>
 where
-    T: TryFrom<Value<'a>> + NoneValue + PartialEq<<T as NoneValue>::NoneType>,
+    T: TryFrom<Value<'a>> + NoneValue,
+    <T as NoneValue>::NoneType: Into<Value<'a>>,
     T::Error: Into<crate::Error>,
 {
     type Error = crate::Error;
 
     fn try_from(value: Value<'a>) -> Result<Self, Self::Error> {
-        T::try_from(value).map_err(Into::into).map(|value| {
-            if value == T::null_value() {
-                Optional::from(None)
-            } else {
-                Optional::from(Some(value))
-            }
-        })
+        // Check for the null sentinel before converting, since `T`'s conversion may
+        // legitimately reject it (e.g. name types validating the empty string).
+        if value == T::null_value().into() {
+            Ok(Optional::from(None))
+        } else {
+            T::try_from(value)
+                .map(|value| Optional::from(Some(value)))
+                .map_err(Into::into)
+        }
     }
 }
 

--- a/zvariant/src/into_value.rs
+++ b/zvariant/src/into_value.rs
@@ -89,6 +89,17 @@ into_value!(Fd<'a>, Fd);
 #[cfg(unix)]
 try_into_value_from_ref!(Fd<'a>, Fd);
 
+#[cfg(feature = "enumflags2")]
+impl<'a, F> From<enumflags2::BitFlags<F>> for Value<'a>
+where
+    F: enumflags2::BitFlag,
+    F::Numeric: Into<Value<'a>>,
+{
+    fn from(v: enumflags2::BitFlags<F>) -> Self {
+        v.bits().into()
+    }
+}
+
 impl<'v, 's: 'v, T> From<T> for Value<'v>
 where
     T: Into<Structure<'s>>,
@@ -173,5 +184,28 @@ where
         }
 
         array.into()
+    }
+}
+
+#[cfg(all(test, feature = "enumflags2"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bitflags_conversion() {
+        #[repr(u32)]
+        #[enumflags2::bitflags]
+        #[derive(Copy, Clone, Debug)]
+        pub enum Flaggy {
+            One = 0x1,
+            Two = 0x2,
+        }
+
+        let flags = Flaggy::One | Flaggy::Two;
+        assert_eq!(Value::from(flags), Value::U32(0x3));
+        assert_eq!(
+            Value::from(enumflags2::BitFlags::<Flaggy>::empty()),
+            Value::U32(0)
+        );
     }
 }

--- a/zvariant/src/optional.rs
+++ b/zvariant/src/optional.rs
@@ -163,6 +163,59 @@ mod tests {
     use std::panic::catch_unwind;
 
     #[test]
+    fn value_conversion_maps_null_sentinel_to_none() {
+        use crate::{Optional, OwnedValue, Str, Value};
+
+        let opt = Optional::<String>::try_from(Value::from("")).unwrap();
+        assert_eq!(*opt, None);
+        let opt = Optional::<String>::try_from(Value::from("hello")).unwrap();
+        assert_eq!(*opt, Some("hello".to_string()));
+
+        let opt = Optional::<u32>::try_from(Value::from(0u32)).unwrap();
+        assert_eq!(*opt, None);
+        let opt = Optional::<u32>::try_from(Value::from(42u32)).unwrap();
+        assert_eq!(*opt, Some(42));
+
+        let owned = OwnedValue::try_from(Value::from(Str::from(""))).unwrap();
+        let opt = Optional::<String>::try_from(owned).unwrap();
+        assert_eq!(*opt, None);
+    }
+
+    #[cfg(feature = "enumflags2")]
+    #[test]
+    fn value_conversion_maps_empty_bitflags_to_none() {
+        use crate::{Optional, OwnedValue, Value};
+        use enumflags2::BitFlags;
+
+        #[repr(u32)]
+        #[enumflags2::bitflags]
+        #[derive(Copy, Clone, Debug, PartialEq)]
+        pub enum Flaggy {
+            One = 0x1,
+            Two = 0x2,
+        }
+
+        // Empty flags (numeric 0) are the null sentinel and must map to `None`.
+        let opt = Optional::<BitFlags<Flaggy>>::try_from(Value::from(0u32)).unwrap();
+        assert_eq!(Option::<BitFlags<Flaggy>>::from(opt), None);
+        let opt = Optional::<BitFlags<Flaggy>>::try_from(Value::from(0x2u32)).unwrap();
+        assert_eq!(
+            Option::<BitFlags<Flaggy>>::from(opt),
+            Some(Flaggy::Two.into())
+        );
+
+        let owned = OwnedValue::try_from(Value::from(0u32)).unwrap();
+        let opt = Optional::<BitFlags<Flaggy>>::try_from(owned).unwrap();
+        assert_eq!(Option::<BitFlags<Flaggy>>::from(opt), None);
+        let owned = OwnedValue::try_from(Value::from(0x3u32)).unwrap();
+        let opt = Optional::<BitFlags<Flaggy>>::try_from(owned).unwrap();
+        assert_eq!(
+            Option::<BitFlags<Flaggy>>::from(opt),
+            Some(Flaggy::One | Flaggy::Two)
+        );
+    }
+
+    #[test]
     fn bool_in_optional() {
         // Ensure trying to encode/decode `bool` in `Optional` fails.
         use crate::{LE, Optional, to_bytes};

--- a/zvariant/src/owned_value.rs
+++ b/zvariant/src/owned_value.rs
@@ -170,7 +170,8 @@ where
 
 impl<'a, T> TryFrom<OwnedValue> for Optional<T>
 where
-    T: TryFrom<Value<'a>> + NoneValue + PartialEq<<T as NoneValue>::NoneType>,
+    T: TryFrom<Value<'a>> + NoneValue,
+    <T as NoneValue>::NoneType: Into<Value<'a>>,
     T::Error: Into<crate::Error>,
 {
     type Error = crate::Error;


### PR DESCRIPTION
### Bug

The name types (`UniqueName`, `InterfaceName`, etc.) validate their input everywhere except in the `Value`/`OwnedValue` conversions. Those were derive-generated and just wrapped the string without checking it. So an invalid name coming off the wire became a typed name, and failed much later in confusing ways (e.g. a method call with an empty destination).

### Fix

- **zbus_names**: Replace the derives with hand-written impls that convert through `TryFrom<Str>`, which validates. Signatures and error type stay the same, so no API changes.
- **zvariant**: Fix a latent bug this exposed in `Optional<T>`. Its `TryFrom<Value>` impl converted to `T` first and checked for the null sentinel (e.g. `""` for "no name") after. That only worked because invalid names used to slip through. Now it checks the sentinel first, like the serde path already does. So `Optional<UniqueName>` from `""` still gives `Ok(None)`, and invalid non-empty names give an error.

### ⚠️ Breaking change (zvariant)

The bounds on the `Optional<T>` conversion impls change from `T: PartialEq<NoneType>` to `NoneType: Into<Value>`. All common none-types (`Self`, `&str`, `String`, numbers) satisfy the new bound.