### PR TITLE
🐛 zb: Reject non-basic dictionary keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1501,6 +1501,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "statrs"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2189,6 +2195,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_repr",
+ "static_assertions",
  "tempfile",
  "test-log",
  "time",

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -169,6 +169,7 @@ chrono = { workspace = true, features = [
     "serde",
     "alloc",
 ], default-features = false }
+static_assertions.workspace = true
 
 [package.metadata.docs.rs]
 # we can't use:

--- a/zbus/src/wire/basic.rs
+++ b/zbus/src/wire/basic.rs
@@ -310,3 +310,122 @@ impl<const CAP: usize> Basic for heapless::String<CAP> {
     const SIGNATURE_CHAR: char = <&str as Basic>::SIGNATURE_CHAR;
     const SIGNATURE_STR: &'static str = <&str as Basic>::SIGNATURE_STR;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+macro_rules! impl_basic_with_repr {
+    ($($ty:ty => $repr:ty),+ $(,)?) => {
+        $(
+            impl Basic for $ty {
+                const SIGNATURE_CHAR: char = <$repr as Basic>::SIGNATURE_CHAR;
+                const SIGNATURE_STR: &'static str = <$repr as Basic>::SIGNATURE_STR;
+            }
+        )+
+    };
+}
+
+impl_basic_with_repr!(
+    std::path::Path => str,
+    std::path::PathBuf => str,
+);
+
+impl<T> Basic for [T; 0]
+where
+    T: Type,
+{
+    const SIGNATURE_CHAR: char = u8::SIGNATURE_CHAR;
+    const SIGNATURE_STR: &'static str = u8::SIGNATURE_STR;
+}
+
+#[cfg(feature = "arrayvec")]
+impl<const CAP: usize> Basic for arrayvec::ArrayString<CAP> {
+    const SIGNATURE_CHAR: char = str::SIGNATURE_CHAR;
+    const SIGNATURE_STR: &'static str = str::SIGNATURE_STR;
+}
+
+#[cfg(feature = "camino")]
+impl_basic_with_repr!(
+    camino::Utf8Path => str,
+    camino::Utf8PathBuf => str,
+);
+
+#[cfg(feature = "url")]
+impl_basic_with_repr!(url::Url => str);
+
+#[cfg(feature = "time")]
+impl_basic_with_repr!(
+    time::Month => u8,
+    time::Weekday => u8,
+);
+
+#[cfg(feature = "chrono")]
+impl<Tz> Basic for chrono::DateTime<Tz>
+where
+    Tz: chrono::TimeZone,
+{
+    const SIGNATURE_CHAR: char = str::SIGNATURE_CHAR;
+    const SIGNATURE_STR: &'static str = str::SIGNATURE_STR;
+}
+
+#[cfg(feature = "chrono")]
+impl_basic_with_repr!(
+    chrono::Month => str,
+    chrono::NaiveDate => str,
+    chrono::NaiveDateTime => str,
+    chrono::NaiveTime => str,
+    chrono::Weekday => str,
+);
+
+#[cfg(feature = "enumflags2")]
+impl<F> Basic for enumflags2::BitFlags<F>
+where
+    F: enumflags2::BitFlag,
+    F::Numeric: Basic,
+{
+    const SIGNATURE_CHAR: char = F::Numeric::SIGNATURE_CHAR;
+    const SIGNATURE_STR: &'static str = F::Numeric::SIGNATURE_STR;
+}
+
+#[cfg(test)]
+mod tests {
+    use static_assertions::assert_impl_all;
+
+    use super::Basic;
+
+    assert_impl_all!([u8; 0]: Basic);
+    assert_impl_all!(std::path::Path: Basic);
+    assert_impl_all!(std::path::PathBuf: Basic);
+    assert_impl_all!(crate::wire::Optional<u8>: Basic);
+
+    #[cfg(feature = "arrayvec")]
+    assert_impl_all!(arrayvec::ArrayString<8>: Basic);
+
+    #[cfg(feature = "camino")]
+    assert_impl_all!(camino::Utf8Path: Basic);
+    #[cfg(feature = "camino")]
+    assert_impl_all!(camino::Utf8PathBuf: Basic);
+
+    #[cfg(feature = "url")]
+    assert_impl_all!(url::Url: Basic);
+
+    #[cfg(feature = "time")]
+    assert_impl_all!(time::Month: Basic);
+    #[cfg(feature = "time")]
+    assert_impl_all!(time::Weekday: Basic);
+
+    #[cfg(feature = "chrono")]
+    assert_impl_all!(chrono::DateTime<chrono::Utc>: Basic);
+    #[cfg(feature = "chrono")]
+    assert_impl_all!(chrono::Month: Basic);
+    #[cfg(feature = "chrono")]
+    assert_impl_all!(chrono::NaiveDate: Basic);
+    #[cfg(feature = "chrono")]
+    assert_impl_all!(chrono::NaiveDateTime: Basic);
+    #[cfg(feature = "chrono")]
+    assert_impl_all!(chrono::NaiveTime: Basic);
+    #[cfg(feature = "chrono")]
+    assert_impl_all!(chrono::Weekday: Basic);
+
+    #[cfg(feature = "comms")]
+    assert_impl_all!(enumflags2::BitFlags<crate::fdo::RequestNameFlags>: Basic);
+}

--- a/zbus/src/wire/dict.rs
+++ b/zbus/src/wire/dict.rs
@@ -278,7 +278,7 @@ macro_rules! to_dict {
     ($ty:ident <K $(: $kbound1:ident $(+ $kbound2:ident)*)*, V $(, $typaram:ident)*>) => {
         impl<'k, 'v, K, V $(, $typaram)*> From<$ty<K, V $(, $typaram)*>> for Dict<'k, 'v>
         where
-            K: Type + Into<Value<'k>>,
+            K: Basic + Into<Value<'k>>,
             V: Type + Into<Value<'v>>,
             $($typaram: BuildHasher,)*
         {

--- a/zbus/src/wire/into_value.rs
+++ b/zbus/src/wire/into_value.rs
@@ -5,7 +5,9 @@ use std::{
     sync::Arc,
 };
 
-use crate::wire::{Array, Dict, NoneValue, ObjectPath, Optional, Str, Structure, Type, Value};
+use crate::wire::{
+    Array, Basic, Dict, NoneValue, ObjectPath, Optional, Str, Structure, Type, Value,
+};
 
 #[cfg(unix)]
 use crate::wire::Fd;
@@ -132,7 +134,7 @@ impl<'a, 'k, 'v, K, V> From<BTreeMap<K, V>> for Value<'a>
 where
     'k: 'a,
     'v: 'a,
-    K: Type + Into<Value<'k>> + std::cmp::Ord,
+    K: Basic + Into<Value<'k>> + std::cmp::Ord,
     V: Type + Into<Value<'v>>,
 {
     fn from(value: BTreeMap<K, V>) -> Self {
@@ -144,7 +146,7 @@ impl<'a, 'k, 'v, K, V, H> From<HashMap<K, V, H>> for Value<'a>
 where
     'k: 'a,
     'v: 'a,
-    K: Type + Into<Value<'k>> + std::hash::Hash + std::cmp::Eq,
+    K: Basic + Into<Value<'k>> + std::hash::Hash + std::cmp::Eq,
     V: Type + Into<Value<'v>>,
     H: BuildHasher + Default,
 {

--- a/zbus/src/wire/optional.rs
+++ b/zbus/src/wire/optional.rs
@@ -5,7 +5,7 @@ use std::{
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
-use crate::wire::Type;
+use crate::wire::{Basic, Type};
 
 /// Type that uses a special value to be used as none.
 ///
@@ -75,6 +75,14 @@ where
 /// [ts]: https://dbus.freedesktop.org/doc/dbus-specification.html#bus-messages-name-owner-changed
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Optional<T>(Option<T>);
+
+impl<T> Basic for Optional<T>
+where
+    T: Basic,
+{
+    const SIGNATURE_CHAR: char = T::SIGNATURE_CHAR;
+    const SIGNATURE_STR: &'static str = T::SIGNATURE_STR;
+}
 
 impl<T> Type for Optional<T>
 where

--- a/zbus/src/wire/owned_value.rs
+++ b/zbus/src/wire/owned_value.rs
@@ -6,8 +6,8 @@ use std::{
 };
 
 use crate::wire::{
-    Array, Dict, NoneValue, ObjectPath, Optional, OwnedObjectPath, Signature, Str, Structure, Type,
-    Value,
+    Array, Basic, Dict, NoneValue, ObjectPath, Optional, OwnedObjectPath, Signature, Str,
+    Structure, Type, Value,
 };
 
 #[cfg(unix)]
@@ -147,7 +147,7 @@ where
 
 impl<K, V> From<BTreeMap<K, V>> for OwnedValue
 where
-    K: Type + Into<Value<'static>> + std::cmp::Ord,
+    K: Basic + Into<Value<'static>> + std::cmp::Ord,
     V: Type + Into<Value<'static>>,
 {
     fn from(value: BTreeMap<K, V>) -> Self {
@@ -176,7 +176,7 @@ where
 
 impl<K, V, H> From<HashMap<K, V, H>> for OwnedValue
 where
-    K: Type + Into<Value<'static>> + std::hash::Hash + std::cmp::Eq,
+    K: Basic + Into<Value<'static>> + std::hash::Hash + std::cmp::Eq,
     V: Type + Into<Value<'static>>,
     H: BuildHasher + Default,
 {

--- a/zbus/src/wire/type/enumflags2.rs
+++ b/zbus/src/wire/type/enumflags2.rs
@@ -3,7 +3,30 @@ use crate::wire::{Signature, Type};
 // BitFlags
 impl<F> Type for enumflags2::BitFlags<F>
 where
-    F: Type + enumflags2::BitFlag,
+    F: enumflags2::BitFlag,
+    F::Numeric: Type,
 {
-    const SIGNATURE: &'static Signature = F::SIGNATURE;
+    const SIGNATURE: &'static Signature = F::Numeric::SIGNATURE;
+}
+
+#[cfg(test)]
+mod tests {
+    use enumflags2::{BitFlags, bitflags};
+
+    use super::*;
+
+    #[bitflags]
+    #[repr(u16)]
+    #[derive(Copy, Clone)]
+    enum Flags {
+        One = 1,
+    }
+
+    #[test]
+    fn signature_comes_from_numeric_type() {
+        fn assert_type<T: Type>() {}
+
+        assert_type::<BitFlags<Flags>>();
+        assert_eq!(BitFlags::<Flags>::SIGNATURE, u16::SIGNATURE);
+    }
 }

--- a/zbus/src/wire/type/libstd.rs
+++ b/zbus/src/wire/type/libstd.rs
@@ -1,4 +1,4 @@
-use crate::wire::{Signature, Type, impl_type_with_repr};
+use crate::wire::{Basic, Signature, Type, impl_type_with_repr};
 use std::{
     cell::{Cell, RefCell},
     cmp::Reverse,
@@ -187,7 +187,7 @@ macro_rules! map_impl {
     ($ty:ident < K $(: $kbound1:ident $(+ $kbound2:ident)*)*, V $(, $typaram:ident : $bound:ident)* >) => {
         impl<K, V $(, $typaram)*> Type for $ty<K, V $(, $typaram)*>
         where
-            K: Type $(+ $kbound1 $(+ $kbound2)*)*,
+            K: Basic $(+ $kbound1 $(+ $kbound2)*)*,
             V: Type,
             $($typaram: $bound,)*
         {
@@ -267,3 +267,61 @@ impl_type_with_repr! {
 // https://github.com/serde-rs/serde/issues/2685
 
 // TODO: Blanket implementation for more types: https://github.com/serde-rs/serde/blob/master/serde/src/ser/impls.rs
+
+#[cfg(test)]
+mod tests {
+    use static_assertions::{assert_impl_all, assert_not_impl_any};
+
+    use super::*;
+    use crate::wire::{Dict, OwnedValue, Value};
+
+    type BasicHashMap = HashMap<String, u8>;
+    type NonBasicHashMap = HashMap<Vec<u8>, u8>;
+    type BasicBTreeMap = BTreeMap<String, u8>;
+    type NonBasicBTreeMap = BTreeMap<Vec<u8>, u8>;
+    type PathHashMap = HashMap<std::path::PathBuf, u8>;
+    type EmptyArrayHashMap = HashMap<[u8; 0], u8>;
+    type OptionalHashMap = HashMap<crate::wire::Optional<u8>, u8>;
+
+    assert_impl_all!(
+        BasicHashMap: Type,
+        Into<Value<'static>>,
+        Into<OwnedValue>,
+        Into<Dict<'static, 'static>>
+    );
+    assert_impl_all!(
+        BasicBTreeMap: Type,
+        Into<Value<'static>>,
+        Into<OwnedValue>,
+        Into<Dict<'static, 'static>>
+    );
+    assert_not_impl_any!(
+        NonBasicHashMap: Type,
+        Into<Value<'static>>,
+        Into<OwnedValue>,
+        Into<Dict<'static, 'static>>
+    );
+    assert_not_impl_any!(
+        NonBasicBTreeMap: Type,
+        Into<Value<'static>>,
+        Into<OwnedValue>,
+        Into<Dict<'static, 'static>>
+    );
+    assert_impl_all!(PathHashMap: Type);
+    assert_impl_all!(EmptyArrayHashMap: Type);
+    assert_impl_all!(
+        OptionalHashMap: Type,
+        Into<Value<'static>>,
+        Into<OwnedValue>,
+        Into<Dict<'static, 'static>>
+    );
+
+    #[cfg(feature = "comms")]
+    assert_impl_all!(
+        HashMap<enumflags2::BitFlags<crate::fdo::RequestNameFlags>, u8>:
+            Type,
+            Into<Value<'static>>,
+            Into<OwnedValue>,
+            Into<Dict<'static, 'static>>
+    );
+}


### PR DESCRIPTION
Require dictionary keys to implement `Basic` for `HashMap` and `BTreeMap`
signatures and conversions. This restores the fix reverted for 5.x compatibility
now that zbus 6.0 provides the planned API-break boundary.

Implement `Basic` only for the existing scalar-representation adapters needed
to preserve valid dictionary keys. Make enumflags use its numeric wire
representation for both `Type` and `Basic`.

Add compile-time assertions covering valid and invalid keys across `Type`, `Dict`,
`Value`, and `OwnedValue`.

Closes #1637.

Generated by GPT-5.