### PR TITLE
🐛 zb: Prune empty ancestor nodes on interface removal

### DIFF
--- a/zbus/src/blocking/object_server.rs
+++ b/zbus/src/blocking/object_server.rs
@@ -160,8 +160,9 @@ impl ObjectServer {
 
     /// Unregister a D-Bus [`crate::object_server::Interface`] at a given path.
     ///
-    /// If there are no more interfaces left at that path, destroys the object as well.
-    /// Returns whether the object was destroyed.
+    /// If there are no more interfaces left at that path, destroys the object as well, along
+    /// with any ancestor objects that are thereby left without interfaces or children of their
+    /// own. The root object is never destroyed. Returns whether the object was destroyed.
     pub fn remove<'p, I, P>(&self, path: P) -> Result<bool>
     where
         I: Interface,

--- a/zbus/src/blocking/object_server.rs
+++ b/zbus/src/blocking/object_server.rs
@@ -160,9 +160,10 @@ impl ObjectServer {
 
     /// Unregister a D-Bus [`crate::object_server::Interface`] at a given path.
     ///
-    /// If there are no more interfaces left at that path, destroys the object as well, along
-    /// with any ancestor objects that are thereby left without interfaces or children of their
-    /// own. The root object is never destroyed. Returns whether the object was destroyed.
+    /// If there are no more interfaces or children left at that path, destroys the object as
+    /// well, along with any ancestor objects that are thereby left without interfaces or
+    /// children of their own. The root object is never destroyed. Returns whether the object
+    /// was destroyed.
     pub fn remove<'p, I, P>(&self, path: P) -> Result<bool>
     where
         I: Interface,

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -9,7 +9,7 @@ use std::net::TcpStream;
 use std::os::unix::net::UnixStream;
 use std::{
     collections::{HashMap, HashSet},
-    vec,
+    mem, vec,
 };
 #[cfg(feature = "tokio")]
 use tokio::net::TcpStream;
@@ -596,9 +596,9 @@ impl<'a> Builder<'a> {
 
         // SAFETY: `Authenticated` is always built with these fields set to `Some`.
         let socket_read = auth.socket_read.take().unwrap();
-        let already_received_bytes = auth.already_received_bytes.drain(..).collect();
+        let already_received_bytes = mem::take(&mut auth.already_received_bytes);
         #[cfg(unix)]
-        let already_received_fds = auth.already_received_fds.drain(..).collect();
+        let already_received_fds = mem::take(&mut auth.already_received_fds);
 
         let mut conn = Connection::new(auth, is_bus_conn, executor, self.method_timeout).await?;
         conn.set_max_queued(self.max_queued.unwrap_or(DEFAULT_MAX_QUEUED));

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -195,9 +195,10 @@ impl ObjectServer {
 
     /// Unregister a D-Bus [`Interface`] at a given path.
     ///
-    /// If there are no more interfaces left at that path, destroys the object as well, along
-    /// with any ancestor objects that are thereby left without interfaces or children of their
-    /// own. The root object is never destroyed. Returns whether the object was destroyed.
+    /// If there are no more interfaces or children left at that path, destroys the object as
+    /// well, along with any ancestor objects that are thereby left without interfaces or
+    /// children of their own. The root object is never destroyed. Returns whether the object
+    /// was destroyed.
     pub async fn remove<'p, I, P>(&self, path: P) -> Result<bool>
     where
         I: Interface,
@@ -209,9 +210,10 @@ impl ObjectServer {
 
     /// Unregister a D-Bus [`Interface`] at a given path, using its name.
     ///
-    /// If there are no more interfaces left at that path, destroys the object as well, along
-    /// with any ancestor objects that are thereby left without interfaces or children of their
-    /// own. The root object is never destroyed. Returns whether the object was destroyed.
+    /// If there are no more interfaces or children left at that path, destroys the object as
+    /// well, along with any ancestor objects that are thereby left without interfaces or
+    /// children of their own. The root object is never destroyed. Returns whether the object
+    /// was destroyed.
     pub async fn remove_named<'p, P>(
         &self,
         path: P,
@@ -231,11 +233,7 @@ impl ObjectServer {
         }
         // Prune before emitting the (fallible) signal, so that an emission failure can't leave
         // empty nodes behind.
-        let destroyed = if node.is_empty() {
-            root.remove_node(&path)
-        } else {
-            false
-        };
+        let destroyed = root.remove_node(&path);
         if let Some(manager_path) = manager_path {
             let ctxt = SignalEmitter::new(&self.connection(), manager_path)?;
             ObjectManager::interfaces_removed(&ctxt, path.clone(), (&[interface_name]).into())

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -156,41 +156,45 @@ impl ObjectServer {
         let (node, manager_path) = root.get_child_mut(&path, true);
         let node = node.unwrap();
         let added = node.add_arc_interface(name.clone(), arc_iface);
-        if added {
-            if name == ObjectManager::name() {
-                // Just added an object manager. Need to signal all managed objects under it.
-                let emitter = SignalEmitter::new(&self.connection(), path)?;
-                let objects = node.get_managed_objects(self, &self.connection()).await?;
-                for (path, owned_interfaces) in objects {
-                    let interfaces = owned_interfaces
-                        .iter()
-                        .map(|(i, props)| {
-                            let props = props
-                                .iter()
-                                .map(|(k, v)| Ok((k.as_str(), Value::try_from(v)?)))
-                                .collect::<Result<_>>();
-                            Ok((i.into(), props?))
-                        })
-                        .collect::<Result<_>>()?;
-                    ObjectManager::interfaces_added(&emitter, path.into(), interfaces).await?;
-                }
-            } else if let Some(manager_path) = manager_path {
-                let emitter = SignalEmitter::new(&self.connection(), manager_path)?;
-                let mut interfaces = HashMap::new();
-                let owned_props = node
-                    .get_properties(self, &self.connection(), name.clone())
-                    .await?;
-                let props = owned_props
+        if !added {
+            // The nodes on the path may have been auto-created just now for this very
+            // registration; remove the ones that nothing else needs.
+            root.remove_node(&path);
+            return Ok(false);
+        }
+        if name == ObjectManager::name() {
+            // Just added an object manager. Need to signal all managed objects under it.
+            let emitter = SignalEmitter::new(&self.connection(), path)?;
+            let objects = node.get_managed_objects(self, &self.connection()).await?;
+            for (path, owned_interfaces) in objects {
+                let interfaces = owned_interfaces
                     .iter()
-                    .map(|(k, v)| Ok((k.as_str(), Value::try_from(v)?)))
+                    .map(|(i, props)| {
+                        let props = props
+                            .iter()
+                            .map(|(k, v)| Ok((k.as_str(), Value::try_from(v)?)))
+                            .collect::<Result<_>>();
+                        Ok((i.into(), props?))
+                    })
                     .collect::<Result<_>>()?;
-                interfaces.insert(name, props);
-
-                ObjectManager::interfaces_added(&emitter, path, interfaces).await?;
+                ObjectManager::interfaces_added(&emitter, path.into(), interfaces).await?;
             }
+        } else if let Some(manager_path) = manager_path {
+            let emitter = SignalEmitter::new(&self.connection(), manager_path)?;
+            let mut interfaces = HashMap::new();
+            let owned_props = node
+                .get_properties(self, &self.connection(), name.clone())
+                .await?;
+            let props = owned_props
+                .iter()
+                .map(|(k, v)| Ok((k.as_str(), Value::try_from(v)?)))
+                .collect::<Result<_>>()?;
+            interfaces.insert(name, props);
+
+            ObjectManager::interfaces_added(&emitter, path, interfaces).await?;
         }
 
-        Ok(added)
+        Ok(true)
     }
 
     /// Unregister a D-Bus [`Interface`] at a given path.

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -195,8 +195,9 @@ impl ObjectServer {
 
     /// Unregister a D-Bus [`Interface`] at a given path.
     ///
-    /// If there are no more interfaces left at that path, destroys the object as well.
-    /// Returns whether the object was destroyed.
+    /// If there are no more interfaces left at that path, destroys the object as well, along
+    /// with any ancestor objects that are thereby left without interfaces or children of their
+    /// own. The root object is never destroyed. Returns whether the object was destroyed.
     pub async fn remove<'p, I, P>(&self, path: P) -> Result<bool>
     where
         I: Interface,
@@ -208,8 +209,9 @@ impl ObjectServer {
 
     /// Unregister a D-Bus [`Interface`] at a given path, using its name.
     ///
-    /// If there are no more interfaces left at that path, destroys the object as well.
-    /// Returns whether the object was destroyed.
+    /// If there are no more interfaces left at that path, destroys the object as well, along
+    /// with any ancestor objects that are thereby left without interfaces or children of their
+    /// own. The root object is never destroyed. Returns whether the object was destroyed.
     pub async fn remove_named<'p, P>(
         &self,
         path: P,
@@ -222,28 +224,24 @@ impl ObjectServer {
         let path = path.try_into().map_err(Into::into)?;
         let mut root = self.root.write().await;
         let (node, manager_path) = root.get_child_mut(&path, false);
+        let manager_path = manager_path.map(ObjectPath::into_owned);
         let node = node.ok_or(Error::InterfaceNotFound)?;
         if !node.remove_interface(&interface_name) {
             return Err(Error::InterfaceNotFound);
         }
+        // Prune before emitting the (fallible) signal, so that an emission failure can't leave
+        // empty nodes behind.
+        let destroyed = if node.is_empty() {
+            root.remove_node(&path)
+        } else {
+            false
+        };
         if let Some(manager_path) = manager_path {
             let ctxt = SignalEmitter::new(&self.connection(), manager_path)?;
             ObjectManager::interfaces_removed(&ctxt, path.clone(), (&[interface_name]).into())
                 .await?;
         }
-        if node.is_empty() {
-            let mut path_parts = path.rsplit('/').filter(|i| !i.is_empty());
-            let last_part = path_parts.next().unwrap();
-            let ppath = ObjectPath::from_string_unchecked(
-                path_parts.fold(String::new(), |a, p| format!("/{p}{a}")),
-            );
-            root.get_child_mut(&ppath, false)
-                .0
-                .unwrap()
-                .remove_node(last_part);
-            return Ok(true);
-        }
-        Ok(false)
+        Ok(destroyed)
     }
 
     /// Get the interface at the given path.

--- a/zbus/src/object_server/node.rs
+++ b/zbus/src/object_server/node.rs
@@ -106,8 +106,62 @@ impl Node {
         })
     }
 
-    pub(super) fn remove_node(&mut self, node: &str) -> bool {
-        self.children.remove(node).is_some()
+    /// Remove the descendant node at `path`.
+    ///
+    /// Ancestors that are thereby left childless with only the default interfaces are removed as
+    /// well. Returns whether the node at `path` was removed. The root node itself is never
+    /// removed.
+    pub(super) fn remove_node(&mut self, path: &ObjectPath<'_>) -> bool {
+        let parts = path
+            .split('/')
+            .filter(|p| !p.is_empty())
+            .collect::<Vec<_>>();
+        if parts.is_empty() {
+            return false;
+        }
+
+        // First pass: check that the whole path exists and find the deepest ancestor that has to
+        // stay: the last one along the path with other children or non-default interfaces of its
+        // own. Everything below it only exists to lead to the target node.
+        let mut node = &*self;
+        let mut keep_depth = 0;
+        for (depth, part) in parts.iter().enumerate() {
+            let Some(child) = node.children.get(*part) else {
+                return false;
+            };
+            if depth + 1 < parts.len()
+                && (child.children.len() > 1 || !child.has_default_interfaces_only())
+            {
+                keep_depth = depth + 1;
+            }
+            node = child;
+        }
+
+        // Second pass: unlink the target node and the now-useless part of its ancestor chain in
+        // one go, by cutting the tree right below the deepest surviving ancestor.
+        let mut node = &mut *self;
+        for part in &parts[..keep_depth] {
+            // The first pass established that the whole path exists.
+            node = node.children.get_mut(*part).unwrap();
+        }
+        let mut disposal = Vec::from_iter(node.children.remove(parts[keep_depth]));
+        let removed = !disposal.is_empty();
+        // Dispose of the detached subtree iteratively: dropping it in one go would recurse per
+        // level, as each node owns its children.
+        while let Some(mut node) = disposal.pop() {
+            disposal.extend(node.children.drain().map(|(_, child)| child));
+        }
+        removed
+    }
+
+    /// Whether the node only has the default interfaces that every node gets on creation.
+    ///
+    /// Note that unlike [`Node::is_empty`], this considers `ObjectManager` a non-default
+    /// interface: a node explicitly serving one must survive the pruning of its children.
+    fn has_default_interfaces_only(&self) -> bool {
+        self.interfaces
+            .keys()
+            .all(|k| *k == Peer::name() || *k == Introspectable::name() || *k == Properties::name())
     }
 
     pub(super) fn add_arc_interface(

--- a/zbus/src/object_server/node.rs
+++ b/zbus/src/object_server/node.rs
@@ -97,20 +97,11 @@ impl Node {
         self.interfaces.remove(interface_name).is_some()
     }
 
-    pub(super) fn is_empty(&self) -> bool {
-        !self.interfaces.keys().any(|k| {
-            *k != Peer::name()
-                && *k != Introspectable::name()
-                && *k != Properties::name()
-                && *k != ObjectManager::name()
-        })
-    }
-
-    /// Remove the descendant node at `path`.
+    /// Remove the node at `path` if it's no longer needed, along with any ancestors that are
+    /// thereby no longer needed either.
     ///
-    /// Ancestors that are thereby left childless with only the default interfaces are removed as
-    /// well. Returns whether the node at `path` was removed. The root node itself is never
-    /// removed.
+    /// A node is still needed if it has children or non-default interfaces (or is the root
+    /// node). Returns whether the node at `path` was removed.
     pub(super) fn remove_node(&mut self, path: &ObjectPath<'_>) -> bool {
         let parts = path
             .split('/')
@@ -136,6 +127,10 @@ impl Node {
             }
             node = child;
         }
+        if !node.children.is_empty() || !node.has_default_interfaces_only() {
+            // The target node is still needed.
+            return false;
+        }
 
         // Second pass: unlink the target node and the now-useless part of its ancestor chain in
         // one go, by cutting the tree right below the deepest surviving ancestor.
@@ -156,8 +151,8 @@ impl Node {
 
     /// Whether the node only has the default interfaces that every node gets on creation.
     ///
-    /// Note that unlike [`Node::is_empty`], this considers `ObjectManager` a non-default
-    /// interface: a node explicitly serving one must survive the pruning of its children.
+    /// Note that this considers `ObjectManager` a non-default interface: it is explicitly
+    /// registered by the user, so a node serving one must not be removed behind their back.
     fn has_default_interfaces_only(&self) -> bool {
         self.interfaces
             .keys()

--- a/zbus/src/object_server/node.rs
+++ b/zbus/src/object_server/node.rs
@@ -29,6 +29,7 @@ impl Node {
             path,
             ..Default::default()
         };
+        // Keep this set in sync with `is_default_interface`.
         assert!(node.add_interface(Peer));
         assert!(node.add_interface(Introspectable));
         assert!(node.add_interface(Properties));
@@ -154,9 +155,7 @@ impl Node {
     /// Note that this considers `ObjectManager` a non-default interface: it is explicitly
     /// registered by the user, so a node serving one must not be removed behind their back.
     fn has_default_interfaces_only(&self) -> bool {
-        self.interfaces
-            .keys()
-            .all(|k| *k == Peer::name() || *k == Introspectable::name() || *k == Properties::name())
+        self.interfaces.keys().all(is_default_interface)
     }
 
     pub(super) fn add_arc_interface(
@@ -269,13 +268,12 @@ impl Node {
         let mut node_list: Vec<_> = self.children.values().collect();
         while let Some(node) = node_list.pop() {
             let mut interfaces = HashMap::new();
-            for iface_name in node.interfaces.keys().filter(|n| {
-                // Filter standard interfaces.
-                *n != &Peer::name()
-                    && *n != &Introspectable::name()
-                    && *n != &Properties::name()
-                    && *n != &ObjectManager::name()
-            }) {
+            for iface_name in node
+                .interfaces
+                .keys()
+                // The default interfaces and `ObjectManager` itself are not managed.
+                .filter(|n| !is_default_interface(n) && **n != ObjectManager::name())
+            {
                 let props = node
                     .get_properties(object_server, connection, iface_name.clone())
                     .await?;
@@ -302,5 +300,43 @@ impl Node {
             .await
             .get_all(object_server, connection, None, &emitter)
             .await
+    }
+}
+
+/// Whether `name` is one of the default interfaces added to every node on creation.
+fn is_default_interface(name: &InterfaceName<'_>) -> bool {
+    *name == Peer::name() || *name == Introspectable::name() || *name == Properties::name()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_node_only_has_the_default_interfaces() {
+        // Guards the coupling between `Node::new` and `is_default_interface`: a default
+        // interface registered by one but unknown to the other would silently break pruning.
+        let node = Node::new("/".try_into().unwrap());
+        assert!(node.has_default_interfaces_only());
+    }
+
+    #[test]
+    fn deep_path_removal_needs_no_deep_stack() {
+        // Neither the removal walk nor the disposal of the removed nodes may recurse per path
+        // component: with this many components on a deliberately small stack, a recursive
+        // implementation aborts with a stack overflow.
+        std::thread::Builder::new()
+            .stack_size(128 * 1024)
+            .spawn(|| {
+                let path_str = format!("/{}", ["n"; 2000].join("/"));
+                let path = ObjectPath::try_from(path_str.as_str()).unwrap();
+                let mut root = Node::new("/".try_into().unwrap());
+                root.get_child_mut(&path, true);
+                assert!(root.remove_node(&path));
+                assert!(root.children.is_empty());
+            })
+            .unwrap()
+            .join()
+            .unwrap();
     }
 }

--- a/zbus/tests/issue/issue_1916.rs
+++ b/zbus/tests/issue/issue_1916.rs
@@ -120,4 +120,37 @@ async fn issue_1916_async() {
     assert!(!object_server.remove::<Iface, _>("/").await.unwrap());
     let xml = introspect("/").await.unwrap();
     assert!(!xml.contains("org.zbus.Issue1916"), "leftover iface: {xml}");
+
+    // An object whose node still has children must not be destroyed, so that the children stay
+    // reachable.
+    object_server.at("/org/zbus", Iface).await.unwrap();
+    object_server.at("/org/zbus/child", Iface).await.unwrap();
+    assert!(!object_server.remove::<Iface, _>("/org/zbus").await.unwrap());
+    let xml = introspect("/org/zbus/child").await.unwrap();
+    assert!(
+        xml.contains("org.zbus.Issue1916"),
+        "child iface lost: {xml}"
+    );
+    // With its own interface already gone, removing the child now prunes the whole chain.
+    assert!(
+        object_server
+            .remove::<Iface, _>("/org/zbus/child")
+            .await
+            .unwrap()
+    );
+    let xml = introspect("/").await.unwrap();
+    assert!(!xml.contains("<node name="), "leftover nodes: {xml}");
+
+    // An `ObjectManager` registered at the path keeps the object alive as well.
+    object_server.at("/org/zbus", ObjectManager).await.unwrap();
+    object_server.at("/org/zbus", Iface).await.unwrap();
+    assert!(!object_server.remove::<Iface, _>("/org/zbus").await.unwrap());
+    assert!(
+        object_server
+            .remove::<ObjectManager, _>("/org/zbus")
+            .await
+            .unwrap()
+    );
+    let xml = introspect("/").await.unwrap();
+    assert!(!xml.contains("<node name="), "leftover nodes: {xml}");
 }

--- a/zbus/tests/issue/issue_1916.rs
+++ b/zbus/tests/issue/issue_1916.rs
@@ -9,6 +9,13 @@ impl Iface {
     fn noop(&self) {}
 }
 
+struct StandardNamed;
+
+#[zbus::interface(name = "org.freedesktop.DBus.Properties")]
+impl StandardNamed {
+    fn noop(&self) {}
+}
+
 #[instrument]
 #[test]
 #[timeout(15000)]
@@ -153,4 +160,30 @@ async fn issue_1916_async() {
     );
     let xml = introspect("/").await.unwrap();
     assert!(!xml.contains("<node name="), "leftover nodes: {xml}");
+
+    // A failed registration (here due to the name colliding with a default interface) must not
+    // leave freshly auto-created nodes behind...
+    assert!(
+        !object_server
+            .at("/org/zbus/ghost", StandardNamed)
+            .await
+            .unwrap()
+    );
+    let xml = introspect("/").await.unwrap();
+    assert!(!xml.contains("<node name="), "leftover nodes: {xml}");
+
+    // ... while a failed registration at a path still in use must not remove anything.
+    object_server.at("/org/zbus/iface", Iface).await.unwrap();
+    assert!(!object_server.at("/org/zbus/iface", Iface).await.unwrap());
+    let xml = introspect("/org/zbus").await.unwrap();
+    assert!(
+        xml.contains("<node name=\"iface\">"),
+        "node wrongly pruned: {xml}"
+    );
+    assert!(
+        object_server
+            .remove::<Iface, _>("/org/zbus/iface")
+            .await
+            .unwrap()
+    );
 }

--- a/zbus/tests/issue/issue_1916.rs
+++ b/zbus/tests/issue/issue_1916.rs
@@ -1,0 +1,123 @@
+use ntest::timeout;
+use tracing::instrument;
+use zbus::{Connection, connection::Builder, fdo::ObjectManager};
+
+struct Iface;
+
+#[zbus::interface(name = "org.zbus.Issue1916")]
+impl Iface {
+    fn noop(&self) {}
+}
+
+#[instrument]
+#[test]
+#[timeout(15000)]
+fn issue_1916() {
+    // Reproducer for issue #1916, where `ObjectServer::remove` only unlinked the leaf node,
+    // leaving the auto-created (and now empty & childless) ancestor nodes behind in the tree.
+    zbus::block_on(issue_1916_async());
+}
+
+async fn issue_1916_async() {
+    let leaf = "/org/zbus/issue1916/sub/leaf";
+    let server_conn = Builder::session()
+        .unwrap()
+        .serve_at(leaf, Iface)
+        .unwrap()
+        .build()
+        .await
+        .unwrap();
+    let client_conn = Connection::session().await.unwrap();
+    let introspect = |path: &'static str| {
+        let client_conn = client_conn.clone();
+        let dest = server_conn.unique_name().unwrap().clone();
+        async move {
+            zbus::fdo::IntrospectableProxy::builder(&client_conn)
+                .destination(dest)
+                .unwrap()
+                .path(path)
+                .unwrap()
+                .build()
+                .await
+                .unwrap()
+                .introspect()
+                .await
+        }
+    };
+    let object_server = server_conn.object_server();
+
+    // Removing the only interface of the only leaf must prune all the auto-created ancestors.
+    assert!(object_server.remove::<Iface, _>(leaf).await.unwrap());
+    let xml = introspect("/").await.unwrap();
+    assert!(!xml.contains("<node name="), "leftover nodes: {xml}");
+
+    // An ancestor with other children must survive the pruning.
+    object_server
+        .at("/org/zbus/issue1916/a", Iface)
+        .await
+        .unwrap();
+    object_server
+        .at("/org/zbus/issue1916/b", Iface)
+        .await
+        .unwrap();
+    assert!(
+        object_server
+            .remove::<Iface, _>("/org/zbus/issue1916/a")
+            .await
+            .unwrap()
+    );
+    let xml = introspect("/org/zbus/issue1916").await.unwrap();
+    assert!(xml.contains("<node name=\"b\">"), "missing node b: {xml}");
+    assert!(!xml.contains("<node name=\"a\">"), "leftover node a: {xml}");
+    assert!(
+        object_server
+            .remove::<Iface, _>("/org/zbus/issue1916/b")
+            .await
+            .unwrap()
+    );
+    let xml = introspect("/").await.unwrap();
+    assert!(!xml.contains("<node name="), "leftover nodes: {xml}");
+
+    // An ancestor with an interface of its own must survive the pruning of its child, even if
+    // that interface is an `ObjectManager`.
+    object_server.at("/org/zbus", Iface).await.unwrap();
+    object_server
+        .at("/org/zbus/issue1916", ObjectManager)
+        .await
+        .unwrap();
+    object_server
+        .at("/org/zbus/issue1916/agent", Iface)
+        .await
+        .unwrap();
+    assert!(
+        object_server
+            .remove::<Iface, _>("/org/zbus/issue1916/agent")
+            .await
+            .unwrap()
+    );
+    let xml = introspect("/org/zbus").await.unwrap();
+    assert!(
+        xml.contains("<node name=\"issue1916\">"),
+        "ObjectManager node pruned: {xml}"
+    );
+    let xml = introspect("/org").await.unwrap();
+    assert!(
+        xml.contains("<node name=\"zbus\">"),
+        "node with own interface pruned: {xml}"
+    );
+    assert!(
+        object_server
+            .remove::<ObjectManager, _>("/org/zbus/issue1916")
+            .await
+            .unwrap()
+    );
+    assert!(object_server.remove::<Iface, _>("/org/zbus").await.unwrap());
+    let xml = introspect("/").await.unwrap();
+    assert!(!xml.contains("<node name="), "leftover nodes: {xml}");
+
+    // The root node is never destroyed, only its interfaces are removed.
+    object_server.at("/", Iface).await.unwrap();
+    assert!(!object_server.remove::<Iface, _>("/").await.unwrap());
+    let xml = introspect("/").await.unwrap();
+    assert!(!xml.contains("org.zbus.Issue1916"), "leftover iface: {xml}");
+}

--- a/zbus/tests/issue/mod.rs
+++ b/zbus/tests/issue/mod.rs
@@ -7,6 +7,7 @@ mod issue_121;
 mod issue_122;
 mod issue_1478;
 mod issue_173;
+mod issue_1916;
 mod issue_260;
 mod issue_466;
 mod issue_68;


### PR DESCRIPTION
Fixes #1916.

`ObjectServer::at` auto-creates ancestor nodes as needed, but `ObjectServer::remove` only unlinked
the leaf node, so the now-empty ancestors stayed in the tree forever, showing up in `Introspect`
and `GetManagedObjects`. The first commit prunes ancestors that are left childless with only the
default interfaces. The follow-up commits fix adjacent problems in the same code that the reviews
of the first one surfaced:

* `remove` used to destroy a node unconditionally once its last user interface was gone, taking
  down live descendant objects and any `ObjectManager` registered at the same path. Both now keep
  the object alive (and `remove` returns `Ok(false)` for them — a behavior change worth noting;
  the old bool also changed from `true` after destroying the whole subtree).
* A failed `at()` (e.g. name collision with a default interface) used to leave its freshly
  auto-created nodes behind with no way to remove them.
* Removing the last interface at the root path `/` panicked (empty parent-path computation); the
  root object is now simply never destroyed.

Notes:

* Everything about the removal is deliberately non-recursive — the tree walk and the disposal of
  the detached node chain alike — since per-component recursion overflows the stack on very deep
  (yet valid) object paths. A regression test runs a deep removal on a deliberately small stack.
* Pruning happens before the fallible `InterfacesRemoved` emission so an emission failure can't
  leak empty nodes; the flip side is that such a failure returns `Err` for a removal that did
  take effect (emission failure implies the connection is dying, so this seemed the lesser evil).
* Known pre-existing gap, left for a follow-up: the error paths of `at()` after the interface
  insert (signal emission / property-read failures) still leave the interface registered and the
  fresh nodes in place.

Generated by Claude Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MuEgaUsWgw2usk5PxNCzxS