### PR TITLE
💬 zv: Name the expected signature in as_value errors

### DIFF
--- a/zvariant/src/as_value/deserialize.rs
+++ b/zvariant/src/as_value/deserialize.rs
@@ -66,9 +66,10 @@ impl<'de, T: Type + serde::Deserialize<'de>> Visitor<'de> for DeserializeValueVi
             .next_element()?
             .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
         if T::SIGNATURE != &sig {
+            let expected = format!("a value of signature `{}`", T::SIGNATURE);
             return Err(serde::de::Error::invalid_value(
                 serde::de::Unexpected::Str(&sig.to_string()),
-                &"the value signature",
+                &expected.as_str(),
             ));
         }
 

--- a/zvariant/tests/issue/issue_1819.rs
+++ b/zvariant/tests/issue/issue_1819.rs
@@ -1,0 +1,37 @@
+use std::collections::HashMap;
+
+use zvariant::{
+    DeserializeDict, Dict, LE, SerializeDict, Type, Value, serialized::Context, to_bytes,
+};
+
+#[test]
+fn issue_1819() {
+    // A peer that wraps a dict value in a variant twice (`v` -> `v` -> `a{sv}`) doesn't match a
+    // typed field, and the error must name the signature we did expect.
+    #[derive(DeserializeDict, SerializeDict, Type, PartialEq, Debug, Default)]
+    #[zvariant(signature = "a{sv}", rename_all = "kebab-case")]
+    struct UpdateInfo {
+        version: Option<String>,
+    }
+
+    #[derive(DeserializeDict, SerializeDict, Type, PartialEq, Debug, Default)]
+    #[zvariant(signature = "a{sv}", rename_all = "kebab-case")]
+    struct BundleInfo {
+        update: Option<UpdateInfo>,
+    }
+
+    let ctxt = Context::new_dbus(LE, 0);
+    let mut update: HashMap<&str, Value<'_>> = HashMap::new();
+    update.insert("version", Value::new("1.0"));
+    let mut info: HashMap<&str, Value<'_>> = HashMap::new();
+    info.insert(
+        "update",
+        Value::Value(Box::new(Value::Dict(Dict::from(update)))),
+    );
+    let encoded = to_bytes(ctxt, &info).unwrap();
+
+    let err = encoded.deserialize::<BundleInfo>().unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains(r#"string "v""#), "{msg}");
+    assert!(msg.contains("a{sv}"), "{msg}");
+}

--- a/zvariant/tests/issue/mod.rs
+++ b/zvariant/tests/issue/mod.rs
@@ -1,4 +1,5 @@
 mod issue_1145;
+mod issue_1819;
 mod issue_59;
 #[cfg(feature = "gvariant")]
 mod issue_99;


### PR DESCRIPTION
When a peer sends a variant whose contained signature doesn't match the field type, the error only said "expected the value signature" — never saying *which* signature we were after, leaving users to guess.

Both reports in #1819 ran into this. RAUC wraps its nested `a{sv}` dicts in a variant twice ([`manifest.c#L1162`](https://github.com/rauc/rauc/blob/3991031a43f244669889e81f5db18ce56e890b68/src/manifest.c#L1162) uses `g_variant_dict_insert(..., "v", ...)`, so the `{sv}` entry wraps an already-wrapped value), and all the resulting error said was:

```
invalid value: string "v", expected the value signature
```

Now:

```
invalid value: string "v", expected a value of signature `a{sv}`
```

which points straight at the mismatch.

No behavioural change beyond the message; the derives already handled the documented shape correctly (verified while researching #1819 — a singly-wrapped `v` → `a{sv}` decodes into a typed `DeserializeDict` field just fine).

Regression test added as `zvariant/tests/issue/issue_1819.rs`, feeding a doubly-wrapped `v` → `v` → `a{sv}` payload and asserting the message names both the signature found and the one expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3GPtmz7fTcdueTquhZp7B

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3GPtmz7fTcdueTquhZp7B)_