### PR TITLE
📝 zm: Document the signals trait generated by `#[interface]`

### DIFF
--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -439,6 +439,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
             reply,
             member_name,
             cfg_attrs,
+            doc_attrs,
             ..
         } = method_info;
 
@@ -471,7 +472,14 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                 *method_clone.sig.inputs.first_mut().unwrap() = parse_quote!(&self);
                 method_clone.vis = Visibility::Inherited;
                 let sig = &method_clone.sig;
+                let signal_docs = if doc_attrs.is_empty() {
+                    let doc = format!("Emit the “{member_name}” signal.");
+                    quote! { #[doc = #doc] }
+                } else {
+                    quote! { #(#doc_attrs)* }
+                };
                 signals_trait_methods.extend(quote! {
+                    #signal_docs
                     #sig;
                 });
                 method_clone.block = parse_quote!({

--- a/zbus_macros/tests/missing_docs.rs
+++ b/zbus_macros/tests/missing_docs.rs
@@ -1,0 +1,22 @@
+#![deny(missing_docs)]
+//! Regression test for issue #1542: everything `#[interface]` generates has to be documented,
+//! otherwise downstream crates that opt into `missing_docs` get warnings they cannot silence.
+
+use zbus::object_server::SignalEmitter;
+use zbus_macros::interface;
+
+/// Interface with a documented and an undocumented signal.
+pub struct Test;
+
+#[interface(name = "org.freedesktop.zbus_macros.MissingDocs")]
+impl Test {
+    /// A method.
+    async fn method(&self) {}
+
+    /// A documented signal.
+    #[zbus(signal)]
+    async fn documented(emitter: &SignalEmitter<'_>) -> zbus::Result<()>;
+
+    #[zbus(signal)]
+    async fn undocumented(emitter: &SignalEmitter<'_>) -> zbus::Result<()>;
+}


### PR DESCRIPTION
`#[interface]` turns every `#[zbus(signal)]` declaration into a method of the generated
`<Type>Signals` trait, but only the signature is taken over — the doc comments of the
declaration are dropped. Crates that opt into `#![warn(missing_docs)]` therefore still get

    warning: missing documentation for a method
      --> src/lib.rs:7:1
       |
     7 | #[zbus::interface(name = "org.example.Iface")]
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

for every interface that declares a signal, even when the signal itself is documented.
#1787 fixed this for the `impl Interface` block, so the signals trait is the remaining case of https://github.com/z-galaxy/zbus/issues/1542.

The doc comments are now carried over to the trait method, and signals without any get a
generated one-liner (`Emit the “ResourceChanged” signal.`), so the lint stays quiet either
way.