### PR TITLE
✨ zv: impl conversion from/to BTreeMap for Value

### DIFF
--- a/zvariant/src/from_value.rs
+++ b/zvariant/src/from_value.rs
@@ -9,7 +9,10 @@ use crate::{
 #[cfg(unix)]
 use crate::Fd;
 
-use std::{collections::HashMap, hash::BuildHasher};
+use std::{
+    collections::{BTreeMap, HashMap},
+    hash::BuildHasher,
+};
 
 macro_rules! value_try_from {
     ($kind:ident, $to:ty) => {
@@ -175,6 +178,24 @@ where
     fn try_from(value: Value<'a>) -> Result<Self, Self::Error> {
         Self::from_bits(F::Numeric::try_from(value)?)
             .map_err(|_| Error::Message("Failed to convert to bitflags".into()))
+    }
+}
+
+impl<'a, K, V> TryFrom<Value<'a>> for BTreeMap<K, V>
+where
+    K: crate::Basic + TryFrom<Value<'a>> + std::cmp::Ord,
+    V: TryFrom<Value<'a>>,
+    K::Error: Into<crate::Error>,
+    V::Error: Into<crate::Error>,
+{
+    type Error = crate::Error;
+
+    fn try_from(value: Value<'a>) -> Result<Self, Self::Error> {
+        if let Value::Dict(v) = value {
+            Self::try_from(v)
+        } else {
+            Err(crate::Error::IncorrectType)
+        }
     }
 }
 

--- a/zvariant/src/into_value.rs
+++ b/zvariant/src/into_value.rs
@@ -1,4 +1,9 @@
-use std::{borrow::Cow, collections::HashMap, hash::BuildHasher, sync::Arc};
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, HashMap},
+    hash::BuildHasher,
+    sync::Arc,
+};
 
 #[cfg(feature = "gvariant")]
 #[allow(deprecated)]
@@ -122,6 +127,18 @@ where
 {
     fn from(v: &'b Vec<V>) -> Value<'v> {
         Value::Array(v.into())
+    }
+}
+
+impl<'a, 'k, 'v, K, V> From<BTreeMap<K, V>> for Value<'a>
+where
+    'k: 'a,
+    'v: 'a,
+    K: Type + Into<Value<'k>> + std::cmp::Ord,
+    V: Type + Into<Value<'v>>,
+{
+    fn from(value: BTreeMap<K, V>) -> Self {
+        Self::Dict(value.into())
     }
 }
 

--- a/zvariant/src/owned_value.rs
+++ b/zvariant/src/owned_value.rs
@@ -1,5 +1,9 @@
 use serde::{Deserialize, Deserializer, Serialize};
-use std::{borrow::Borrow, collections::HashMap, hash::BuildHasher};
+use std::{
+    borrow::Borrow,
+    collections::{BTreeMap, HashMap},
+    hash::BuildHasher,
+};
 
 use crate::{
     Array, Dict, NoneValue, ObjectPath, Optional, OwnedObjectPath, Signature, Str, Structure, Type,
@@ -135,6 +139,34 @@ where
 
     fn try_from(value: OwnedValue) -> Result<Self, Self::Error> {
         Self::try_from(value.0)
+    }
+}
+
+impl<'k, 'v, K, V> TryFrom<OwnedValue> for BTreeMap<K, V>
+where
+    K: crate::Basic + TryFrom<Value<'k>> + std::cmp::Ord,
+    V: TryFrom<Value<'v>>,
+    K::Error: Into<crate::Error>,
+    V::Error: Into<crate::Error>,
+{
+    type Error = crate::Error;
+
+    fn try_from(value: OwnedValue) -> Result<Self, Self::Error> {
+        if let Value::Dict(v) = value.0 {
+            Self::try_from(v)
+        } else {
+            Err(crate::Error::IncorrectType)
+        }
+    }
+}
+
+impl<K, V> From<BTreeMap<K, V>> for OwnedValue
+where
+    K: Type + Into<Value<'static>> + std::cmp::Ord,
+    V: Type + Into<Value<'static>>,
+{
+    fn from(value: BTreeMap<K, V>) -> Self {
+        Self(value.into())
     }
 }
 


### PR DESCRIPTION
`Dict` itself already supports `BTreeMap`, so this seems like it may have been an oversight of sorts.