### PR TITLE
✨ xmlgen: Maintain definition order

### DIFF
--- a/zbus/tests/iface_and_proxy/client.rs
+++ b/zbus/tests/iface_and_proxy/client.rs
@@ -70,13 +70,12 @@ pub async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> 
         .find(|i| i.name() == "org.freedesktop.MyIface")
         .unwrap();
     // Test if the r# prefix for the keyword was removed
-    assert!(my_iface.methods().iter().any(|m| m.name() == "Type"));
-    assert!(my_iface.properties().iter().any(|p| p.name() == "Let"));
-    assert!(my_iface.signals().iter().any(|s| s.name() == "Match"));
+    assert!(my_iface.methods().any(|m| m.name() == "Type"));
+    assert!(my_iface.properties().any(|p| p.name() == "Let"));
+    assert!(my_iface.signals().any(|s| s.name() == "Match"));
     assert_eq!(
         my_iface
             .methods()
-            .iter()
             .find(|m| m.name() == "RawIdentifierParameter")
             .unwrap()
             .args()

--- a/zbus_xml/src/lib.rs
+++ b/zbus_xml/src/lib.rs
@@ -436,18 +436,8 @@ pub struct Interface<'a> {
     #[serde(rename = "@name", borrow)]
     name: InterfaceName<'a>,
 
-    #[serde(rename = "method", default)]
-    methods: Vec<Method<'a>>,
-    #[serde(rename = "property", default)]
-    properties: Vec<Property<'a>>,
-    #[serde(rename = "signal", default)]
-    signals: Vec<Signal<'a>>,
-    #[serde(rename = "annotation", default)]
-    annotations: Vec<Annotation>,
-    #[serde(skip)]
-    docstring: Option<String>,
-    #[serde(skip)]
-    telepathy_types: Vec<telepathy::TypeDef>,
+    #[serde(default)]
+    children: Vec<Child<'a>>,
 }
 
 impl<'a> Interface<'a> {
@@ -458,22 +448,46 @@ impl<'a> Interface<'a> {
 
     /// Returns the interface methods.
     pub fn methods(&self) -> impl Iterator<Item = &Method<'a>> {
-        self.methods.iter()
+        self.children.iter().filter_map(|child| {
+            if let Child::Method(m) = child {
+                Some(m)
+            } else {
+                None
+            }
+        })
     }
 
     /// Returns the interface signals.
     pub fn signals(&self) -> impl Iterator<Item = &Signal<'a>> {
-        self.signals.iter()
+        self.children.iter().filter_map(|child| {
+            if let Child::Signal(s) = child {
+                Some(s)
+            } else {
+                None
+            }
+        })
     }
 
     /// Returns the interface properties.
     pub fn properties(&self) -> impl Iterator<Item = &Property<'a>> {
-        self.properties.iter()
+        self.children.iter().filter_map(|child| {
+            if let Child::Property(p) = child {
+                Some(p)
+            } else {
+                None
+            }
+        })
     }
 
     /// Return the associated annotations.
     pub fn annotations(&self) -> impl Iterator<Item = &Annotation> {
-        self.annotations.iter()
+        self.children.iter().filter_map(|child| {
+            if let Child::Annotation(a) = child {
+                Some(a)
+            } else {
+                None
+            }
+        })
     }
 
     /// Return the content of the Telepathy `tp:docstring` extension element, if any.
@@ -482,37 +496,107 @@ impl<'a> Interface<'a> {
     /// surrounding whitespace trimmed. Note that docstrings are only captured when parsing;
     /// the writer does not emit them.
     pub fn docstring(&self) -> Option<&str> {
-        self.docstring.as_deref()
+        self.children
+            .iter()
+            .filter_map(|child| {
+                if let Child::Docstring(s) = child {
+                    Some(s.as_ref())
+                } else {
+                    None
+                }
+            })
+            .next()
     }
 
     /// Return the Telepathy type definitions on this interface.
     pub fn telepathy_types(&self) -> impl Iterator<Item = &telepathy::TypeDef> {
-        self.telepathy_types.iter()
+        self.children.iter().filter_map(|child| {
+            if let Child::TelepathyTypeDef(t) = child {
+                Some(t)
+            } else {
+                None
+            }
+        })
     }
 
     fn write_xml<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
         write!(w, "<interface name=\"{}\"", escape(self.name.as_str()))?;
-        if self.methods.is_empty()
-            && self.properties.is_empty()
-            && self.signals.is_empty()
-            && self.annotations.is_empty()
-        {
+        if !self.children.iter().any(|child| {
+            matches!(
+                child,
+                Child::Method(_) | Child::Signal(_) | Child::Property(_) | Child::Annotation(_)
+            )
+        }) {
             return write!(w, "/>");
         }
         write!(w, ">")?;
-        for method in &self.methods {
-            method.write_xml(w)?;
-        }
-        for property in &self.properties {
-            property.write_xml(w)?;
-        }
-        for signal in &self.signals {
-            signal.write_xml(w)?;
-        }
-        for annotation in &self.annotations {
-            annotation.write_xml(w)?;
+        for child in &self.children {
+            child.write_xml(w)?;
         }
         write!(w, "</interface>")
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub enum Child<'a> {
+    #[serde(borrow)]
+    Method(Method<'a>),
+    #[serde(borrow)]
+    Property(Property<'a>),
+    #[serde(borrow)]
+    Signal(Signal<'a>),
+    Annotation(Annotation),
+    Docstring(String),
+    #[serde(skip)]
+    TelepathyTypeDef(telepathy::TypeDef),
+}
+
+impl<'a> From<Method<'a>> for Child<'a> {
+    fn from(method: Method<'a>) -> Self {
+        Self::Method(method)
+    }
+}
+
+impl<'a> From<Property<'a>> for Child<'a> {
+    fn from(property: Property<'a>) -> Self {
+        Self::Property(property)
+    }
+}
+
+impl<'a> From<Signal<'a>> for Child<'a> {
+    fn from(signal: Signal<'a>) -> Self {
+        Self::Signal(signal)
+    }
+}
+
+impl<'a> From<Annotation> for Child<'a> {
+    fn from(annotation: Annotation) -> Self {
+        Self::Annotation(annotation)
+    }
+}
+
+impl<'a> From<String> for Child<'a> {
+    fn from(docstring: String) -> Self {
+        Self::Docstring(docstring)
+    }
+}
+
+impl<'a> From<telepathy::TypeDef> for Child<'a> {
+    fn from(type_def: telepathy::TypeDef) -> Self {
+        Self::TelepathyTypeDef(type_def)
+    }
+}
+
+impl<'a> Child<'a> {
+    fn write_xml<W: Write>(&'a self, w: &mut W) -> std::io::Result<()> {
+        match self {
+            Self::Method(m) => m.write_xml(w),
+            Self::Property(p) => p.write_xml(w),
+            Self::Signal(s) => s.write_xml(w),
+            Self::Annotation(a) => a.write_xml(w),
+            Self::Docstring(_) => Ok(()),
+            Self::TelepathyTypeDef(_) => Ok(()),
+        }
     }
 }
 

--- a/zbus_xml/src/lib.rs
+++ b/zbus_xml/src/lib.rs
@@ -457,23 +457,23 @@ impl<'a> Interface<'a> {
     }
 
     /// Returns the interface methods.
-    pub fn methods(&self) -> &[Method<'a>] {
-        &self.methods
+    pub fn methods(&self) -> impl Iterator<Item = &Method<'a>> {
+        self.methods.iter()
     }
 
     /// Returns the interface signals.
-    pub fn signals(&self) -> &[Signal<'a>] {
-        &self.signals
+    pub fn signals(&self) -> impl Iterator<Item = &Signal<'a>> {
+        self.signals.iter()
     }
 
     /// Returns the interface properties.
-    pub fn properties(&self) -> &[Property<'_>] {
-        &self.properties
+    pub fn properties(&self) -> impl Iterator<Item = &Property<'a>> {
+        self.properties.iter()
     }
 
     /// Return the associated annotations.
-    pub fn annotations(&self) -> &[Annotation] {
-        &self.annotations
+    pub fn annotations(&self) -> impl Iterator<Item = &Annotation> {
+        self.annotations.iter()
     }
 
     /// Return the content of the Telepathy `tp:docstring` extension element, if any.
@@ -486,8 +486,8 @@ impl<'a> Interface<'a> {
     }
 
     /// Return the Telepathy type definitions on this interface.
-    pub fn telepathy_types(&self) -> &[telepathy::TypeDef] {
-        &self.telepathy_types
+    pub fn telepathy_types(&self) -> impl Iterator<Item = &telepathy::TypeDef> {
+        self.telepathy_types.iter()
     }
 
     fn write_xml<W: Write>(&self, w: &mut W) -> std::io::Result<()> {

--- a/zbus_xml/src/lib.rs
+++ b/zbus_xml/src/lib.rs
@@ -446,6 +446,11 @@ impl<'a> Interface<'a> {
         self.name.as_ref()
     }
 
+    /// Returns the child elements.
+    pub fn children(&self) -> impl Iterator<Item = &Child<'a>> {
+        self.children.iter()
+    }
+
     /// Returns the interface methods.
     pub fn methods(&self) -> impl Iterator<Item = &Method<'a>> {
         self.children.iter().filter_map(|child| {

--- a/zbus_xml/src/xml.rs
+++ b/zbus_xml/src/xml.rs
@@ -249,40 +249,37 @@ fn interface<'i>(
     self_closing: bool,
 ) -> PResult<Interface<'static>> {
     let name = attrs.name(|n| InterfaceName::try_from(n).map_err(Error::Zbus))?;
-    let mut methods = Vec::new();
-    let mut properties = Vec::new();
-    let mut signals = Vec::new();
-    let mut annotations = Vec::new();
-    let mut docstring = None;
-    let mut telepathy_types = Vec::new();
+    let mut interface_children = Vec::<crate::Child<'static>>::new();
     children(
         input,
         tag,
         self_closing,
         |input, child, attrs, sc| match child {
             "method" => {
-                methods.push(method(input, child, attrs, sc)?);
+                interface_children.push(method(input, child, attrs, sc)?.into());
                 Ok(true)
             }
             "property" => {
-                properties.push(property(input, child, attrs, sc)?);
+                interface_children.push(property(input, child, attrs, sc)?.into());
                 Ok(true)
             }
             "signal" => {
-                signals.push(signal(input, child, attrs, sc)?);
+                interface_children.push(signal(input, child, attrs, sc)?.into());
                 Ok(true)
             }
             "annotation" => {
-                annotations.push(annotation(input, child, attrs, sc)?);
+                interface_children.push(annotation(input, child, attrs, sc)?.into());
                 Ok(true)
             }
             other if is_docstring(other) => {
-                docstring = capture_docstring(input, other, sc)?.or(docstring.take());
+                if let Some(docstring) = capture_docstring(input, other, sc)? {
+                    interface_children.push(docstring.into());
+                }
                 Ok(true)
             }
             other => {
                 if let Some(def) = telepathy_type_def(input, other, &attrs, sc)? {
-                    telepathy_types.push(def);
+                    interface_children.push(def.into());
                 }
                 Ok(true)
             }
@@ -291,12 +288,7 @@ fn interface<'i>(
 
     Ok(Interface {
         name,
-        methods,
-        properties,
-        signals,
-        annotations,
-        docstring,
-        telepathy_types,
+        children: interface_children,
     })
 }
 

--- a/zbus_xml/tests/tests.rs
+++ b/zbus_xml/tests/tests.rs
@@ -10,13 +10,9 @@ fn serde() -> Result<(), Box<dyn Error>> {
     let node = Node::try_from(example)?;
     assert_eq!(node, node_r);
     assert_eq!(node.interfaces().len(), 1);
-    assert_eq!(node.interfaces()[0].methods().len(), 3);
-    assert_eq!(
-        node.interfaces()[0].methods()[0].args()[0]
-            .direction()
-            .unwrap(),
-        ArgDirection::In
-    );
+    let methods = node.interfaces()[0].methods().collect::<Vec<_>>();
+    assert_eq!(methods.len(), 3);
+    assert_eq!(methods[0].args()[0].direction().unwrap(), ArgDirection::In);
     assert_eq!(node.nodes().len(), 4);
 
     let node_str: Node<'_> = example.try_into()?;
@@ -58,7 +54,11 @@ fn multi_complete_arg_type() -> Result<(), Box<dyn Error>> {
     "#;
 
     let node = Node::try_from(input)?;
-    let arg = &node.interfaces()[0].methods()[0].args()[0];
+    let arg = &node.interfaces()[0]
+        .methods()
+        .next()
+        .expect("interface method")
+        .args()[0];
     let Signature::Structure(fields) = arg.ty().inner() else {
         panic!("expected `tt` to parse as a structure");
     };
@@ -81,7 +81,10 @@ fn escaped_attributes() -> Result<(), Box<dyn Error>> {
     "#;
 
     let node = Node::try_from(input)?;
-    let annotation = &node.interfaces()[0].annotations()[0];
+    let annotation = &node.interfaces()[0]
+        .annotations()
+        .next()
+        .expect("interface annotation");
     assert_eq!(annotation.value(), r#"<b> & "q" 'a' AB"#);
 
     // Escaping survives a write/parse round-trip.
@@ -103,7 +106,10 @@ fn attribute_whitespace_normalization() -> Result<(), Box<dyn Error>> {
                  </interface>\n</node>";
 
     let node = Node::try_from(input)?;
-    let annotation = &node.interfaces()[0].annotations()[0];
+    let annotation = &node.interfaces()[0]
+        .annotations()
+        .next()
+        .expect("interface annotation");
     assert_eq!(annotation.value(), "a b c \n\t\rd");
 
     // The writer escapes whitespace so it survives normalization by any parser.
@@ -180,7 +186,10 @@ fn ignores_unknown_elements_and_text() -> Result<(), Box<dyn Error>> {
 
     let node = Node::try_from(input)?;
     assert_eq!(node.interfaces().len(), 1);
-    let method = &node.interfaces()[0].methods()[0];
+    let method = &node.interfaces()[0]
+        .methods()
+        .next()
+        .expect("interface method");
     assert_eq!(method.args().len(), 1);
     assert_eq!(method.args()[0].name(), Some("testarg"));
 
@@ -228,7 +237,7 @@ fn assert_args(context: &str, args: &[Arg], expected: &[ArgSpec]) {
 /// no particular order.
 fn assert_methods(iface: &Interface<'_>, expected: &[(&str, &[ArgSpec])]) {
     assert_eq!(
-        iface.methods().len(),
+        iface.methods().count(),
         expected.len(),
         "{}: method count",
         iface.name(),
@@ -236,7 +245,6 @@ fn assert_methods(iface: &Interface<'_>, expected: &[(&str, &[ArgSpec])]) {
     for (name, args) in expected {
         let method = iface
             .methods()
-            .iter()
             .find(|m| m.name() == *name)
             .unwrap_or_else(|| panic!("method `{}.{name}` not found", iface.name()));
         assert_args(&format!("{}.{name}", iface.name()), method.args(), args);
@@ -246,7 +254,7 @@ fn assert_methods(iface: &Interface<'_>, expected: &[(&str, &[ArgSpec])]) {
 /// Assert that `iface`'s signals are exactly `expected` (name and full argument list each).
 fn assert_signals(iface: &Interface<'_>, expected: &[(&str, &[ArgSpec])]) {
     assert_eq!(
-        iface.signals().len(),
+        iface.signals().count(),
         expected.len(),
         "{}: signal count",
         iface.name(),
@@ -254,7 +262,6 @@ fn assert_signals(iface: &Interface<'_>, expected: &[(&str, &[ArgSpec])]) {
     for (name, args) in expected {
         let signal = iface
             .signals()
-            .iter()
             .find(|s| s.name() == *name)
             .unwrap_or_else(|| panic!("signal `{}.{name}` not found", iface.name()));
         assert_args(&format!("{}.{name}", iface.name()), signal.args(), args);
@@ -264,7 +271,7 @@ fn assert_signals(iface: &Interface<'_>, expected: &[(&str, &[ArgSpec])]) {
 /// Assert that `iface`'s properties are exactly `expected` (name, signature and access each).
 fn assert_properties(iface: &Interface<'_>, expected: &[(&str, &str, PropertyAccess)]) {
     assert_eq!(
-        iface.properties().len(),
+        iface.properties().count(),
         expected.len(),
         "{}: property count",
         iface.name(),
@@ -272,7 +279,6 @@ fn assert_properties(iface: &Interface<'_>, expected: &[(&str, &str, PropertyAcc
     for &(name, ty, access) in expected {
         let property = iface
             .properties()
-            .iter()
             .find(|p| p.name() == name)
             .unwrap_or_else(|| panic!("property `{}.{name}` not found", iface.name()));
         assert!(
@@ -467,7 +473,6 @@ fn real_world_systemd() -> Result<(), Box<dyn Error>> {
             "Manager.GetUnit",
             manager
                 .methods()
-                .iter()
                 .find(|m| m.name() == "GetUnit")
                 .expect("GetUnit method")
                 .args(),
@@ -477,7 +482,6 @@ fn real_world_systemd() -> Result<(), Box<dyn Error>> {
             "Manager.StartUnit",
             manager
                 .methods()
-                .iter()
                 .find(|m| m.name() == "StartUnit")
                 .expect("StartUnit method")
                 .args(),
@@ -491,7 +495,6 @@ fn real_world_systemd() -> Result<(), Box<dyn Error>> {
             "Manager.UnitNew",
             manager
                 .signals()
-                .iter()
                 .find(|s| s.name() == "UnitNew")
                 .expect("UnitNew signal")
                 .args(),
@@ -501,7 +504,6 @@ fn real_world_systemd() -> Result<(), Box<dyn Error>> {
             "Manager.JobNew",
             manager
                 .signals()
-                .iter()
                 .find(|s| s.name() == "JobNew")
                 .expect("JobNew signal")
                 .args(),
@@ -514,7 +516,6 @@ fn real_world_systemd() -> Result<(), Box<dyn Error>> {
 
         let version = manager
             .properties()
-            .iter()
             .find(|p| p.name() == "Version")
             .expect("Version property");
         assert!(version.ty() == "s", "Version type");
@@ -532,7 +533,6 @@ fn real_world_systemd() -> Result<(), Box<dyn Error>> {
         for name in ["LogLevel", "LogTarget"] {
             let property = manager
                 .properties()
-                .iter()
                 .find(|p| p.name() == name)
                 .unwrap_or_else(|| panic!("Manager.{name} property"));
             assert!(property.ty() == "s", "Manager.{name}: type");
@@ -561,14 +561,16 @@ fn real_world_systemd() -> Result<(), Box<dyn Error>> {
         "org.freedesktop.systemd1.Scope",
     ] {
         let iface = interface(&node, name);
-        assert!(!iface.properties().is_empty(), "{name}: has properties");
+        assert!(
+            iface.properties().next().is_some(),
+            "{name}: has properties"
+        );
     }
     // The generic Unit interface exposes the well-known Id/ActiveState string properties.
     let unit = interface(&node, "org.freedesktop.systemd1.Unit");
     for name in ["Id", "ActiveState"] {
         let property = unit
             .properties()
-            .iter()
             .find(|p| p.name() == name)
             .unwrap_or_else(|| panic!("Unit.{name} property"));
         assert!(property.ty() == "s", "Unit.{name}: type");
@@ -736,7 +738,11 @@ fn invalid_enum_attributes() -> Result<(), Box<dyn Error>> {
     let write_only = "<node><interface name=\"org.test.I\">\
                       <property name=\"P\" type=\"s\" access=\"write\"/></interface></node>";
     let node = Node::try_from(write_only)?;
-    let access = node.interfaces()[0].properties()[0].access();
+    let access = node.interfaces()[0]
+        .properties()
+        .next()
+        .expect("interface property")
+        .access();
     assert_eq!(access, PropertyAccess::Write);
     assert!(access.write() && !access.read());
 
@@ -816,24 +822,28 @@ fn docstrings() -> Result<(), Box<dyn Error>> {
     assert!(docstring.contains("<tp:rationale>"));
     assert!(docstring.ends_with("</tp:rationale>"));
 
-    let method = &interface.methods()[0];
+    let method = &interface.methods().next().expect("interface method");
     assert_eq!(method.docstring(), Some("Does the thing."));
     assert_eq!(method.args()[0].docstring(), Some("The thing to do."));
     assert_eq!(method.args()[1].docstring(), None);
 
-    let signal = &interface.signals()[0];
+    let signal = &interface.signals().next().expect("interface signal");
     assert_eq!(signal.docstring(), Some("Emitted when the thing was done."));
     assert_eq!(
         signal.args()[0].docstring(),
         Some("The thing that was done.")
     );
 
+    let mut properties = interface.properties();
     assert_eq!(
-        interface.properties()[0].docstring(),
+        properties.next().expect("interface property").docstring(),
         Some("Whether the thing has been done.")
     );
     // Whitespace-only and self-closing docstrings count as absent.
-    assert_eq!(interface.properties()[1].docstring(), None);
+    assert_eq!(
+        properties.next().expect("interface property").docstring(),
+        None
+    );
 
     Ok(())
 }
@@ -932,7 +942,7 @@ fn telepathy_type_definitions() -> Result<(), Box<dyn Error>> {
         TypeDef::Enum(ordering),
         TypeDef::Struct(playlist),
         TypeDef::Mapping(map),
-    ] = interface.telepathy_types()
+    ] = interface.telepathy_types().collect::<Vec<_>>()[..]
     else {
         panic!("expected enum, struct and mapping on the interface");
     };
@@ -973,10 +983,14 @@ fn telepathy_type_definitions() -> Result<(), Box<dyn Error>> {
     assert_eq!(map.signature().to_string(), "a{sv}");
 
     // `tp:type` references on args and properties.
-    let method = &interface.methods()[0];
+    let method = &interface.methods().next().expect("interface method");
     assert_eq!(method.args()[0].tp_type(), Some("Playlist[]"));
     assert_eq!(
-        interface.properties()[0].tp_type(),
+        interface
+            .properties()
+            .next()
+            .expect("interface property")
+            .tp_type(),
         Some("Playlist_Ordering[]")
     );
 
@@ -1082,7 +1096,7 @@ fn unknown_children_of_telepathy_definitions() -> Result<(), Box<dyn Error>> {
     let (node, warnings) = Node::from_reader_with_warnings(input.as_bytes())?;
     // The definitions themselves still parse fine.
     assert_eq!(node.telepathy_types().len(), 1);
-    assert_eq!(node.interfaces()[0].telepathy_types().len(), 2);
+    assert_eq!(node.interfaces()[0].telepathy_types().count(), 2);
 
     let elements: Vec<_> = warnings.iter().map(|w| w.element()).collect();
     assert_eq!(elements, ["tp:added", "tp:changed", "bogus"]);

--- a/zbus_xmlgen/src/lib.rs
+++ b/zbus_xmlgen/src/lib.rs
@@ -253,7 +253,7 @@ impl<'i> CodeGenerator<'i> {
         writeln!(w, ")]")?;
         writeln!(w, "pub trait {name} {{")?;
 
-        let mut methods = iface.methods().to_vec();
+        let mut methods = iface.methods().collect::<Vec<_>>();
         methods.sort_by(|a, b| a.name().partial_cmp(&b.name()).unwrap());
         for m in &methods {
             let (inputs, output) = inputs_output_from_args(m.args(), &types);
@@ -268,7 +268,7 @@ impl<'i> CodeGenerator<'i> {
             writeln!(w, "    fn {name}({inputs}){output};")?;
         }
 
-        let mut signals = iface.signals().to_vec();
+        let mut signals = iface.signals().collect::<Vec<_>>();
         signals.sort_by(|a, b| a.name().partial_cmp(&b.name()).unwrap());
         for signal in &signals {
             let args = parse_signal_args(signal.args(), &types);
@@ -284,7 +284,7 @@ impl<'i> CodeGenerator<'i> {
             writeln!(w, "    fn {name}({args}) -> zbus::Result<()>;",)?;
         }
 
-        let mut props = iface.properties().to_vec();
+        let mut props = iface.properties().collect::<Vec<_>>();
         props.sort_by(|a, b| a.name().partial_cmp(&b.name()).unwrap());
         for p in props {
             let name = to_identifier(&to_snakecase(p.name().as_str()));
@@ -533,11 +533,10 @@ impl<'i> Types<'i> {
         let mut referenced = HashSet::new();
         let mut pending: Vec<&str> = interface
             .methods()
-            .iter()
             .flat_map(|m| m.args())
-            .chain(interface.signals().iter().flat_map(|s| s.args()))
+            .chain(interface.signals().flat_map(|s| s.args()))
             .filter_map(Arg::tp_type)
-            .chain(interface.properties().iter().filter_map(Property::tp_type))
+            .chain(interface.properties().filter_map(Property::tp_type))
             .collect();
         for def in interface.telepathy_types() {
             member_references(def, &mut pending);
@@ -563,7 +562,7 @@ impl<'i> Types<'i> {
         let mut taken: HashSet<String> = ["Proxy", "ProxyBlocking"]
             .iter()
             .map(|suffix| format!("{trait_name}{suffix}"))
-            .chain(interface.signals().iter().flat_map(|signal| {
+            .chain(interface.signals().flat_map(|signal| {
                 let signal = pascal_case(signal.name().as_str());
                 [
                     signal.clone(),
@@ -578,7 +577,7 @@ impl<'i> Types<'i> {
         let node_defs = node_types
             .iter()
             .filter(|def| referenced.contains(def.name()));
-        for def in interface.telepathy_types().iter().chain(node_defs) {
+        for def in interface.telepathy_types().chain(node_defs) {
             if generatable(def)
                 && !generated.contains_key(def.name())
                 && taken.insert(type_name(def.name()))

--- a/zbus_xmlgen/src/lib.rs
+++ b/zbus_xmlgen/src/lib.rs
@@ -253,71 +253,68 @@ impl<'i> CodeGenerator<'i> {
         writeln!(w, ")]")?;
         writeln!(w, "pub trait {name} {{")?;
 
-        let mut methods = iface.methods().collect::<Vec<_>>();
-        methods.sort_by(|a, b| a.name().partial_cmp(&b.name()).unwrap());
-        for m in &methods {
-            let (inputs, output) = inputs_output_from_args(m.args(), &types);
-            let name = to_identifier(&to_snakecase(m.name().as_str()));
-            writeln!(w)?;
-            writeln!(w, "    /// {} method", m.name())?;
-            write_member_docs(w, m.docstring(), m.args())?;
-            if pascal_case(&name) != m.name().as_str() {
-                writeln!(w, "    #[zbus(name = \"{}\")]", m.name())?;
-            }
-            hide_clippy_lints(w, m, &types)?;
-            writeln!(w, "    fn {name}({inputs}){output};")?;
-        }
-
-        let mut signals = iface.signals().collect::<Vec<_>>();
-        signals.sort_by(|a, b| a.name().partial_cmp(&b.name()).unwrap());
-        for signal in &signals {
-            let args = parse_signal_args(signal.args(), &types);
-            let name = to_identifier(&to_snakecase(signal.name().as_str()));
-            writeln!(w)?;
-            writeln!(w, "    /// {} signal", signal.name())?;
-            write_member_docs(w, signal.docstring(), signal.args())?;
-            if pascal_case(&name) != signal.name().as_str() {
-                writeln!(w, "    #[zbus(signal, name = \"{}\")]", signal.name())?;
-            } else {
-                writeln!(w, "    #[zbus(signal)]")?;
-            }
-            writeln!(w, "    fn {name}({args}) -> zbus::Result<()>;",)?;
-        }
-
-        let mut props = iface.properties().collect::<Vec<_>>();
-        props.sort_by(|a, b| a.name().partial_cmp(&b.name()).unwrap());
-        for p in props {
-            let name = to_identifier(&to_snakecase(p.name().as_str()));
-            let fn_attribute = if pascal_case(&name) != p.name().as_str() {
-                format!("    #[zbus(property, name = \"{}\")]", p.name())
-            } else {
-                "    #[zbus(property)]".to_string()
-            };
-
-            writeln!(w)?;
-            writeln!(w, "    /// {} property", p.name())?;
-            write_member_docs(w, p.docstring(), &[])?;
-            // Named types satisfy both directions of the property value conversions, owned.
-            let named = types.resolve(p.tp_type(), p.ty(), false);
-            if p.access().read() {
-                writeln!(w, "{fn_attribute}")?;
-                let output = match &named {
-                    Some(named) => named.clone(),
-                    None => {
-                        hide_clippy_type_complexity_lint(w, p.ty())?;
-                        to_rust_type(p.ty(), false, false)
+        for child in iface.children() {
+            match child {
+                zbus_xml::Child::Method(m) => {
+                    let (inputs, output) = inputs_output_from_args(m.args(), &types);
+                    let name = to_identifier(&to_snakecase(m.name().as_str()));
+                    writeln!(w)?;
+                    writeln!(w, "    /// {} method", m.name())?;
+                    write_member_docs(w, m.docstring(), m.args())?;
+                    if pascal_case(&name) != m.name().as_str() {
+                        writeln!(w, "    #[zbus(name = \"{}\")]", m.name())?;
                     }
-                };
-                writeln!(w, "    fn {name}(&self) -> zbus::Result<{output}>;",)?;
-            }
+                    hide_clippy_lints(w, m, &types)?;
+                    writeln!(w, "    fn {name}({inputs}){output};")?;
+                }
+                zbus_xml::Child::Signal(signal) => {
+                    let args = parse_signal_args(signal.args(), &types);
+                    let name = to_identifier(&to_snakecase(signal.name().as_str()));
+                    writeln!(w)?;
+                    writeln!(w, "    /// {} signal", signal.name())?;
+                    write_member_docs(w, signal.docstring(), signal.args())?;
+                    if pascal_case(&name) != signal.name().as_str() {
+                        writeln!(w, "    #[zbus(signal, name = \"{}\")]", signal.name())?;
+                    } else {
+                        writeln!(w, "    #[zbus(signal)]")?;
+                    }
+                    writeln!(w, "    fn {name}({args}) -> zbus::Result<()>;",)?;
+                }
+                zbus_xml::Child::Property(p) => {
+                    let name = to_identifier(&to_snakecase(p.name().as_str()));
+                    let fn_attribute = if pascal_case(&name) != p.name().as_str() {
+                        format!("    #[zbus(property, name = \"{}\")]", p.name())
+                    } else {
+                        "    #[zbus(property)]".to_string()
+                    };
 
-            if p.access().write() {
-                writeln!(w, "{fn_attribute}")?;
-                let input = named.unwrap_or_else(|| to_property_setter_type(p.ty()));
-                writeln!(
-                    w,
-                    "    fn set_{name}(&self, value: {input}) -> zbus::Result<()>;",
-                )?;
+                    writeln!(w)?;
+                    writeln!(w, "    /// {} property", p.name())?;
+                    write_member_docs(w, p.docstring(), &[])?;
+                    // Named types satisfy both directions of the property value conversions, owned.
+                    let named = types.resolve(p.tp_type(), p.ty(), false);
+                    if p.access().read() {
+                        writeln!(w, "{fn_attribute}")?;
+                        let output = match &named {
+                            Some(named) => named.clone(),
+                            None => {
+                                hide_clippy_type_complexity_lint(w, p.ty())?;
+                                to_rust_type(p.ty(), false, false)
+                            }
+                        };
+                        writeln!(w, "    fn {name}(&self) -> zbus::Result<{output}>;",)?;
+                    }
+
+                    if p.access().write() {
+                        writeln!(w, "{fn_attribute}")?;
+                        let input = named.unwrap_or_else(|| to_property_setter_type(p.ty()));
+                        writeln!(
+                            w,
+                            "    fn set_{name}(&self, value: {input}) -> zbus::Result<()>;",
+                        )?;
+                    }
+                }
+                _ => (),
             }
         }
         writeln!(w, "}}")

--- a/zbus_xmlgen/tests/data/property_setters.rs
+++ b/zbus_xmlgen/tests/data/property_setters.rs
@@ -1,27 +1,10 @@
 #[proxy(interface = "com.example.PropertySetters", assume_defaults = true)]
 pub trait PropertySetters {
-    /// ArrayOfStruct property
+    /// Variant property
     #[zbus(property)]
-    fn array_of_struct(&self) -> zbus::Result<Vec<(i32, i32)>>;
+    fn variant(&self) -> zbus::Result<zbus::OwnedValue>;
     #[zbus(property)]
-    fn set_array_of_struct(&self, value: &[(i32, i32)]) -> zbus::Result<()>;
-
-    /// ArrayOfVariant property
-    #[zbus(property)]
-    fn array_of_variant(&self) -> zbus::Result<Vec<zbus::OwnedValue>>;
-    #[zbus(property)]
-    fn set_array_of_variant(&self, value: &[zbus::Value<'_>]) -> zbus::Result<()>;
-
-    /// DictStrToVariant property
-    #[zbus(property)]
-    fn dict_str_to_variant(
-        &self,
-    ) -> zbus::Result<std::collections::HashMap<String, zbus::OwnedValue>>;
-    #[zbus(property)]
-    fn set_dict_str_to_variant(
-        &self,
-        value: std::collections::HashMap<&str, zbus::Value<'_>>,
-    ) -> zbus::Result<()>;
+    fn set_variant(&self, value: zbus::Value<'_>) -> zbus::Result<()>;
 
     /// StructPair property
     #[zbus(property)]
@@ -35,15 +18,32 @@ pub trait PropertySetters {
     #[zbus(property)]
     fn set_struct_single(&self, value: (i32,)) -> zbus::Result<()>;
 
+    /// ArrayOfVariant property
+    #[zbus(property)]
+    fn array_of_variant(&self) -> zbus::Result<Vec<zbus::OwnedValue>>;
+    #[zbus(property)]
+    fn set_array_of_variant(&self, value: &[zbus::Value<'_>]) -> zbus::Result<()>;
+
+    /// ArrayOfStruct property
+    #[zbus(property)]
+    fn array_of_struct(&self) -> zbus::Result<Vec<(i32, i32)>>;
+    #[zbus(property)]
+    fn set_array_of_struct(&self, value: &[(i32, i32)]) -> zbus::Result<()>;
+
+    /// DictStrToVariant property
+    #[zbus(property)]
+    fn dict_str_to_variant(
+        &self,
+    ) -> zbus::Result<std::collections::HashMap<String, zbus::OwnedValue>>;
+    #[zbus(property)]
+    fn set_dict_str_to_variant(
+        &self,
+        value: std::collections::HashMap<&str, zbus::Value<'_>>,
+    ) -> zbus::Result<()>;
+
     /// StructWithArrayOfVariant property
     #[zbus(property)]
     fn struct_with_array_of_variant(&self) -> zbus::Result<(Vec<zbus::OwnedValue>,)>;
     #[zbus(property)]
     fn set_struct_with_array_of_variant(&self, value: (&[zbus::Value<'_>],)) -> zbus::Result<()>;
-
-    /// Variant property
-    #[zbus(property)]
-    fn variant(&self) -> zbus::Result<zbus::OwnedValue>;
-    #[zbus(property)]
-    fn set_variant(&self, value: zbus::Value<'_>) -> zbus::Result<()>;
 }

--- a/zbus_xmlgen/tests/data/sample_object0.rs
+++ b/zbus_xmlgen/tests/data/sample_object0.rs
@@ -1,5 +1,24 @@
 #[proxy(interface = "com.example.SampleInterface0", assume_defaults = true)]
 pub trait SampleInterface0 {
+    /// Frobate method
+    fn frobate(
+        &self,
+        foz: i32,
+        foo: i32,
+    ) -> zbus::Result<(String, std::collections::HashMap<u32, String>)>;
+
+    /// Bazic method
+    fn bazic(&self, bar: &(i32, i32), foo: &(i32,)) -> zbus::Result<((i32, i32), Vec<(i32,)>)>;
+
+    /// Bazify method
+    fn bazify(&self, bar: &(i32, i32, u32)) -> zbus::Result<zbus::OwnedValue>;
+
+    /// MogrifyMe method
+    fn mogrify_me(&self, bar: &(i32, i32, &[&zbus::Value<'_>])) -> zbus::Result<()>;
+
+    /// GetSignature method
+    fn get_signature(&self, challenge: &zbus::Signature) -> zbus::Result<zbus::Signature>;
+
     /// BarplexSig method
     fn barplex_sig(
         &self,
@@ -15,25 +34,6 @@ pub trait SampleInterface0 {
             bool,
         ),
     ) -> zbus::Result<Vec<(String, zbus::OwnedObjectPath)>>;
-
-    /// Bazic method
-    fn bazic(&self, bar: &(i32, i32), foo: &(i32,)) -> zbus::Result<((i32, i32), Vec<(i32,)>)>;
-
-    /// Bazify method
-    fn bazify(&self, bar: &(i32, i32, u32)) -> zbus::Result<zbus::OwnedValue>;
-
-    /// Frobate method
-    fn frobate(
-        &self,
-        foz: i32,
-        foo: i32,
-    ) -> zbus::Result<(String, std::collections::HashMap<u32, String>)>;
-
-    /// GetSignature method
-    fn get_signature(&self, challenge: &zbus::Signature) -> zbus::Result<zbus::Signature>;
-
-    /// MogrifyMe method
-    fn mogrify_me(&self, bar: &(i32, i32, &[&zbus::Value<'_>])) -> zbus::Result<()>;
 
     /// Odyssey method
     #[allow(clippy::too_many_arguments)]
@@ -60,16 +60,16 @@ pub trait SampleInterface0 {
     #[zbus(signal)]
     fn signal_array_of_strings(&self, array: Vec<&str>) -> zbus::Result<()>;
 
+    /// SignalValue signal
+    #[zbus(signal)]
+    fn signal_value(&self, value: zbus::Value<'_>) -> zbus::Result<()>;
+
     /// SignalDictStringToValue signal
     #[zbus(signal)]
     fn signal_dict_string_to_value(
         &self,
         dict: std::collections::HashMap<&str, zbus::Value<'_>>,
     ) -> zbus::Result<()>;
-
-    /// SignalValue signal
-    #[zbus(signal)]
-    fn signal_value(&self, value: zbus::Value<'_>) -> zbus::Result<()>;
 
     /// Bar property
     #[zbus(property)]

--- a/zbus_xmlgen/tests/data/struct_return.rs
+++ b/zbus_xmlgen/tests/data/struct_return.rs
@@ -3,15 +3,15 @@ pub trait StructReturn {
     /// ReturnsBareStruct method
     fn returns_bare_struct(&self) -> zbus::Result<((u64, u64),)>;
 
-    /// ReturnsNestedStruct method
-    fn returns_nested_struct(&self) -> zbus::Result<(((String, String), i32),)>;
-
-    /// ReturnsOneString method
-    fn returns_one_string(&self) -> zbus::Result<String>;
-
     /// ReturnsStruct method
     fn returns_struct(&self) -> zbus::Result<((String, String),)>;
 
     /// ReturnsTwoStrings method
     fn returns_two_strings(&self) -> zbus::Result<(String, String)>;
+
+    /// ReturnsOneString method
+    fn returns_one_string(&self) -> zbus::Result<String>;
+
+    /// ReturnsNestedStruct method
+    fn returns_nested_struct(&self) -> zbus::Result<(((String, String), i32),)>;
 }

--- a/zbus_xmlgen/tests/data/telepathy_docstrings.rs
+++ b/zbus_xmlgen/tests/data/telepathy_docstrings.rs
@@ -106,16 +106,6 @@ pub trait Playlists {
     /// * `playlist_id` - The id of the playlist to activate.
     fn activate_playlist(&self, playlist_id: &PlaylistId) -> zbus::Result<()>;
 
-    /// GetMetadata method
-    ///
-    /// Gets the metadata of a playlist.
-    ///
-    /// # Arguments
-    ///
-    /// * `mismatch` - A tp:type not matching the signature falls back to the plain type.
-    /// * `metadata` - The metadata of the playlist.
-    fn get_metadata(&self, mismatch: &str) -> zbus::Result<MetadataMap>;
-
     /// GetPlaylists method
     ///
     /// Gets a set of playlists.
@@ -135,6 +125,16 @@ pub trait Playlists {
         reverse_order: bool,
     ) -> zbus::Result<Vec<Playlist>>;
 
+    /// GetMetadata method
+    ///
+    /// Gets the metadata of a playlist.
+    ///
+    /// # Arguments
+    ///
+    /// * `mismatch` - A tp:type not matching the signature falls back to the plain type.
+    /// * `metadata` - The metadata of the playlist.
+    fn get_metadata(&self, mismatch: &str) -> zbus::Result<MetadataMap>;
+
     /// PlaylistChanged signal
     ///
     /// Indicates that either the Name or Icon attribute of a playlist has changed.
@@ -148,6 +148,14 @@ pub trait Playlists {
     /// * `playlist` - The playlist which details have changed.
     #[zbus(signal)]
     fn playlist_changed(&self, playlist: Playlist) -> zbus::Result<()>;
+
+    /// Orderings property
+    ///
+    /// The available orderings. At least one must be offered.
+    ///
+    /// Media players may not have access to all the data required for some orderings.
+    #[zbus(property)]
+    fn orderings(&self) -> zbus::Result<Vec<PlaylistOrdering>>;
 
     /// ActivePlaylist property
     ///
@@ -164,14 +172,6 @@ pub trait Playlists {
     fn loop_status(&self) -> zbus::Result<LoopStatus>;
     #[zbus(property)]
     fn set_loop_status(&self, value: LoopStatus) -> zbus::Result<()>;
-
-    /// Orderings property
-    ///
-    /// The available orderings. At least one must be offered.
-    ///
-    /// Media players may not have access to all the data required for some orderings.
-    #[zbus(property)]
-    fn orderings(&self) -> zbus::Result<Vec<PlaylistOrdering>>;
 
     /// PlaylistCount property
     ///

--- a/zbus_xmlgen/tests/data/telepathy_edge_cases.rs
+++ b/zbus_xmlgen/tests/data/telepathy_edge_cases.rs
@@ -67,17 +67,17 @@ pub trait EdgeCases {
         dropped_enum: u32,
     ) -> zbus::Result<StatusMap>;
 
-    /// Changed signal
-    #[zbus(signal)]
-    fn changed(&self, status: Status) -> zbus::Result<()>;
-
-    /// NamedKeys property
-    #[zbus(property)]
-    fn named_keys(&self) -> zbus::Result<NamedKeyMap>;
-
     /// OddValues property
     #[zbus(property)]
     fn odd_values(&self) -> zbus::Result<OddValues>;
     #[zbus(property)]
     fn set_odd_values(&self, value: OddValues) -> zbus::Result<()>;
+
+    /// NamedKeys property
+    #[zbus(property)]
+    fn named_keys(&self) -> zbus::Result<NamedKeyMap>;
+
+    /// Changed signal
+    #[zbus(signal)]
+    fn changed(&self, status: Status) -> zbus::Result<()>;
 }


### PR DESCRIPTION
I found it a bit odd that `zbus-xmlgen` reorders the fields and did something about it. By default it does keep the previous behavior, but it can now keep the file ordering with a `--file-order` flag to `zbus-xmlgen`, or if used by code then the `CodeGenerator::with_sorted()` method.

I don't believe the changes have a noticeable impact on performance. This is a breaking change though, considering the public interface of `zbus_xml::Interface` changed in a non-backwards compatible way.

I've also considered renaming the `Interface::methods()`-like methods to `iter_methods()` to make in clear from the name that an iterator is returned. Let me know if this is something you'd prefer - if you're interested in taking this change at all.

---
The --file-order flag, or for the CodeGenerator the sorted flag, toggles whether to sort elements by type and alphabetically, or whether to keep the order as defined by the XML specification.