### PR TITLE
🚩 zb: Make stream builder APIs additive

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -129,9 +129,10 @@ jobs:
           dbus-run-session --config-file /tmp/dbus-session.conf -- \
             cargo --locked test --release --verbose --all-features \
               -- --skip fdpass_systemd
-          # All features except tokio.
+          # Test the full zbus suite with async-io but without Tokio.
           dbus-run-session --config-file /tmp/dbus-session.conf -- \
-            cargo --locked test --release --verbose --features uuid,url,time,chrono,option-as-array,vsock,bus-impl \
+            cargo --locked test --release --verbose -p zbus \
+              --features uuid,url,time,chrono,option-as-array,vsock,bus-impl \
               -- --skip fdpass_systemd
           # Test tokio support.
           dbus-run-session --config-file /tmp/dbus-session.conf -- \

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -125,6 +125,10 @@ jobs:
           # Start IBus daemon for IBus test.
           ibus-daemon -d --xim
           sleep 2
+          # Test all workspace features together.
+          dbus-run-session --config-file /tmp/dbus-session.conf -- \
+            cargo --locked test --release --verbose --all-features \
+              -- --skip fdpass_systemd
           # All features except tokio.
           dbus-run-session --config-file /tmp/dbus-session.conf -- \
             cargo --locked test --release --verbose --features uuid,url,time,chrono,option-as-array,vsock,bus-impl \

--- a/book/src/connection.md
+++ b/book/src/connection.md
@@ -62,8 +62,8 @@ let (client_conn, server_conn) = futures_util::try_join!(
 # }
 ```
 
-`async_io_unix_stream` (and `async_io_tcp_stream`) take a [`std::os::unix::net::UnixStream`]. With `tokio`
-enabled you can instead pass a [`tokio::net::UnixStream`] to `unix_stream`.
+`async_io_unix_stream` takes a [`std::os::unix::net::UnixStream`]. With `tokio` enabled you can
+instead pass a [`tokio::net::UnixStream`] to `tokio_unix_stream`.
 
 [`std::os::unix::net::UnixStream`]: https://doc.rust-lang.org/std/os/unix/net/struct.UnixStream.html
 [`tokio::net::UnixStream`]: https://docs.rs/tokio/latest/tokio/net/struct.UnixStream.html

--- a/book/src/upgrading-to-6.md
+++ b/book/src/upgrading-to-6.md
@@ -296,8 +296,37 @@ The compatibility module is removed in zbus 7.0.
 
 ## Other changes in 6.0
 
-Four more things break in 6.0 without being a consequence of the crate merge. They reach code
+Five more things break in 6.0 without being a consequence of the crate merge. They reach code
 that never mentioned `zvariant` or `zbus_names`.
+
+### Stream constructors name their I/O backend
+
+The stream constructors on `connection::Builder` no longer change their parameter type when Cargo
+features are unified. `unix_stream`, `tcp_stream` and `vsock_stream` are gone; choose the
+constructor that matches the stream instead:
+
+- `tokio::net::UnixStream`: `Builder::unix_stream` becomes `Builder::tokio_unix_stream` with
+  `tokio`.
+- `std::os::unix::net::UnixStream` or `uds_windows::UnixStream`: `Builder::unix_stream` becomes
+  `Builder::async_io_unix_stream` with `async-io`.
+- `tokio::net::TcpStream`: `Builder::tcp_stream` becomes `Builder::tokio_tcp_stream` with `tokio`.
+- `std::net::TcpStream`: `Builder::tcp_stream` becomes `Builder::async_io_tcp_stream` with
+  `async-io`.
+- `tokio_vsock::VsockStream`: `Builder::vsock_stream` becomes `Builder::tokio_vsock_stream` with
+  `tokio-vsock`.
+- `vsock::VsockStream`: `Builder::vsock_stream` becomes `Builder::async_io_vsock_stream` with
+  `vsock`.
+
+`async_io_unix_stream` and `async_io_tcp_stream` already existed in zbus 5.19 and keep their
+names. The Unix and TCP renames also apply to `zbus::blocking::connection::Builder`; the blocking
+builder has no VSOCK stream constructors.
+
+When the corresponding runtime features are enabled, both sets of applicable constructors are
+available; enabling one feature no longer changes a constructor supplied by the other. A supplied
+stream's constructor explicitly chooses its I/O backend. For address-created async connections,
+transports supported by both backends instead choose at run time: tokio when the current thread is
+inside a tokio runtime, and `async-io` otherwise. The stream constructor does not override the
+internal task executor selected while building the connection.
 
 ### The encoding context has no format
 

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -212,6 +212,10 @@ name = "basic"
 required-features = ["comms"]
 
 [[test]]
+name = "builder_feature_additivity"
+required-features = ["comms"]
+
+[[test]]
 name = "builder_message_stream"
 required-features = ["comms"]
 

--- a/zbus/src/blocking/connection/builder.rs
+++ b/zbus/src/blocking/connection/builder.rs
@@ -1,8 +1,3 @@
-#[cfg(not(feature = "tokio"))]
-use std::net::TcpStream;
-#[cfg(feature = "tokio")]
-use tokio::net::TcpStream;
-
 // Feature-independent stream types for the `async_io_*_stream` builders.
 #[cfg(feature = "async-io")]
 use std::net::TcpStream as AsyncIoTcpStream;
@@ -118,24 +113,6 @@ impl<'a> Builder<'a> {
     #[cfg(feature = "async-io")]
     pub fn async_io_tcp_stream(stream: AsyncIoTcpStream) -> Self {
         Self(crate::connection::Builder::async_io_tcp_stream(stream))
-    }
-
-    /// Create a builder for a connection that will use the given TCP stream.
-    ///
-    /// This method expects a
-    /// [`tokio::net::TcpStream`](https://docs.rs/tokio/latest/tokio/net/struct.TcpStream.html).
-    /// Without the `tokio` feature it accepts a [`std::net::TcpStream`] instead, but that form is
-    /// deprecated in favor of [`async_io_tcp_stream`](Self::async_io_tcp_stream).
-    #[cfg_attr(
-        not(feature = "tokio"),
-        deprecated(
-            since = "5.19.0",
-            note = "Use `async_io_tcp_stream` to avoid a build failure if the `tokio` feature gets enabled"
-        )
-    )]
-    #[allow(deprecated)] // forwards to the async builder's equally-deprecated `tcp_stream`
-    pub fn tcp_stream(stream: TcpStream) -> Self {
-        Self(crate::connection::Builder::tcp_stream(stream))
     }
 
     /// Create a builder for a connection that will use the given TCP stream with Tokio.

--- a/zbus/src/blocking/connection/builder.rs
+++ b/zbus/src/blocking/connection/builder.rs
@@ -85,12 +85,14 @@ impl<'a> Builder<'a> {
         crate::connection::Builder::address(address).map(Self)
     }
 
-    /// Create a builder for a connection that will use the given unix stream.
+    /// Create a builder for a connection that will use the given unix stream with `async-io`.
     ///
     /// The stream is a [`std::os::unix::net::UnixStream`] (or [`uds_windows::UnixStream`] on
-    /// Windows).
+    /// Windows). Enabling the `tokio` feature does not change the stream type accepted by this
+    /// method. To use a [Tokio Unix stream][tokio-unix] instead, see `tokio_unix_stream`.
     ///
     /// [`uds_windows::UnixStream`]: https://docs.rs/uds_windows/latest/uds_windows/struct.UnixStream.html
+    /// [tokio-unix]: https://docs.rs/tokio/latest/tokio/net/struct.UnixStream.html
     #[cfg(all(any(unix, windows), feature = "async-io"))]
     pub fn async_io_unix_stream(stream: AsyncIoUnixStream) -> Self {
         Self(crate::connection::Builder::async_io_unix_stream(stream))

--- a/zbus/src/blocking/connection/builder.rs
+++ b/zbus/src/blocking/connection/builder.rs
@@ -1,13 +1,7 @@
 #[cfg(not(feature = "tokio"))]
 use std::net::TcpStream;
-#[cfg(all(unix, not(feature = "tokio")))]
-use std::os::unix::net::UnixStream;
 #[cfg(feature = "tokio")]
 use tokio::net::TcpStream;
-#[cfg(all(unix, feature = "tokio"))]
-use tokio::net::UnixStream;
-#[cfg(all(windows, not(feature = "tokio")))]
-use uds_windows::UnixStream;
 
 // Feature-independent stream types for the `async_io_*_stream` builders.
 #[cfg(feature = "async-io")]
@@ -96,31 +90,6 @@ impl<'a> Builder<'a> {
     #[cfg(all(any(unix, windows), feature = "async-io"))]
     pub fn async_io_unix_stream(stream: AsyncIoUnixStream) -> Self {
         Self(crate::connection::Builder::async_io_unix_stream(stream))
-    }
-
-    /// Create a builder for a connection that will use the given unix stream.
-    ///
-    /// This method expects a
-    /// [`tokio::net::UnixStream`](https://docs.rs/tokio/latest/tokio/net/struct.UnixStream.html).
-    /// Without the `tokio` feature it accepts a [`std::os::unix::net::UnixStream`] instead, but
-    /// that form is deprecated in favor of
-    /// [`async_io_unix_stream`](Self::async_io_unix_stream).
-    ///
-    /// Since tokio currently [does not support Unix domain sockets][tuds] on Windows, this method
-    /// is not available when the `tokio` feature is enabled and building for Windows target.
-    ///
-    /// [tuds]: https://github.com/tokio-rs/tokio/issues/2201
-    #[cfg_attr(
-        not(feature = "tokio"),
-        deprecated(
-            since = "5.19.0",
-            note = "Use `async_io_unix_stream` to avoid a build failure if the `tokio` feature gets enabled"
-        )
-    )]
-    #[cfg(any(unix, not(feature = "tokio")))]
-    #[allow(deprecated)] // forwards to the async builder's equally-deprecated `unix_stream`
-    pub fn unix_stream(stream: UnixStream) -> Self {
-        Self(crate::connection::Builder::unix_stream(stream))
     }
 
     /// Create a builder for a connection that will use the given unix stream with Tokio.

--- a/zbus/src/blocking/connection/builder.rs
+++ b/zbus/src/blocking/connection/builder.rs
@@ -121,6 +121,22 @@ impl<'a> Builder<'a> {
         Self(crate::connection::Builder::unix_stream(stream))
     }
 
+    /// Create a builder for a connection that will use the given unix stream with Tokio.
+    ///
+    /// The stream is a [`tokio::net::UnixStream`]. To use a
+    /// [`std::os::unix::net::UnixStream`] instead, see `async_io_unix_stream`.
+    ///
+    /// The Tokio runtime that owns the stream must remain alive for the connection's lifetime.
+    ///
+    /// This method is not available on Windows because Tokio does not currently [support Unix
+    /// domain sockets there][tuds].
+    ///
+    /// [tuds]: https://github.com/tokio-rs/tokio/issues/2201
+    #[cfg(all(unix, feature = "tokio"))]
+    pub fn tokio_unix_stream(stream: tokio::net::UnixStream) -> Self {
+        Self(crate::connection::Builder::tokio_unix_stream(stream))
+    }
+
     /// Create a builder for a connection that will use the given TCP stream.
     ///
     /// The stream is a [`std::net::TcpStream`].

--- a/zbus/src/blocking/connection/builder.rs
+++ b/zbus/src/blocking/connection/builder.rs
@@ -163,6 +163,17 @@ impl<'a> Builder<'a> {
         Self(crate::connection::Builder::tcp_stream(stream))
     }
 
+    /// Create a builder for a connection that will use the given TCP stream with Tokio.
+    ///
+    /// The stream is a [`tokio::net::TcpStream`]. To use a [`std::net::TcpStream`] instead, see
+    /// `async_io_tcp_stream`.
+    ///
+    /// The Tokio runtime that owns the stream must remain alive for the connection's lifetime.
+    #[cfg(feature = "tokio")]
+    pub fn tokio_tcp_stream(stream: tokio::net::TcpStream) -> Self {
+        Self(crate::connection::Builder::tokio_tcp_stream(stream))
+    }
+
     /// Create a builder for a connection that will use the given pre-authenticated socket.
     ///
     /// This is similar to [`Builder::socket`], except that the socket is either already

--- a/zbus/src/blocking/connection/builder.rs
+++ b/zbus/src/blocking/connection/builder.rs
@@ -139,9 +139,13 @@ impl<'a> Builder<'a> {
         Self(crate::connection::Builder::tokio_unix_stream(stream))
     }
 
-    /// Create a builder for a connection that will use the given TCP stream.
+    /// Create a builder for a connection that will use the given TCP stream with `async-io`.
     ///
-    /// The stream is a [`std::net::TcpStream`].
+    /// The stream is a [`std::net::TcpStream`]. Enabling the `tokio` feature does not change the
+    /// stream type accepted by this method. To use a [Tokio TCP stream][tokio-tcp] instead, see
+    /// `tokio_tcp_stream`.
+    ///
+    /// [tokio-tcp]: https://docs.rs/tokio/latest/tokio/net/struct.TcpStream.html
     #[cfg(feature = "async-io")]
     pub fn async_io_tcp_stream(stream: AsyncIoTcpStream) -> Self {
         Self(crate::connection::Builder::async_io_tcp_stream(stream))

--- a/zbus/src/blocking/connection/mod.rs
+++ b/zbus/src/blocking/connection/mod.rs
@@ -342,9 +342,6 @@ mod tests {
         blocking::{MessageIterator, connection::Builder},
     };
 
-    // Exercises the deprecated `unix_stream` (which must keep working); the `async_io_unix_stream`
-    // replacement just forwards to the async builder covered elsewhere.
-    #[allow(deprecated)]
     #[test]
     #[timeout(15000)]
     fn unix_p2p() {
@@ -355,12 +352,11 @@ mod tests {
 
         let (tx, rx) = std::sync::mpsc::channel();
         let server_thread = thread::spawn(move || {
-            let c = Builder::unix_stream(p0)
-                .server(guid)
-                .unwrap()
-                .p2p()
-                .build()
-                .unwrap();
+            #[cfg(not(feature = "tokio"))]
+            let builder = Builder::async_io_unix_stream(p0);
+            #[cfg(feature = "tokio")]
+            let builder = Builder::tokio_unix_stream(p0);
+            let c = builder.server(guid).unwrap().p2p().build().unwrap();
             rx.recv().unwrap();
             let reply = c
                 .call_method(None::<()>, "/", Some("org.zbus.p2p"), "Test", &())
@@ -370,7 +366,11 @@ mod tests {
             val
         });
 
-        let c = Builder::unix_stream(p1).p2p().build().unwrap();
+        #[cfg(not(feature = "tokio"))]
+        let builder = Builder::async_io_unix_stream(p1);
+        #[cfg(feature = "tokio")]
+        let builder = Builder::tokio_unix_stream(p1);
+        let c = builder.p2p().build().unwrap();
 
         let listener = c.monitor_activity();
 

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -239,6 +239,22 @@ impl<'a> Builder<'a> {
         }
     }
 
+    /// Create a builder for a connection that will use the given unix stream with Tokio.
+    ///
+    /// The stream is a [`tokio::net::UnixStream`]. To use a
+    /// [`std::os::unix::net::UnixStream`] instead, see `async_io_unix_stream`.
+    ///
+    /// The Tokio runtime that owns the stream must remain alive for the connection's lifetime.
+    ///
+    /// This method is not available on Windows because Tokio does not currently [support Unix
+    /// domain sockets there][tuds].
+    ///
+    /// [tuds]: https://github.com/tokio-rs/tokio/issues/2201
+    #[cfg(all(unix, feature = "tokio"))]
+    pub fn tokio_unix_stream(stream: tokio::net::UnixStream) -> Self {
+        Self::new(Target::TokioUnixStream(stream))
+    }
+
     /// Create a builder for a connection that will use the given TCP stream.
     ///
     /// The stream is a [`std::net::TcpStream`].

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -201,12 +201,14 @@ impl<'a> Builder<'a> {
         )))
     }
 
-    /// Create a builder for a connection that will use the given unix stream.
+    /// Create a builder for a connection that will use the given unix stream with `async-io`.
     ///
     /// The stream is a [`std::os::unix::net::UnixStream`] (or [`uds_windows::UnixStream`] on
-    /// Windows).
+    /// Windows). Enabling the `tokio` feature does not change the stream type accepted by this
+    /// method. To use a [Tokio Unix stream][tokio-unix] instead, see `tokio_unix_stream`.
     ///
     /// [`uds_windows::UnixStream`]: https://docs.rs/uds_windows/latest/uds_windows/struct.UnixStream.html
+    /// [tokio-unix]: https://docs.rs/tokio/latest/tokio/net/struct.UnixStream.html
     #[cfg(all(any(unix, windows), feature = "async-io"))]
     pub fn async_io_unix_stream(stream: AsyncIoUnixStream) -> Self {
         Self::new(Target::AsyncIoUnixStream(stream))

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -5,20 +5,14 @@ use enumflags2::BitFlags;
 use event_listener::Event;
 #[cfg(not(feature = "tokio"))]
 use std::net::TcpStream;
-#[cfg(all(unix, not(feature = "tokio")))]
-use std::os::unix::net::UnixStream;
 use std::{
     collections::{HashMap, HashSet},
     mem, vec,
 };
 #[cfg(feature = "tokio")]
 use tokio::net::TcpStream;
-#[cfg(all(unix, feature = "tokio"))]
-use tokio::net::UnixStream;
 #[cfg(feature = "tokio-vsock")]
 use tokio_vsock::VsockStream;
-#[cfg(all(windows, not(feature = "tokio")))]
-use uds_windows::UnixStream;
 #[cfg(all(feature = "vsock", not(feature = "tokio-vsock")))]
 use vsock::VsockStream;
 
@@ -212,37 +206,6 @@ impl<'a> Builder<'a> {
     #[cfg(all(any(unix, windows), feature = "async-io"))]
     pub fn async_io_unix_stream(stream: AsyncIoUnixStream) -> Self {
         Self::new(Target::AsyncIoUnixStream(stream))
-    }
-
-    /// Create a builder for a connection that will use the given unix stream.
-    ///
-    /// This method expects a
-    /// [`tokio::net::UnixStream`](https://docs.rs/tokio/latest/tokio/net/struct.UnixStream.html).
-    /// Without the `tokio` feature it accepts a [`std::os::unix::net::UnixStream`] instead, but
-    /// that form is deprecated in favor of
-    /// [`async_io_unix_stream`](Self::async_io_unix_stream).
-    ///
-    /// Since tokio currently [does not support Unix domain sockets][tuds] on Windows, this method
-    /// is not available when the `tokio` feature is enabled and building for Windows target.
-    ///
-    /// [tuds]: https://github.com/tokio-rs/tokio/issues/2201
-    #[cfg_attr(
-        not(feature = "tokio"),
-        deprecated(
-            since = "5.19.0",
-            note = "Use `async_io_unix_stream` to avoid a build failure if the `tokio` feature gets enabled"
-        )
-    )]
-    #[cfg(any(unix, not(feature = "tokio")))]
-    pub fn unix_stream(stream: UnixStream) -> Self {
-        #[cfg(not(feature = "tokio"))]
-        {
-            Self::new(Target::AsyncIoUnixStream(stream))
-        }
-        #[cfg(feature = "tokio")]
-        {
-            Self::new(Target::TokioUnixStream(stream))
-        }
     }
 
     /// Create a builder for a connection that will use the given unix stream with Tokio.

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -287,6 +287,17 @@ impl<'a> Builder<'a> {
         }
     }
 
+    /// Create a builder for a connection that will use the given TCP stream with Tokio.
+    ///
+    /// The stream is a [`tokio::net::TcpStream`]. To use a [`std::net::TcpStream`] instead, see
+    /// `async_io_tcp_stream`.
+    ///
+    /// The Tokio runtime that owns the stream must remain alive for the connection's lifetime.
+    #[cfg(feature = "tokio")]
+    pub fn tokio_tcp_stream(stream: tokio::net::TcpStream) -> Self {
+        Self::new(Target::TokioTcpStream(stream))
+    }
+
     /// Create a builder for a connection that will use the given VSOCK stream.
     ///
     /// This method is only available when either `vsock` or `tokio-vsock` feature is enabled. The

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -3,14 +3,10 @@ use async_broadcast::Receiver as ActiveReceiver;
 use async_io::Async;
 use enumflags2::BitFlags;
 use event_listener::Event;
-#[cfg(not(feature = "tokio"))]
-use std::net::TcpStream;
 use std::{
     collections::{HashMap, HashSet},
     mem, vec,
 };
-#[cfg(feature = "tokio")]
-use tokio::net::TcpStream;
 #[cfg(feature = "tokio-vsock")]
 use tokio_vsock::VsockStream;
 #[cfg(all(feature = "vsock", not(feature = "tokio-vsock")))]
@@ -234,30 +230,6 @@ impl<'a> Builder<'a> {
     #[cfg(feature = "async-io")]
     pub fn async_io_tcp_stream(stream: AsyncIoTcpStream) -> Self {
         Self::new(Target::AsyncIoTcpStream(stream))
-    }
-
-    /// Create a builder for a connection that will use the given TCP stream.
-    ///
-    /// This method expects a
-    /// [`tokio::net::TcpStream`](https://docs.rs/tokio/latest/tokio/net/struct.TcpStream.html).
-    /// Without the `tokio` feature it accepts a [`std::net::TcpStream`] instead, but that form is
-    /// deprecated in favor of [`async_io_tcp_stream`](Self::async_io_tcp_stream).
-    #[cfg_attr(
-        not(feature = "tokio"),
-        deprecated(
-            since = "5.19.0",
-            note = "Use `async_io_tcp_stream` to avoid a build failure if the `tokio` feature gets enabled"
-        )
-    )]
-    pub fn tcp_stream(stream: TcpStream) -> Self {
-        #[cfg(not(feature = "tokio"))]
-        {
-            Self::new(Target::AsyncIoTcpStream(stream))
-        }
-        #[cfg(feature = "tokio")]
-        {
-            Self::new(Target::TokioTcpStream(stream))
-        }
     }
 
     /// Create a builder for a connection that will use the given TCP stream with Tokio.

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -261,9 +261,13 @@ impl<'a> Builder<'a> {
         Self::new(Target::TokioUnixStream(stream))
     }
 
-    /// Create a builder for a connection that will use the given TCP stream.
+    /// Create a builder for a connection that will use the given TCP stream with `async-io`.
     ///
-    /// The stream is a [`std::net::TcpStream`].
+    /// The stream is a [`std::net::TcpStream`]. Enabling the `tokio` feature does not change the
+    /// stream type accepted by this method. To use a [Tokio TCP stream][tokio-tcp] instead, see
+    /// `tokio_tcp_stream`.
+    ///
+    /// [tokio-tcp]: https://docs.rs/tokio/latest/tokio/net/struct.TcpStream.html
     #[cfg(feature = "async-io")]
     pub fn async_io_tcp_stream(stream: AsyncIoTcpStream) -> Self {
         Self::new(Target::AsyncIoTcpStream(stream))

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -62,6 +62,8 @@ enum Target {
     AsyncIoTcpStream(AsyncIoTcpStream),
     #[cfg(any(feature = "vsock", feature = "tokio-vsock"))]
     VsockStream(VsockStream),
+    #[cfg(feature = "vsock")]
+    AsyncIoVsockStream(vsock::VsockStream),
     Address(Address),
     Socket(Split<Box<dyn ReadHalf>, Box<dyn WriteHalf>>),
     AuthenticatedSocket(Split<Box<dyn ReadHalf>, Box<dyn WriteHalf>>),
@@ -306,6 +308,18 @@ impl<'a> Builder<'a> {
     #[cfg(any(feature = "vsock", feature = "tokio-vsock"))]
     pub fn vsock_stream(stream: VsockStream) -> Self {
         Self::new(Target::VsockStream(stream))
+    }
+
+    /// Create a builder for a connection that will use the given VSOCK stream with `async-io`.
+    ///
+    /// The stream is a [`vsock::VsockStream`]. Enabling the `tokio-vsock` feature does not change
+    /// the stream type accepted by this method. To use a [Tokio VSOCK stream][tokio-vsock]
+    /// instead, see `tokio_vsock_stream`.
+    ///
+    /// [tokio-vsock]: https://docs.rs/tokio-vsock/latest/tokio_vsock/struct.VsockStream.html
+    #[cfg(feature = "vsock")]
+    pub fn async_io_vsock_stream(stream: vsock::VsockStream) -> Self {
+        Self::new(Target::AsyncIoVsockStream(stream))
     }
 
     /// Create a builder for a connection that will use the given socket.
@@ -779,6 +793,8 @@ impl<'a> Builder<'a> {
             Target::VsockStream(stream) => Async::new(stream)?.into(),
             #[cfg(feature = "tokio-vsock")]
             Target::VsockStream(stream) => stream.into(),
+            #[cfg(feature = "vsock")]
+            Target::AsyncIoVsockStream(stream) => Async::new(stream)?.into(),
             Target::Address(address) => {
                 guid = address.guid().map(|g| g.to_owned().into());
                 match address.connect().await? {

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -64,6 +64,8 @@ enum Target {
     VsockStream(VsockStream),
     #[cfg(feature = "vsock")]
     AsyncIoVsockStream(vsock::VsockStream),
+    #[cfg(feature = "tokio-vsock")]
+    TokioVsockStream(tokio_vsock::VsockStream),
     Address(Address),
     Socket(Split<Box<dyn ReadHalf>, Box<dyn WriteHalf>>),
     AuthenticatedSocket(Split<Box<dyn ReadHalf>, Box<dyn WriteHalf>>),
@@ -320,6 +322,19 @@ impl<'a> Builder<'a> {
     #[cfg(feature = "vsock")]
     pub fn async_io_vsock_stream(stream: vsock::VsockStream) -> Self {
         Self::new(Target::AsyncIoVsockStream(stream))
+    }
+
+    /// Create a builder for a connection that will use the given VSOCK stream with Tokio.
+    ///
+    /// The stream is a [`tokio_vsock::VsockStream`]. To use a [native VSOCK stream][vsock] instead,
+    /// see `async_io_vsock_stream`.
+    ///
+    /// The Tokio runtime that owns the stream must remain alive for the connection's lifetime.
+    ///
+    /// [vsock]: https://docs.rs/vsock/latest/vsock/struct.VsockStream.html
+    #[cfg(feature = "tokio-vsock")]
+    pub fn tokio_vsock_stream(stream: tokio_vsock::VsockStream) -> Self {
+        Self::new(Target::TokioVsockStream(stream))
     }
 
     /// Create a builder for a connection that will use the given socket.
@@ -795,6 +810,8 @@ impl<'a> Builder<'a> {
             Target::VsockStream(stream) => stream.into(),
             #[cfg(feature = "vsock")]
             Target::AsyncIoVsockStream(stream) => Async::new(stream)?.into(),
+            #[cfg(feature = "tokio-vsock")]
+            Target::TokioVsockStream(stream) => stream.into(),
             Target::Address(address) => {
                 guid = address.guid().map(|g| g.to_owned().into());
                 match address.connect().await? {

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -788,7 +788,9 @@ fn start_internal_executor(executor: &Executor<'static>, internal_executor: bool
         std::thread::Builder::new()
             .name("zbus::Connection executor".into())
             .spawn(move || {
-                crate::utils::block_on(async move {
+                // `utils::block_on` selects tokio when both backends are enabled, which would make
+                // tasks on this async-io executor unexpectedly observe a tokio runtime.
+                async_io::block_on(async move {
                     // Run as long as there is a task to run.
                     while !executor.is_empty() {
                         executor.tick().await;

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -7,10 +7,6 @@ use std::{
     collections::{HashMap, HashSet},
     mem, vec,
 };
-#[cfg(feature = "tokio-vsock")]
-use tokio_vsock::VsockStream;
-#[cfg(all(feature = "vsock", not(feature = "tokio-vsock")))]
-use vsock::VsockStream;
 
 // Feature-independent stream types for the `async_io_*_stream` builders: these always take the
 // blocking/`async-io` stream, so enabling `tokio` elsewhere can't change what they accept.
@@ -50,8 +46,6 @@ enum Target {
     TokioTcpStream(tokio::net::TcpStream),
     #[cfg(feature = "async-io")]
     AsyncIoTcpStream(AsyncIoTcpStream),
-    #[cfg(any(feature = "vsock", feature = "tokio-vsock"))]
-    VsockStream(VsockStream),
     #[cfg(feature = "vsock")]
     AsyncIoVsockStream(vsock::VsockStream),
     #[cfg(feature = "tokio-vsock")]
@@ -241,16 +235,6 @@ impl<'a> Builder<'a> {
     #[cfg(feature = "tokio")]
     pub fn tokio_tcp_stream(stream: tokio::net::TcpStream) -> Self {
         Self::new(Target::TokioTcpStream(stream))
-    }
-
-    /// Create a builder for a connection that will use the given VSOCK stream.
-    ///
-    /// This method is only available when either `vsock` or `tokio-vsock` feature is enabled. The
-    /// type of `stream` is `vsock::VsockStream` with `vsock` feature and `tokio_vsock::VsockStream`
-    /// with `tokio-vsock` feature.
-    #[cfg(any(feature = "vsock", feature = "tokio-vsock"))]
-    pub fn vsock_stream(stream: VsockStream) -> Self {
-        Self::new(Target::VsockStream(stream))
     }
 
     /// Create a builder for a connection that will use the given VSOCK stream with `async-io`.
@@ -745,10 +729,6 @@ impl<'a> Builder<'a> {
             Target::TokioTcpStream(stream) => stream.into(),
             #[cfg(feature = "async-io")]
             Target::AsyncIoTcpStream(stream) => Async::new(stream)?.into(),
-            #[cfg(all(feature = "vsock", not(feature = "tokio-vsock")))]
-            Target::VsockStream(stream) => Async::new(stream)?.into(),
-            #[cfg(feature = "tokio-vsock")]
-            Target::VsockStream(stream) => stream.into(),
             #[cfg(feature = "vsock")]
             Target::AsyncIoVsockStream(stream) => Async::new(stream)?.into(),
             #[cfg(feature = "tokio-vsock")]

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -1752,10 +1752,32 @@ mod p2p_tests {
     #[test]
     #[timeout(15000)]
     fn unix_p2p_async_io_backend() {
+        use futures_lite::FutureExt;
+        use std::time::Duration;
+
         async_io::block_on(async {
             let (server1, client1) = async_io_unix_p2p_pipe().await.unwrap();
             assert!(server1.executor().needs_internal_driver());
             assert!(client1.executor().needs_internal_driver());
+
+            server1
+                .executor()
+                .spawn(
+                    async {
+                        assert!(
+                            tokio::runtime::Handle::try_current().is_err(),
+                            "async-io executor task unexpectedly entered a tokio runtime",
+                        );
+                    },
+                    "verify async-io runtime",
+                )
+                .or(async {
+                    async_io::Timer::after(Duration::from_secs(5)).await;
+                    panic!("async-io executor task did not run");
+                })
+                .await
+                .unwrap();
+
             let (server2, client2) = async_io_unix_p2p_pipe().await.unwrap();
 
             test_p2p(server1, client1, server2, client2).await.unwrap();

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -1693,12 +1693,12 @@ mod p2p_tests {
             let p0 = listener.accept().await.unwrap().0;
 
             (
-                Builder::tcp_stream(p0)
+                Builder::tokio_tcp_stream(p0)
                     .server(guid)
                     .unwrap()
                     .p2p()
                     .auth_mechanism(AuthMechanism::Anonymous),
-                Builder::tcp_stream(p1).p2p(),
+                Builder::tokio_tcp_stream(p1).p2p(),
             )
         };
 

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -1739,7 +1739,10 @@ mod p2p_tests {
             Builder::async_io_unix_stream(p0),
         );
         #[cfg(feature = "tokio")]
-        let (b1, b0) = (Builder::unix_stream(p1), Builder::unix_stream(p0));
+        let (b1, b0) = (
+            Builder::tokio_unix_stream(p1),
+            Builder::tokio_unix_stream(p0),
+        );
 
         futures_util::try_join!(b1.p2p().build(), b0.server(guid).unwrap().p2p().build(),)
     }

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -1832,7 +1832,11 @@ mod p2p_tests {
                 crate::Task::spawn_blocking(move || listener.incoming().next(), "").await?;
             #[cfg(feature = "tokio-vsock")]
             let server = listener.incoming().next().await;
-            Builder::vsock_stream(server.unwrap()?)
+            #[cfg(all(feature = "vsock", not(feature = "tokio-vsock")))]
+            let builder = Builder::async_io_vsock_stream(server.unwrap()?);
+            #[cfg(feature = "tokio-vsock")]
+            let builder = Builder::tokio_vsock_stream(server.unwrap()?);
+            builder
                 .server(guid)?
                 .p2p()
                 .auth_mechanism(AuthMechanism::Anonymous)
@@ -1873,13 +1877,13 @@ mod p2p_tests {
         let server = listener.incoming().next().unwrap().unwrap();
 
         futures_util::try_join!(
-            Builder::vsock_stream(server)
+            Builder::async_io_vsock_stream(server)
                 .server(guid)
                 .unwrap()
                 .p2p()
                 .auth_mechanism(AuthMechanism::Anonymous)
                 .build(),
-            Builder::vsock_stream(client).p2p().build(),
+            Builder::async_io_vsock_stream(client).p2p().build(),
         )
     }
 
@@ -1896,13 +1900,13 @@ mod p2p_tests {
         let server = listener.incoming().next().await.unwrap().unwrap();
 
         futures_util::try_join!(
-            Builder::vsock_stream(server)
+            Builder::tokio_vsock_stream(server)
                 .server(guid)
                 .unwrap()
                 .p2p()
                 .auth_mechanism(AuthMechanism::Anonymous)
                 .build(),
-            Builder::vsock_stream(client).p2p().build(),
+            Builder::tokio_vsock_stream(client).p2p().build(),
         )
     }
 

--- a/zbus/tests/builder_feature_additivity.rs
+++ b/zbus/tests/builder_feature_additivity.rs
@@ -25,3 +25,22 @@ fn unix_stream_builder_signatures_are_additive() {
             zbus::blocking::connection::Builder::tokio_unix_stream;
     }
 }
+
+#[test]
+fn tcp_stream_builder_signatures_are_additive() {
+    #[cfg(feature = "async-io")]
+    {
+        let _: fn(std::net::TcpStream) -> Builder<'static> = Builder::async_io_tcp_stream;
+        #[cfg(feature = "blocking-api")]
+        let _: fn(std::net::TcpStream) -> zbus::blocking::connection::Builder<'static> =
+            zbus::blocking::connection::Builder::async_io_tcp_stream;
+    }
+
+    #[cfg(feature = "tokio")]
+    {
+        let _: fn(tokio::net::TcpStream) -> Builder<'static> = Builder::tokio_tcp_stream;
+        #[cfg(feature = "blocking-api")]
+        let _: fn(tokio::net::TcpStream) -> zbus::blocking::connection::Builder<'static> =
+            zbus::blocking::connection::Builder::tokio_tcp_stream;
+    }
+}

--- a/zbus/tests/builder_feature_additivity.rs
+++ b/zbus/tests/builder_feature_additivity.rs
@@ -1,0 +1,27 @@
+//! Compile-time checks that enabling another runtime feature does not replace a stream builder.
+
+use zbus::connection::Builder;
+
+#[cfg(all(unix, feature = "async-io"))]
+type AsyncIoUnixStream = std::os::unix::net::UnixStream;
+#[cfg(all(windows, feature = "async-io"))]
+type AsyncIoUnixStream = uds_windows::UnixStream;
+
+#[test]
+fn unix_stream_builder_signatures_are_additive() {
+    #[cfg(all(any(unix, windows), feature = "async-io"))]
+    {
+        let _: fn(AsyncIoUnixStream) -> Builder<'static> = Builder::async_io_unix_stream;
+        #[cfg(feature = "blocking-api")]
+        let _: fn(AsyncIoUnixStream) -> zbus::blocking::connection::Builder<'static> =
+            zbus::blocking::connection::Builder::async_io_unix_stream;
+    }
+
+    #[cfg(all(unix, feature = "tokio"))]
+    {
+        let _: fn(tokio::net::UnixStream) -> Builder<'static> = Builder::tokio_unix_stream;
+        #[cfg(feature = "blocking-api")]
+        let _: fn(tokio::net::UnixStream) -> zbus::blocking::connection::Builder<'static> =
+            zbus::blocking::connection::Builder::tokio_unix_stream;
+    }
+}

--- a/zbus/tests/builder_feature_additivity.rs
+++ b/zbus/tests/builder_feature_additivity.rs
@@ -44,3 +44,12 @@ fn tcp_stream_builder_signatures_are_additive() {
             zbus::blocking::connection::Builder::tokio_tcp_stream;
     }
 }
+
+#[test]
+fn vsock_stream_builder_signatures_are_additive() {
+    #[cfg(feature = "vsock")]
+    let _: fn(vsock::VsockStream) -> Builder<'static> = Builder::async_io_vsock_stream;
+
+    #[cfg(feature = "tokio-vsock")]
+    let _: fn(tokio_vsock::VsockStream) -> Builder<'static> = Builder::tokio_vsock_stream;
+}

--- a/zbus/tests/builder_message_stream.rs
+++ b/zbus/tests/builder_message_stream.rs
@@ -7,48 +7,70 @@
 
 #![cfg(all(unix, feature = "bus-impl"))]
 
-use std::os::unix::net::UnixStream;
-
 use futures_util::StreamExt;
 use ntest::timeout;
 use test_log::test;
-use zbus::{Connection, Guid, block_on, connection::Builder};
+use zbus::{Connection, Guid, connection::Builder};
 
 /// Simulates the busd race: a bus client pipelines Hello during SASL auth, before the server
 /// has started polling. `build_message_stream` must still deliver it.
-#[allow(deprecated)] // exercises the deprecated `unix_stream`, which must keep working
+#[cfg(feature = "async-io")]
 #[test]
 #[timeout(15000)]
-fn build_message_stream_does_not_drop_pipelined_hello() {
-    block_on(async {
-        let (s0, s1) = UnixStream::pair().unwrap();
+fn build_message_stream_does_not_drop_pipelined_hello_async_io() {
+    async_io::block_on(async {
+        let (s0, s1) = std::os::unix::net::UnixStream::pair().unwrap();
         let guid = Guid::generate();
 
-        // Server: SASL auth, set up stream, receive Hello, reply to it.
-        let server = async {
-            let mut stream = Builder::unix_stream(s0)
+        build_message_stream_does_not_drop_pipelined_hello(
+            Builder::async_io_unix_stream(s0)
                 .server(guid)
                 .unwrap()
-                .p2p()
-                .build_message_stream()
-                .await
-                .unwrap();
-
-            let hello = stream
-                .next()
-                .await
-                .expect("stream terminated unexpectedly")
-                .unwrap();
-            assert_eq!(hello.header().member().unwrap().as_str(), "Hello");
-
-            // Reply so the client's build() can complete.
-            let conn = Connection::from(stream);
-            conn.reply(&hello.header(), &(":1.1",)).await.unwrap();
-        };
-
-        // Run both concurrently so the SASL handshake completes cooperatively.
-        // The client is a bus connection whose build() pipelines Hello during SASL auth.
-        let ((), client) = futures_util::join!(server, Builder::unix_stream(s1).build());
-        let _client_conn = client.unwrap();
+                .p2p(),
+            Builder::async_io_unix_stream(s1),
+        )
+        .await;
     });
+}
+
+#[cfg(feature = "tokio")]
+#[test]
+#[timeout(15000)]
+fn build_message_stream_does_not_drop_pipelined_hello_tokio() {
+    tokio::runtime::Runtime::new().unwrap().block_on(async {
+        let (s0, s1) = tokio::net::UnixStream::pair().unwrap();
+        let guid = Guid::generate();
+
+        build_message_stream_does_not_drop_pipelined_hello(
+            Builder::tokio_unix_stream(s0).server(guid).unwrap().p2p(),
+            Builder::tokio_unix_stream(s1),
+        )
+        .await;
+    });
+}
+
+async fn build_message_stream_does_not_drop_pipelined_hello(
+    server_builder: Builder<'_>,
+    client_builder: Builder<'_>,
+) {
+    // Server: SASL auth, set up stream, receive Hello, reply to it.
+    let server = async {
+        let mut stream = server_builder.build_message_stream().await.unwrap();
+
+        let hello = stream
+            .next()
+            .await
+            .expect("stream terminated unexpectedly")
+            .unwrap();
+        assert_eq!(hello.header().member().unwrap().as_str(), "Hello");
+
+        // Reply so the client's build() can complete.
+        let conn = Connection::from(stream);
+        conn.reply(&hello.header(), &(":1.1",)).await.unwrap();
+    };
+
+    // Run both concurrently so the SASL handshake completes cooperatively.
+    // The client is a bus connection whose build() pipelines Hello during SASL auth.
+    let ((), client) = futures_util::join!(server, client_builder.build());
+    let _client_conn = client.unwrap();
 }

--- a/zbus/tests/e2e.rs
+++ b/zbus/tests/e2e.rs
@@ -34,7 +34,6 @@ fn iface_and_proxy_unix_p2p() {
     block_on(iface_and_proxy_(true));
 }
 
-#[allow(deprecated)] // exercises the deprecated `unix_stream`, which must keep working
 #[instrument]
 async fn iface_and_proxy_(#[allow(unused)] p2p: bool) {
     let event = event_listener::Event::new();
@@ -62,13 +61,24 @@ async fn iface_and_proxy_(#[allow(unused)] p2p: bool) {
         {
             let (p0, p1) = UnixStream::pair().unwrap();
 
-            (
-                connection::Builder::unix_stream(p0)
+            #[cfg(not(feature = "tokio"))]
+            let builders = (
+                connection::Builder::async_io_unix_stream(p0)
                     .server(guid)
                     .unwrap()
                     .p2p(),
-                connection::Builder::unix_stream(p1).p2p(),
-            )
+                connection::Builder::async_io_unix_stream(p1).p2p(),
+            );
+            #[cfg(feature = "tokio")]
+            let builders = (
+                connection::Builder::tokio_unix_stream(p0)
+                    .server(guid)
+                    .unwrap()
+                    .p2p(),
+                connection::Builder::tokio_unix_stream(p1).p2p(),
+            );
+
+            builders
         }
 
         #[cfg(windows)]

--- a/zbus/tests/e2e.rs
+++ b/zbus/tests/e2e.rs
@@ -91,11 +91,11 @@ async fn iface_and_proxy_(#[allow(unused)] p2p: bool) {
                 let p0 = listener.incoming().next().unwrap().unwrap();
 
                 (
-                    connection::Builder::tcp_stream(p0)
+                    connection::Builder::async_io_tcp_stream(p0)
                         .server(guid)
                         .unwrap()
                         .p2p(),
-                    connection::Builder::tcp_stream(p1).p2p(),
+                    connection::Builder::async_io_tcp_stream(p1).p2p(),
                 )
             }
 
@@ -107,11 +107,11 @@ async fn iface_and_proxy_(#[allow(unused)] p2p: bool) {
                 let p0 = listener.accept().await.unwrap().0;
 
                 (
-                    connection::Builder::tcp_stream(p0)
+                    connection::Builder::tokio_tcp_stream(p0)
                         .server(guid)
                         .unwrap()
                         .p2p(),
-                    connection::Builder::tcp_stream(p1).p2p(),
+                    connection::Builder::tokio_tcp_stream(p1).p2p(),
                 )
             }
         }

--- a/zbus/tests/issue/issue_1003.rs
+++ b/zbus/tests/issue/issue_1003.rs
@@ -10,7 +10,6 @@ use zbus::{AuthMechanism, Guid, block_on, connection::Builder};
 
 const UID: u32 = 0;
 
-#[allow(deprecated)] // exercises the deprecated `unix_stream`, which must keep working
 #[test]
 #[timeout(15000)]
 #[instrument]
@@ -26,15 +25,23 @@ fn issue_1003() {
 
         let (p0, p1) = UnixStream::pair().unwrap();
 
+        #[cfg(not(feature = "tokio"))]
         let (service_conn_builder, client_conn_builder) = (
-            Builder::unix_stream(p0)
-                .auth_mechanism(AuthMechanism::External)
-                .server(guid)
-                .unwrap()
-                .p2p()
-                .user_id(UID),
-            Builder::unix_stream(p1).p2p().user_id(UID),
+            Builder::async_io_unix_stream(p0),
+            Builder::async_io_unix_stream(p1),
         );
+        #[cfg(feature = "tokio")]
+        let (service_conn_builder, client_conn_builder) = (
+            Builder::tokio_unix_stream(p0),
+            Builder::tokio_unix_stream(p1),
+        );
+        let service_conn_builder = service_conn_builder
+            .auth_mechanism(AuthMechanism::External)
+            .server(guid)
+            .unwrap()
+            .p2p()
+            .user_id(UID);
+        let client_conn_builder = client_conn_builder.p2p().user_id(UID);
 
         let (service_conn, client_conn) = futures_util::try_join!(
             service_conn_builder.build(),

--- a/zbus/tests/issue/issue_279.rs
+++ b/zbus/tests/issue/issue_279.rs
@@ -1,7 +1,6 @@
 use test_log::test;
 use tracing::instrument;
 
-#[allow(deprecated)] // exercises the deprecated `unix_stream`, which must keep working
 #[test(tokio::test(flavor = "multi_thread", worker_threads = 2))]
 #[instrument]
 async fn issue_279() {
@@ -16,8 +15,12 @@ async fn issue_279() {
     let guid = zbus::Guid::generate();
     let (p0, p1) = UnixStream::pair().unwrap();
 
-    let server = Builder::unix_stream(p0).server(guid).unwrap().p2p().build();
-    let client = Builder::unix_stream(p1).p2p().build();
+    let server = Builder::tokio_unix_stream(p0)
+        .server(guid)
+        .unwrap()
+        .p2p()
+        .build();
+    let client = Builder::tokio_unix_stream(p1).p2p().build();
     let (client, server) = try_join!(client, server).unwrap();
     let mut stream = MessageStream::from(client);
     let next_msg_fut = stream.try_next();

--- a/zbus/tests/issue/issue_813.rs
+++ b/zbus/tests/issue/issue_813.rs
@@ -5,7 +5,6 @@ use zbus::block_on;
 
 use zbus::Result;
 
-#[allow(deprecated)] // exercises the deprecated `unix_stream`, which must keep working
 #[instrument]
 #[test]
 #[timeout(15000)]
@@ -59,7 +58,11 @@ fn issue_813() {
         let server_event = event_listener::Event::new();
         let server_listener = server_event.listen();
         let server = async move {
-            let _conn = Builder::unix_stream(p0)
+            #[cfg(not(feature = "tokio"))]
+            let builder = Builder::async_io_unix_stream(p0);
+            #[cfg(feature = "tokio")]
+            let builder = Builder::tokio_unix_stream(p0);
+            let _conn = builder
                 .server(guid)?
                 .p2p()
                 .serve_at(


### PR DESCRIPTION
**Attribution:** This PR title and description were prepared by Codex and published through the connected `zeenix` GitHub account.

The stream builder API still changed parameter types under Cargo feature unification: `unix_stream`, `tcp_stream`, and `vsock_stream` selected one backend at compile time. Since zbus 6 is already an API break, this follows the split API discussed in #1824 instead of carrying that 5.x compatibility compromise forward.

## Changes

- add explicit `async_io_*` and `tokio_*` Unix, TCP, and VSOCK constructors while the old APIs still coexist;
- test that every constructor remains available under unified features;
- remove the ambiguous constructors in a separate breaking-change commit and migrate in-tree callers;
- keep address-created async connections runtime-selected: Tokio inside an active Tokio runtime, and async-io otherwise;
- make an explicitly supplied stream select the I/O backend named by its constructor while the active runtime independently selects the task executor;
- keep an async-io connection's internal executor on `async_io::block_on` in dual-runtime builds, with regression coverage;
- document the 6.0 stream-constructor migration;
- run the root CI test with `--all-features` and retain a Tokio-free zbus suite for async-io-only arms.

## Testing

- `cargo +nightly fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo clippy --locked`
- focused all-feature Clippy for `builder_feature_additivity` and `builder_message_stream`
- `RUSTFLAGS='-D warnings' cargo test --locked --all-features --no-run`
- Tokio-free release test build with `async-io` and `blocking-api`, without zbus's `tokio` feature
- `builder_message_stream` under async-io only, Tokio only, and both backends
- additive signature checks under each single and combined Unix/TCP/VSOCK feature set
- dual-runtime selector and async-io internal-driver regression tests
- rustdoc with async-io only, Tokio only, and all features
- dual-backend compile checks for macOS and Windows targets