### PR TITLE
🔥 zb,zm,zx,xmlgen: Drop pre-6.0 deprecated APIs

### DIFF
--- a/zbus/src/blocking/connection/mod.rs
+++ b/zbus/src/blocking/connection/mod.rs
@@ -282,20 +282,6 @@ impl Connection {
         block_on(self.inner.peer_creds())
     }
 
-    /// Return the peer credentials.
-    ///
-    /// The fields are populated on the best effort basis. Some or all fields may not even make
-    /// sense for certain sockets or on certain platforms and hence will be set to `None`.
-    ///
-    /// # Caveats
-    ///
-    /// Currently `linux_security_label` field is not populated.
-    #[deprecated(since = "5.13.0", note = "Use `peer_creds` instead")]
-    pub fn peer_credentials(&self) -> io::Result<ConnectionCredentials> {
-        #[allow(deprecated)]
-        block_on(self.inner.peer_credentials())
-    }
-
     /// Close the connection.
     ///
     /// After this call, all reading and writing operations will fail.

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -1212,24 +1212,6 @@ impl Connection {
             .expect("credentials should have been set"))
     }
 
-    /// Return the peer credentials.
-    ///
-    /// The fields are populated on the best effort basis. Some or all fields may not even make
-    /// sense for certain sockets or on certain platforms and hence will be set to `None`.
-    ///
-    /// # Caveats
-    ///
-    /// Currently `linux_security_label` field is not populated.
-    #[deprecated(since = "5.13.0", note = "Use `peer_creds` instead")]
-    pub async fn peer_credentials(&self) -> io::Result<ConnectionCredentials> {
-        self.inner
-            .socket_write
-            .lock()
-            .await
-            .peer_credentials()
-            .await
-    }
-
     /// Close the connection.
     ///
     /// After this call, all reading and writing operations will fail.

--- a/zbus/src/connection/socket/vsock.rs
+++ b/zbus/src/connection/socket/vsock.rs
@@ -17,8 +17,8 @@ impl super::ReadHalf for std::sync::Arc<async_io::Async<vsock::VsockStream>> {
         }
     }
 
-    fn auth_mechanism(&self) -> crate::AuthMechanism {
-        crate::AuthMechanism::Anonymous
+    fn auth_mechanism(&self) -> crate::conn::AuthMechanism {
+        crate::conn::AuthMechanism::Anonymous
     }
 }
 

--- a/zbus/src/lib.rs
+++ b/zbus/src/lib.rs
@@ -102,13 +102,6 @@ pub use connection as conn;
 #[cfg(feature = "comms")]
 pub use connection::Connection;
 #[cfg(feature = "comms")]
-#[deprecated(
-    since = "5.0.0",
-    note = "Please use `connection::AuthMechanism` instead"
-)]
-pub use connection::handshake::AuthMechanism;
-
-#[cfg(feature = "comms")]
 mod message_stream;
 #[cfg(feature = "comms")]
 pub use message_stream::*;

--- a/zbus/src/object_server/interface/dispatch_result.rs
+++ b/zbus/src/object_server/interface/dispatch_result.rs
@@ -2,55 +2,13 @@ use std::{future::Future, pin::Pin};
 
 use zbus::message::Flags;
 
-use crate::{Connection, Result, fdo, message::Message, wire::DynamicType};
+use crate::{Connection, fdo, message::Message, wire::DynamicType};
 use tracing::trace;
 
 /// A helper type returned by [`Interface`](`crate::object_server::Interface`) callbacks.
-#[deprecated(since = "5.15.0", note = "Use `DispatchResult2` instead.")]
-pub enum DispatchResult<'a> {
-    /// This interface does not support the given method.
-    NotFound,
-
-    /// Retry with [Interface::call_mut](`crate::object_server::Interface::call_mut).
-    ///
-    /// This is equivalent to NotFound if returned by call_mut.
-    RequiresMut,
-
-    /// The method was found and will be completed by running this Future.
-    Async(Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>),
-}
-
-#[allow(deprecated)]
-impl<'a> DispatchResult<'a> {
-    /// Helper for creating the Async variant.
-    pub fn new_async<F, T, E>(conn: &'a Connection, msg: &'a Message, f: F) -> Self
-    where
-        F: Future<Output = ::std::result::Result<T, E>> + Send + 'a,
-        T: serde::Serialize + DynamicType + Send + Sync,
-        E: zbus::DBusError + Send,
-    {
-        DispatchResult::Async(Box::pin(async move {
-            let hdr = msg.header();
-            let ret = f.await;
-            if !hdr.primary().flags().contains(Flags::NoReplyExpected) {
-                match ret {
-                    Ok(r) => conn.reply(&hdr, &r).await,
-                    Err(e) => conn.reply_dbus_error(&hdr, e).await,
-                }
-                .map(|_seq| ())
-            } else {
-                trace!("No reply expected for {:?} by the caller.", msg);
-                Ok(())
-            }
-        }))
-    }
-}
-
-/// A helper type returned by [`Interface`](`crate::object_server::Interface`) callbacks.
 ///
-/// Unlike [`DispatchResult`], the [`Async`](DispatchResult2::Async) variant uses
-/// [`fdo::Result`] so that D-Bus error names are preserved without nesting through
-/// intermediate [`crate::Error`] conversions.
+/// The [`Async`](DispatchResult2::Async) variant uses [`fdo::Result`] so that D-Bus error names are
+/// preserved without nesting through intermediate [`crate::Error`] conversions.
 ///
 /// This is an unstable type — compatibility may break in minor version bumps.
 pub enum DispatchResult2<'a> {

--- a/zbus/src/object_server/interface/interface_ref.rs
+++ b/zbus/src/object_server/interface/interface_ref.rs
@@ -98,11 +98,6 @@ where
     pub fn signal_emitter(&self) -> &SignalEmitter<'static> {
         &self.emitter
     }
-
-    #[deprecated(since = "0.5.0", note = "Please use `signal_emitter` instead.")]
-    pub fn signal_context(&self) -> &SignalEmitter<'static> {
-        &self.emitter
-    }
 }
 
 impl<I> Clone for InterfaceRef<I> {

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -16,14 +16,10 @@ use crate::{
 
 mod interface;
 pub(crate) use interface::ArcInterface;
-#[allow(deprecated)]
-pub use interface::DispatchResult;
 pub use interface::{DispatchResult2, Interface, InterfaceDeref, InterfaceDerefMut, InterfaceRef};
 
 mod signal_emitter;
 pub use signal_emitter::SignalEmitter;
-#[deprecated(since = "5.0.0", note = "Please use `SignalEmitter` instead.")]
-pub type SignalContext<'s> = SignalEmitter<'s>;
 
 mod dispatch_notifier;
 pub use dispatch_notifier::ResponseDispatchNotifier;

--- a/zbus/src/wire/file_path.rs
+++ b/zbus/src/wire/file_path.rs
@@ -76,7 +76,6 @@ impl<'f> From<&'f OsString> for FilePath<'f> {
 
 impl From<OsString> for FilePath<'_> {
     fn from(value: OsString) -> Self {
-        #[allow(deprecated)]
         FilePath(vec_to_cstr(value.as_encoded_bytes().to_vec()))
     }
 }
@@ -149,12 +148,7 @@ impl<'f> From<FilePath<'f>> for PathBuf {
 /// # Returns
 ///
 /// A `Cow<'_, CStr>` containing a *guaranteed* null-terminated string.
-#[doc(hidden)]
-#[deprecated(
-    since = "5.9.0",
-    note = "This function was never meant to be public and will be removed in a future release."
-)]
-pub fn vec_to_cstr(mut bytes: Vec<u8>) -> Cow<'static, CStr> {
+fn vec_to_cstr(mut bytes: Vec<u8>) -> Cow<'static, CStr> {
     if let Some(pos) = bytes.iter().position(|&b| b == 0) {
         bytes.truncate(pos + 1);
     } else {
@@ -237,7 +231,6 @@ mod file_path_test {
 
     #[test]
     fn vec_nul_termination() {
-        #[allow(deprecated)]
         fn call_vec_to_cstr(v: Vec<u8>) -> Cow<'static, CStr> {
             vec_to_cstr(v)
         }

--- a/zbus/src/wire/mod.rs
+++ b/zbus/src/wire/mod.rs
@@ -272,10 +272,6 @@ pub use owned_value::*;
 mod container_depths;
 
 pub mod as_value;
-#[deprecated(since = "5.5.0", note = "Use `as_value::Deserialize` instead.")]
-pub use as_value::Deserialize as DeserializeValue;
-#[deprecated(since = "5.5.0", note = "Use `as_value::Serialize` instead.")]
-pub use as_value::Serialize as SerializeValue;
 
 pub use zbus_macros::{DeserializeDict, OwnedValue, SerializeDict, Type, Value, signature};
 

--- a/zbus/src/zvariant.rs
+++ b/zbus/src/zvariant.rs
@@ -41,11 +41,11 @@ pub use crate::wire::{
 // The remaining derives and `signature!` come straight from the macro crate so that they land
 // only in the macro namespace and leave the type namespace to the aliases below.
 pub use zbus_macros::{DeserializeDict, OwnedValue, SerializeDict, Value, signature};
-// Submodules, the two `unsafe` writer functions, the `Type` helper macros and the
-// already-deprecated leftovers, all silent.
+// Submodules, the two `unsafe` writer functions and the `Type` helper macros, all silent.
 pub use crate::wire::{
-    DeserializeValue, SerializeValue, as_value, dbus, export, impl_type_with_repr, static_str_type,
-    to_writer, to_writer_for_signature, vec_to_cstr,
+    as_value,
+    as_value::{Deserialize as DeserializeValue, Serialize as SerializeValue},
+    dbus, export, impl_type_with_repr, static_str_type, to_writer, to_writer_for_signature,
 };
 
 /// Deprecated alias of [`crate::wire::Array`].

--- a/zbus/tests/issue/issue_1003.rs
+++ b/zbus/tests/issue/issue_1003.rs
@@ -6,7 +6,10 @@ use ntest::timeout;
 use test_log::test;
 use tracing::{debug, instrument};
 
-use zbus::{AuthMechanism, Guid, block_on, connection::Builder};
+use zbus::{
+    Guid, block_on,
+    connection::{AuthMechanism, Builder},
+};
 
 const UID: u32 = 0;
 

--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -70,7 +70,6 @@ def_attrs! {
         object_server none,
         connection none,
         header none,
-        signal_context none,
         signal_emitter none
     };
 }
@@ -572,11 +571,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                         .iter()
                         .find(|input| {
                             let a = ArgAttributes::parse(&input.attrs).unwrap();
-                            !a.object_server
-                                && !a.connection
-                                && !a.header
-                                && !a.signal_context
-                                && !a.signal_emitter
+                            !a.object_server && !a.connection && !a.header && !a.signal_emitter
                         })
                         .ok_or_else(|| Error::new_spanned(inputs, "Expected a value argument"))?;
 
@@ -1066,7 +1061,6 @@ fn get_args_from_inputs(
                 connection,
                 header,
                 signal_emitter,
-                signal_context,
             } = ArgAttributes::parse(&input.attrs)?;
 
             if object_server {
@@ -1108,22 +1102,22 @@ fn get_args_from_inputs(
                     }),
                     _ => Some(quote! { let #header_arg = __zbus__message.header(); }),
                 };
-            } else if signal_context || signal_emitter {
+            } else if signal_emitter {
                 if signal_emitter_arg_decl.is_some() {
                     return Err(Error::new_spanned(
                         input,
-                        "There can only be one `signal_emitter` or `signal_context` argument",
+                        "There can only be one `signal_emitter` argument",
                     ));
                 }
 
-                let signal_context_arg = &input.pat;
+                let signal_emitter_arg = &input.pat;
 
                 signal_emitter_arg_decl = match method_type {
                     MethodType::Property(_) => Some(
-                        quote! { let #signal_context_arg = ::std::clone::Clone::clone(__zbus__signal_emitter); },
+                        quote! { let #signal_emitter_arg = ::std::clone::Clone::clone(__zbus__signal_emitter); },
                     ),
                     _ => Some(quote! {
-                        let #signal_context_arg = match hdr.path() {
+                        let #signal_emitter_arg = match hdr.path() {
                             ::std::option::Option::Some(p) => {
                                 #zbus::object_server::SignalEmitter::new(__zbus__connection, p).expect("Infallible conversion failed")
                             }
@@ -1295,7 +1289,6 @@ fn is_special_arg(attrs: &[Attribute]) -> bool {
                 if path.is_ident("object_server") ||
                     path.is_ident("connection") ||
                     path.is_ident("header") ||
-                    path.is_ident("signal_context") ||
                     path.is_ident("signal_emitter")
             )
         })
@@ -1571,11 +1564,7 @@ impl Proxy {
             .iter()
             .filter(|input| {
                 let a = ArgAttributes::parse(&input.attrs).unwrap();
-                !a.object_server
-                    && !a.connection
-                    && !a.header
-                    && !a.signal_context
-                    && !a.signal_emitter
+                !a.object_server && !a.connection && !a.header && !a.signal_emitter
             })
             .cloned()
             .collect();

--- a/zbus_xml/src/error.rs
+++ b/zbus_xml/src/error.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, convert::Infallible, error, fmt, io, num::NonZeroUsize, sync::Arc};
+use std::{convert::Infallible, error, fmt, io, sync::Arc};
 
 /// The error type for `zbus_xml`.
 ///
@@ -12,22 +12,6 @@ pub enum Error {
     Xml(XmlError),
     /// An I/O error.
     Io(Arc<io::Error>),
-    /// An XML error from quick_xml
-    #[deprecated(
-        since = "5.2.0",
-        note = "This variant is no longer returned from any of our API. \
-                Match on `Error::Xml` instead."
-    )]
-    #[allow(deprecated)]
-    QuickXml(DeError),
-    /// An XML serialization error from quick_xml
-    #[deprecated(
-        since = "5.2.0",
-        note = "This variant is no longer returned from any of our API. \
-                Match on `Error::Xml` or `Error::Io` instead."
-    )]
-    #[allow(deprecated)]
-    QuickXmlSer(SeError),
 }
 
 impl PartialEq for Error {
@@ -46,10 +30,6 @@ impl error::Error for Error {
             Error::Zbus(e) => Some(e),
             Error::Xml(e) => Some(e),
             Error::Io(e) => Some(e),
-            #[allow(deprecated)]
-            Error::QuickXml(e) => Some(e),
-            #[allow(deprecated)]
-            Error::QuickXmlSer(e) => Some(e),
         }
     }
 }
@@ -60,10 +40,6 @@ impl fmt::Display for Error {
             Error::Zbus(e) => write!(f, "{e}"),
             Error::Xml(e) => write!(f, "XML error: {e}"),
             Error::Io(e) => write!(f, "I/O error: {e}"),
-            #[allow(deprecated)]
-            Error::QuickXml(e) => write!(f, "XML error: {e}"),
-            #[allow(deprecated)]
-            Error::QuickXmlSer(e) => write!(f, "XML serialization error: {e}"),
         }
     }
 }
@@ -125,107 +101,6 @@ impl fmt::Display for XmlError {
 }
 
 impl error::Error for XmlError {}
-
-/// A copy of `quick_xml::de::DeError`, kept for backwards compatibility.
-///
-/// This crate no longer uses quick-xml, so this error is never returned. It only exists so that
-/// code matching on [`Error::QuickXml`] keeps compiling. The `InvalidXml` variant carries the
-/// error message as a string instead of the quick-xml error type it used to wrap, so `source()`
-/// returns `None` for it.
-#[doc(hidden)]
-#[deprecated(
-    since = "5.2.0",
-    note = "This error is no longer returned from any of our API. \
-            Match on `Error::Xml` instead."
-)]
-#[derive(Clone, Debug)]
-pub enum DeError {
-    /// Serde custom error.
-    Custom(String),
-    /// XML parsing error.
-    InvalidXml(String),
-    /// `MapAccess::next_value[_seed]` was called before `MapAccess::next_key[_seed]`.
-    KeyNotRead,
-    /// Deserializer encountered a start tag with an unexpected name.
-    UnexpectedStart(Vec<u8>),
-    /// The reader produced an EOF event when it wasn't expecting one.
-    UnexpectedEof,
-    /// Too many events were skipped while deserializing a sequence.
-    TooManyEvents(NonZeroUsize),
-}
-
-#[allow(deprecated)]
-impl fmt::Display for DeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Custom(s) => f.write_str(s),
-            Self::InvalidXml(e) => f.write_str(e),
-            Self::KeyNotRead => f.write_str(
-                "invalid `Deserialize` implementation: `MapAccess::next_value[_seed]` was called \
-                 before `MapAccess::next_key[_seed]`",
-            ),
-            Self::UnexpectedStart(e) => {
-                write!(
-                    f,
-                    "unexpected `Event::Start({})`",
-                    String::from_utf8_lossy(e)
-                )
-            }
-            Self::UnexpectedEof => f.write_str("unexpected `Event::Eof`"),
-            Self::TooManyEvents(s) => write!(f, "deserializer buffered {s} events, limit exceeded"),
-        }
-    }
-}
-
-#[allow(deprecated)]
-impl error::Error for DeError {}
-
-/// A copy of `quick_xml::se::SeError`, kept for backwards compatibility.
-///
-/// This crate no longer uses quick-xml, so this error is never returned. It only exists so that
-/// code matching on [`Error::QuickXmlSer`] keeps compiling.
-#[doc(hidden)]
-#[deprecated(
-    since = "5.2.0",
-    note = "This error is no longer returned from any of our API. \
-            Match on `Error::Xml` or `Error::Io` instead."
-)]
-#[derive(Clone, Debug)]
-pub enum SeError {
-    /// Serde custom error.
-    Custom(String),
-    /// XML document cannot be written to the underlying source.
-    Io(Arc<io::Error>),
-    /// Some value could not be formatted.
-    Fmt(std::fmt::Error),
-    /// Serialized type cannot be represented in XML.
-    Unsupported(Cow<'static, str>),
-    /// Some value could not be turned to UTF-8.
-    NonEncodable(std::str::Utf8Error),
-}
-
-#[allow(deprecated)]
-impl fmt::Display for SeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Custom(s) => f.write_str(s),
-            Self::Io(e) => write!(f, "I/O error: {e}"),
-            Self::Fmt(e) => write!(f, "formatting error: {e}"),
-            Self::Unsupported(s) => write!(f, "unsupported value: {s}"),
-            Self::NonEncodable(e) => write!(f, "malformed UTF-8: {e}"),
-        }
-    }
-}
-
-#[allow(deprecated)]
-impl error::Error for SeError {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        match self {
-            Self::Io(e) => Some(e),
-            _ => None,
-        }
-    }
-}
 
 /// Alias for a `Result` with the error type `zbus_xml::Error`.
 pub type Result<T> = std::result::Result<T, Error>;

--- a/zbus_xml/src/lib.rs
+++ b/zbus_xml/src/lib.rs
@@ -12,8 +12,6 @@
 )))]
 
 mod error;
-#[allow(deprecated)]
-pub use error::{DeError, SeError};
 pub use error::{Error, Result, XmlError};
 
 mod xml;

--- a/zbus_xmlgen/src/lib.rs
+++ b/zbus_xmlgen/src/lib.rs
@@ -1,8 +1,7 @@
 use snakecase::ascii::to_snakecase;
 use std::{
     collections::{HashMap, HashSet},
-    error::Error,
-    fmt::{Display, Formatter, Write},
+    fmt::Write,
     process::{Command, Stdio},
 };
 
@@ -14,31 +13,6 @@ use zbus_xml::{
     Arg, ArgDirection, Interface, Property,
     telepathy::{self, TypeDef},
 };
-
-#[deprecated(since = "5.4.0", note = "use `CodeGenerator::file_code` instead")]
-pub fn write_interfaces(
-    interfaces: &[Interface<'_>],
-    standard_interfaces: &[Interface<'_>],
-    service: Option<BusName<'_>>,
-    path: Option<ObjectPath<'_>>,
-    input_src: &str,
-    cargo_bin_name: &str,
-    cargo_bin_version: &str,
-) -> Result<String, Box<dyn Error + 'static>> {
-    let code = CodeGenerator::new()
-        .with_service(service.as_ref())
-        .with_path(path.as_ref())
-        .with_format(true)
-        .file_code(
-            interfaces,
-            standard_interfaces,
-            input_src,
-            cargo_bin_name,
-            cargo_bin_version,
-        )?;
-
-    Ok(code)
-}
 
 /// Write a doc header, listing the included Interfaces and how the
 /// code was generated.
@@ -137,27 +111,6 @@ fn write_doc_header<W: std::fmt::Write>(
     )?;
 
     Ok(())
-}
-
-#[deprecated(since = "5.4.0", note = "use `CodeGenerator` instead")]
-pub struct GenTrait<'i> {
-    pub interface: &'i Interface<'i>,
-    pub service: Option<&'i BusName<'i>>,
-    pub path: Option<&'i ObjectPath<'i>>,
-    pub format: bool,
-}
-
-#[allow(deprecated)]
-impl Display for GenTrait<'_> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let code = CodeGenerator::new()
-            .with_service(self.service)
-            .with_path(self.path)
-            .with_format(self.format)
-            .interface_code(self.interface)?;
-
-        write!(f, "{code}")
-    }
 }
 
 /// Generates Rust code from D-Bus introspection data.

--- a/zbus_xmlgen/tests/gen.rs
+++ b/zbus_xmlgen/tests/gen.rs
@@ -94,26 +94,3 @@ fn shared_node_types_in_one_file() -> Result<(), Box<dyn Error>> {
 
     Ok(())
 }
-
-#[test]
-#[allow(deprecated)]
-fn deprecated_gen_trait() -> Result<(), Box<dyn Error>> {
-    // The deprecated `GenTrait` still works, matching `CodeGenerator` sans node-level types.
-    let input = include_str!("data/sample_object0.xml");
-    let node = Node::from_reader(input.as_bytes())?;
-    let interface = &node.interfaces()[0];
-
-    let gen_trait = zbus_xmlgen::GenTrait {
-        interface,
-        path: None,
-        service: None,
-        format: true,
-    }
-    .to_string();
-    let code = CodeGenerator::new()
-        .with_format(true)
-        .interface_code(interface)?;
-    assert_eq!(gen_trait, code);
-
-    Ok(())
-}


### PR DESCRIPTION
Remove compatibility APIs deprecated before zbus 6.0 across zbus, zbus_macros,
zbus_xml, and zbus_xmlgen.

Keep the compatibility surface first deprecated in 6.0 because it is scheduled
for removal in 7.0.

Closes #1915.

Generated by GPT-5.