### PR TITLE
🚸 zb,zm: Drop *Value requirements from properties

### DIFF
--- a/book/src/client.md
+++ b/book/src/client.md
@@ -376,16 +376,6 @@ Environment variables:
   ...
 ```
 
-#### Trait-bounds for property values
-
-If you use custom types for property values, you might get a compile error for missing
-`TryFrom<zbus::wire::Value<'_>>` and/or `TryFrom<OwnedValue>` implementations. This is because
-properties are always sent as Variants on the bus, so you need to implement these conversions for
-your custom types.
-
-Not to worry though, the `zbus::wire` module provides a [`Value`] and [`OwnedValue`] derive macro
-to implement these conversions for you.
-
 #### Watching for changes
 
 By default, the proxy will cache the properties and watch for changes.
@@ -616,7 +606,5 @@ There you have it, a Rust-friendly binding for your D-Bus service!
 [`pkg-config`]: https://www.freedesktop.org/wiki/Software/pkg-config/
 [cob]: blocking.html
 [`Stream`]: https://docs.rs/futures/4/futures/stream/trait.Stream.html
-[`Value`]: https://docs.rs/zbus/latest/zbus/wire/derive.Value.html
-[`OwnedValue`]: https://docs.rs/zbus/latest/zbus/wire/derive.OwnedValue.html
 
 [^busctl]: `busctl` is part of [`systemd`](https://systemd.io/).

--- a/book/src/service.md
+++ b/book/src/service.md
@@ -297,16 +297,6 @@ org.zbus.MyGreeter1                 interface -         -             -
 .GreetedEveryone                    signal    -         -             -
 ```
 
-### Trait-bounds for property values
-
-If you use custom types for property values, you might get a compile error for missing
-`TryFrom<zbus::wire::Value<'_>>` and/or `TryFrom<OwnedValue>` implementations. This is because
-properties are always sent as Variants on the bus, so you need to implement these conversions for
-your custom types.
-
-Not to worry though, the `zbus::wire` module provides a [`Value`] and [`OwnedValue`] derive macro
-to implement these conversions for you.
-
 ### Method errors
 
 There are two possibilities for the return value of interface methods. The first is for infallible
@@ -442,21 +432,17 @@ proxy.whatever().await?;
 While it's extremely useful to be able to generate the client-side proxy code directly from
 `interface` as it allows you to avoid duplicating code, there are some limitations to be aware of:
 
-* The trait bounds of the `proxy` macro methods' arguments and return value, now also apply to the
-  `interface` methods. For example, when only generating the service-side code, the method return
-  values need to implement `serde::Serialize` but when generating the client-side proxy code, the
-  method return values need to implement `serde::DeserializeOwned` as well.
-* Reference types in return values of `interface` methods won't work. As you may have noticed,
-  unlike the previous examples the `greeter_name` method in the example above returns a `String`
-  instead of a `&str`. This is because the methods in the `proxy` macro do not support reference
-  type to be returned from its methods.
+* The `proxy` macro's trait bounds also apply to ordinary `interface` methods. A service-only
+  method result needs `Serialize + Type`, while the corresponding generated proxy method also
+  needs `DeserializeOwned`.
+* Ordinary method return values cannot borrow. A borrowing property getter is supported: its
+  generated proxy getter is generic over an owned `DeserializeOwned + Type` result selected by the
+  caller.
 * Methods returning [`object_server::ResponseDispatchNotifier`] wrapper type will do the same for
   proxy as well.
 
 [D-Bus concepts]: concepts.html#bus-name--service-name
 [didoc]: https://docs.rs/zbus/latest/zbus/attr.interface.html
-[`Value`]: https://docs.rs/zbus/latest/zbus/wire/derive.Value.html
-[`OwnedValue`]: https://docs.rs/zbus/latest/zbus/wire/derive.OwnedValue.html
 [`zbus::DBusError`]:https://docs.rs/zbus/latest/zbus/trait.DBusError.html
 [`zbus::fdo::Error`]: https://docs.rs/zbus/latest/zbus/fdo/enum.Error.html
 [`zbus::fdo::Error::UnknownProperty`]: https://docs.rs/zbus/latest/zbus/fdo/enum.Error.html#variant.UnknownProperty

--- a/book/src/upgrading-to-6.md
+++ b/book/src/upgrading-to-6.md
@@ -296,8 +296,27 @@ The compatibility module is removed in zbus 7.0.
 
 ## Other changes in 6.0
 
-Five more things break in 6.0 without being a consequence of the crate merge. They reach code
+Six more things break in 6.0 without being a consequence of the crate merge. They reach code
 that never mentioned `zvariant` or `zbus_names`.
+
+### Property methods use Serde traits
+
+Property APIs now use the same Serde traits and `Type` bounds as regular methods. Client-side
+getters require `DeserializeOwned + Type` and setters require `Serialize + Type`; service-side
+getters require `Serialize + Type` and setters require `Deserialize + Type`. Replace custom
+`Value` and `OwnedValue` conversions with the appropriate Serde traits and `Type`.
+
+Property getters declared with `#[proxy]` must use owned result types. A proxy generated from an
+interface getter with a borrowing result is generic over its owned result type; select a
+`DeserializeOwned + Type` representation at the call site.
+
+Serde now also determines the property's wire representation. Audit `#[serde(...)]` attributes
+before upgrading because they were not used by the old `Value` conversions. In particular, an
+ordinary Serde derive serializes a unit enum as its variant index, not an explicit Rust
+discriminant. Use `serde_repr` for an integer enum whose discriminants are its D-Bus values.
+
+A property type mismatch now returns `Error::SignatureMismatch` rather than
+`Error::IncorrectType`. The new error includes both the actual and expected signatures.
 
 ### Stream constructors name their I/O backend
 
@@ -408,6 +427,10 @@ conversions if its `NoneType` has no `Into<Value>`.
 
 The order matters for any `T` whose conversion validates its input. The name types above reject
 the empty string, and the sentinel now maps to `None` without being converted at all.
+
+The public `NoneValue::NoneType` associated type for each owned name type is now `String` rather
+than `&'static str`. This allows `Optional<Owned*Name>` to implement `DeserializeOwned` without
+changing its wire encoding.
 
 ## A stale zvariant in the dependency graph
 

--- a/zbus/src/blocking/proxy/mod.rs
+++ b/zbus/src/blocking/proxy/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     names::{BusName, InterfaceName, MemberName, UniqueName},
     proxy::{Defaults, MethodFlags},
     utils::block_on,
-    wire::{ObjectPath, OwnedValue, Value},
+    wire::{ObjectPath, Value},
 };
 
 use crate::fdo;
@@ -168,8 +168,7 @@ impl<'a> Proxy<'a> {
     /// the peer.
     pub fn cached_property<T>(&self, property_name: &str) -> Result<Option<T>>
     where
-        T: TryFrom<OwnedValue>,
-        T::Error: Into<Error>,
+        T: serde::de::DeserializeOwned + crate::wire::Type,
     {
         self.inner().cached_property(property_name)
     }
@@ -191,8 +190,7 @@ impl<'a> Proxy<'a> {
     /// `org.freedesktop.DBus.Properties` interface.
     pub fn get_property<T>(&self, property_name: &str) -> Result<T>
     where
-        T: TryFrom<OwnedValue>,
-        T::Error: Into<Error>,
+        T: serde::de::DeserializeOwned + crate::wire::Type,
     {
         block_on(self.inner().get_property(property_name))
     }
@@ -200,9 +198,9 @@ impl<'a> Proxy<'a> {
     /// Set the property `property_name`.
     ///
     /// Effectively, call the `Set` method of the `org.freedesktop.DBus.Properties` interface.
-    pub fn set_property<'t, T>(&self, property_name: &str, value: T) -> fdo::Result<()>
+    pub fn set_property<T>(&self, property_name: &str, value: T) -> fdo::Result<()>
     where
-        T: 't + Into<Value<'t>>,
+        T: serde::Serialize + crate::wire::Type,
     {
         block_on(self.inner().set_property(property_name, value))
     }
@@ -461,8 +459,7 @@ impl<T> PropertyChanged<'_, T> {
 
 impl<T> PropertyChanged<'_, T>
 where
-    T: TryFrom<crate::wire::OwnedValue>,
-    T::Error: Into<crate::Error>,
+    T: serde::de::DeserializeOwned + crate::wire::Type,
 {
     /// Get the value of the property that changed.
     ///

--- a/zbus/src/names/bus_name.rs
+++ b/zbus/src/names/bus_name.rs
@@ -533,9 +533,9 @@ impl PartialEq<BusName<'_>> for OwnedBusName {
 }
 
 impl NoneValue for OwnedBusName {
-    type NoneType = <BusName<'static> as NoneValue>::NoneType;
+    type NoneType = String;
 
     fn null_value() -> Self::NoneType {
-        BusName::null_value()
+        String::new()
     }
 }

--- a/zbus/src/names/unique_name.rs
+++ b/zbus/src/names/unique_name.rs
@@ -73,7 +73,7 @@ mod tests {
     fn optional_owned_value_conversion_maps_empty_name_to_none() {
         use crate::wire::Optional;
 
-        // The path proxy property getters take: `TryFrom<OwnedValue>` on an owned type.
+        // The sentinel must be recognized before the empty name is validated.
         let owned = OwnedValue::from(crate::wire::Str::from(""));
         let opt = Optional::<OwnedUniqueName>::try_from(owned).unwrap();
         assert!(Option::<OwnedUniqueName>::from(opt).is_none());

--- a/zbus/src/names/unique_name.rs
+++ b/zbus/src/names/unique_name.rs
@@ -110,6 +110,30 @@ mod tests {
     }
 
     #[test]
+    fn optional_owned_name_is_deserialize_owned() {
+        use crate::{
+            names::OwnedBusName,
+            wire::{LE, Optional, serialized::Context, to_bytes},
+        };
+        use serde::de::DeserializeOwned;
+
+        fn assert_deserialize_owned<T: DeserializeOwned>() {}
+
+        assert_deserialize_owned::<Optional<OwnedUniqueName>>();
+        assert_deserialize_owned::<Optional<OwnedBusName>>();
+
+        let ctxt = Context::new(LE, 0);
+        let encoded = to_bytes(ctxt, &Optional::<OwnedUniqueName>::default()).unwrap();
+        let opt: Optional<OwnedUniqueName> = encoded.deserialize().unwrap().0;
+        assert!(Option::<OwnedUniqueName>::from(opt).is_none());
+
+        let name = OwnedUniqueName::try_from(":1.42").unwrap();
+        let encoded = to_bytes(ctxt, &Optional::from(Some(name.clone()))).unwrap();
+        let opt: Optional<OwnedUniqueName> = encoded.deserialize().unwrap().0;
+        assert_eq!(Option::<OwnedUniqueName>::from(opt), Some(name));
+    }
+
+    #[test]
     fn value_conversion_round_trips_valid_name() {
         let name = UniqueName::try_from(":1.23").unwrap();
         let value = Value::from(name.clone());

--- a/zbus/src/names/utils.rs
+++ b/zbus/src/names/utils.rs
@@ -398,10 +398,10 @@ macro_rules! define_name_type_impls {
         }
 
         impl crate::wire::NoneValue for $owned_name {
-            type NoneType = <$name<'static> as crate::wire::NoneValue>::NoneType;
+            type NoneType = String;
 
             fn null_value() -> Self::NoneType {
-                $name::null_value()
+                String::new()
             }
         }
 

--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     fdo::{self, IntrospectableProxy, NameOwnerChanged, PropertiesChangedStream, PropertiesProxy},
     message::{Flags, Message, Sequence, Type},
     names::{BusName, InterfaceName, MemberName, UniqueName},
-    wire::{ObjectPath, OwnedValue, Str, Value},
+    wire::{ObjectPath, OwnedValue, Str, Value, as_value},
 };
 
 mod builder;
@@ -189,8 +189,7 @@ impl<T> PropertyChanged<'_, T> {
 
 impl<T> PropertyChanged<'_, T>
 where
-    T: TryFrom<crate::wire::OwnedValue>,
-    T::Error: Into<crate::Error>,
+    T: serde::de::DeserializeOwned + crate::wire::Type,
 {
     /// Get the value of the property that changed.
     ///
@@ -200,7 +199,7 @@ where
     pub async fn get(&self) -> Result<T> {
         self.get_raw()
             .await
-            .and_then(|v| T::try_from(OwnedValue::try_from(&*v)?).map_err(Into::into))
+            .and_then(|value| convert_property_value(&value))
     }
 }
 
@@ -712,12 +711,11 @@ impl<'a> Proxy<'a> {
     /// the peer.
     pub fn cached_property<T>(&self, property_name: &str) -> Result<Option<T>>
     where
-        T: TryFrom<OwnedValue>,
-        T::Error: Into<Error>,
+        T: serde::de::DeserializeOwned + crate::wire::Type,
     {
         self.cached_property_raw(property_name)
             .as_deref()
-            .map(|v| T::try_from(OwnedValue::try_from(v)?).map_err(Into::into))
+            .map(convert_property_value)
             .transpose()
     }
 
@@ -781,8 +779,7 @@ impl<'a> Proxy<'a> {
     /// `Get` method of the `org.freedesktop.DBus.Properties` interface.
     pub async fn get_property<T>(&self, property_name: &str) -> Result<T>
     where
-        T: TryFrom<OwnedValue>,
-        T::Error: Into<Error>,
+        T: serde::de::DeserializeOwned + crate::wire::Type,
     {
         if let Some(cache) = self.get_property_cache() {
             cache.ready().await?;
@@ -792,19 +789,29 @@ impl<'a> Proxy<'a> {
         }
 
         let value = self.get_proxy_property(property_name).await?;
-        value.try_into().map_err(Into::into)
+        convert_property_value(&value)
     }
 
     /// Set the property `property_name`.
     ///
     /// Effectively, call the `Set` method of the `org.freedesktop.DBus.Properties` interface.
-    pub async fn set_property<'t, T>(&self, property_name: &str, value: T) -> fdo::Result<()>
+    pub async fn set_property<T>(&self, property_name: &str, value: T) -> fdo::Result<()>
     where
-        T: 't + Into<Value<'t>>,
+        T: serde::Serialize + crate::wire::Type,
     {
         self.properties_proxy()
-            .set(self.inner.interface.as_ref(), property_name, &value.into())
-            .await
+            .inner()
+            .call::<_, _, ()>(
+                "Set",
+                &crate::wire::DynamicTuple((
+                    self.inner.interface.as_ref(),
+                    property_name,
+                    as_value::Serialize(&value),
+                )),
+            )
+            .await?;
+
+        Ok(())
     }
 
     /// Call a method and return the reply.
@@ -1360,6 +1367,13 @@ where
 
     /// The reference to the underlying `zbus::Proxy`.
     fn inner(&self) -> &Proxy<'c>;
+}
+
+fn convert_property_value<T>(value: &Value<'_>) -> Result<T>
+where
+    T: serde::de::DeserializeOwned + crate::wire::Type,
+{
+    as_value::deserialize_for_property(value)
 }
 
 enum Either<L, R> {

--- a/zbus/src/wire/as_value/mod.rs
+++ b/zbus/src/wire/as_value/mod.rs
@@ -10,6 +10,10 @@ mod deserialize;
 pub use deserialize::{Deserialize, deserialize};
 mod serialize;
 pub use serialize::{Serialize, serialize};
+mod property;
+pub use property::deserialize_for_property;
+mod value_serializer;
+pub use value_serializer::to_owned_value;
 
 /// Utilities to (de)serialize an optional value as a [`enum@zbus::wire::Value`].
 pub mod optional {

--- a/zbus/src/wire/as_value/property.rs
+++ b/zbus/src/wire/as_value/property.rs
@@ -856,3 +856,319 @@ fn signatures_compatible(actual: &Signature, expected: &Signature, unwrap_varian
         _ => false,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use serde::Deserialize;
+
+    use super::*;
+    use crate::wire::{Array, OwnedValue, StructureBuilder, Type};
+
+    fn convert_property_value<T>(value: &Value<'_>) -> T
+    where
+        T: for<'de> Deserialize<'de> + Type,
+    {
+        deserialize_for_property(value).unwrap()
+    }
+
+    #[test]
+    fn unwraps_array_variants() {
+        let mut array = Array::new(&Signature::Variant);
+        array
+            .append(Value::Value(Box::new(Value::from("one"))))
+            .unwrap();
+        array
+            .append(Value::Value(Box::new(Value::from("two"))))
+            .unwrap();
+
+        assert_eq!(
+            convert_property_value::<Vec<String>>(&Value::Array(array)),
+            ["one", "two"]
+        );
+    }
+
+    #[test]
+    fn unwraps_variants_in_nested_containers() {
+        let mut inner = Array::new(&Signature::Variant);
+        inner
+            .append(Value::Value(Box::new(Value::from("value"))))
+            .unwrap();
+        let mut outer = Array::new(inner.signature());
+        outer.append(Value::Array(inner)).unwrap();
+        let structure = StructureBuilder::new()
+            .append_field(Value::Array(outer))
+            .build()
+            .unwrap();
+        let decoded: (Vec<Vec<String>>,) = convert_property_value(&Value::Structure(structure));
+
+        assert_eq!(decoded.0, [vec!["value".to_string()]]);
+    }
+
+    #[test]
+    fn unwraps_dict_variants() {
+        let mut dict = Dict::new(&Signature::Str, &Signature::Variant);
+        dict.append(
+            Value::from("key"),
+            Value::Value(Box::new(Value::from("value"))),
+        )
+        .unwrap();
+
+        assert_eq!(
+            convert_property_value::<HashMap<String, String>>(&Value::Dict(dict))["key"],
+            "value"
+        );
+    }
+
+    #[test]
+    fn unwraps_variants_in_nested_dicts() {
+        let mut properties = Dict::new(&Signature::Str, &Signature::Variant);
+        properties
+            .append(
+                Value::from("ssid"),
+                Value::Value(Box::new(Value::from("home"))),
+            )
+            .unwrap();
+        let mut interfaces = Dict::new(&Signature::Str, properties.signature());
+        interfaces
+            .append(Value::from("802-11-wireless"), Value::Dict(properties))
+            .unwrap();
+
+        let decoded: HashMap<String, HashMap<String, String>> =
+            convert_property_value(&Value::Dict(interfaces));
+        assert_eq!(decoded["802-11-wireless"]["ssid"], "home");
+    }
+
+    #[test]
+    fn rejects_unrelated_empty_containers() {
+        let array = Value::Array(Array::new(&Signature::I32));
+        assert!(deserialize_for_property::<Vec<String>>(&array).is_err());
+
+        let dict = Value::Dict(Dict::new(&Signature::I32, &Signature::Str));
+        assert!(deserialize_for_property::<HashMap<String, String>>(&dict).is_err());
+    }
+
+    #[test]
+    fn preserves_variant_values() {
+        let value = Value::U32(42);
+        let decoded: Value<'_> = deserialize_for_property(&value).unwrap();
+        assert_eq!(decoded, Value::U32(42));
+
+        let decoded = convert_property_value::<OwnedValue>(&value);
+        assert_eq!(decoded, OwnedValue::from(42_u32));
+
+        let value = Value::Value(Box::new(Value::U32(42)));
+        let decoded = convert_property_value::<OwnedValue>(&value);
+        assert_eq!(decoded, OwnedValue::try_from(value).unwrap());
+    }
+
+    #[test]
+    fn unwraps_variant_structure_and_enum_fields() {
+        #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize, crate::wire::Type)]
+        struct WithValue(u32, OwnedValue);
+
+        #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize, crate::wire::Type)]
+        enum NewType {
+            First(OwnedValue),
+            Second(OwnedValue),
+        }
+
+        #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize, crate::wire::Type)]
+        enum Fields {
+            First(u8, OwnedValue),
+            Second { y: u8, value: OwnedValue },
+        }
+
+        let value = WithValue(7, OwnedValue::from(42_u32));
+        let serialized = Value::from(super::super::to_owned_value(&value).unwrap());
+        assert_eq!(convert_property_value::<WithValue>(&serialized), value);
+
+        let value = NewType::Second(OwnedValue::from(42_u32));
+        let serialized = Value::from(super::super::to_owned_value(&value).unwrap());
+        assert_eq!(convert_property_value::<NewType>(&serialized), value);
+
+        let value = Fields::Second {
+            y: 7,
+            value: OwnedValue::from(42_u32),
+        };
+        let serialized = Value::from(super::super::to_owned_value(&value).unwrap());
+        assert_eq!(convert_property_value::<Fields>(&serialized), value);
+    }
+
+    #[test]
+    fn borrows_strings_from_values() {
+        let value = Value::from("borrowed");
+        let decoded: &str = deserialize_for_property(&value).unwrap();
+        assert_eq!(decoded, "borrowed");
+    }
+
+    #[test]
+    fn deserializes_signatures() {
+        let value = Value::Signature(Signature::try_from("a{sv}").unwrap());
+        assert_eq!(
+            deserialize_for_property::<Signature>(&value).unwrap(),
+            Signature::try_from("a{sv}").unwrap()
+        );
+    }
+
+    #[test]
+    fn deserializes_repr_enums() {
+        #[repr(u32)]
+        #[derive(Debug, PartialEq, crate::wire::Type, serde_repr::Deserialize_repr)]
+        enum Kind {
+            First = 1,
+            Second = 2,
+        }
+
+        let value = Value::U32(2);
+        assert_eq!(
+            deserialize_for_property::<Kind>(&value).unwrap(),
+            Kind::Second
+        );
+    }
+
+    #[test]
+    fn deserializes_wire_enum_representations() {
+        #[derive(Debug, PartialEq, crate::wire::Type, serde::Deserialize)]
+        enum Unit {
+            First,
+            Second,
+        }
+
+        let value = Value::U32(1);
+        assert_eq!(
+            deserialize_for_property::<Unit>(&value).unwrap(),
+            Unit::Second
+        );
+
+        #[derive(Debug, PartialEq, crate::wire::Type, serde::Deserialize)]
+        #[zvariant(signature = "s")]
+        #[serde(rename_all = "snake_case")]
+        enum StringUnit {
+            First,
+            Second,
+        }
+
+        let value = Value::from("second");
+        assert_eq!(
+            deserialize_for_property::<StringUnit>(&value).unwrap(),
+            StringUnit::Second
+        );
+
+        #[derive(Debug, PartialEq, crate::wire::Type, serde::Deserialize)]
+        enum NewType {
+            First(f64),
+            Second(f64),
+        }
+
+        let value = StructureBuilder::new()
+            .append_field(Value::U32(1))
+            .append_field(Value::F64(2.5))
+            .build()
+            .unwrap();
+        assert_eq!(
+            deserialize_for_property::<NewType>(&Value::Structure(value)).unwrap(),
+            NewType::Second(2.5)
+        );
+
+        #[derive(Debug, PartialEq, crate::wire::Type, serde::Deserialize)]
+        enum Fields {
+            First(u8, u32),
+            Second { y: u8, t: u32 },
+        }
+
+        let payload = StructureBuilder::new()
+            .append_field(Value::U8(3))
+            .append_field(Value::U32(4))
+            .build()
+            .unwrap();
+        let value = StructureBuilder::new()
+            .append_field(Value::U32(1))
+            .append_field(Value::Structure(payload))
+            .build()
+            .unwrap();
+        assert_eq!(
+            deserialize_for_property::<Fields>(&Value::Structure(value)).unwrap(),
+            Fields::Second { y: 3, t: 4 }
+        );
+    }
+
+    #[test]
+    fn deserializes_value_containers_and_dict_structs() {
+        #[derive(Debug, PartialEq, crate::wire::DeserializeDict, crate::wire::Type)]
+        #[zvariant(signature = "dict")]
+        struct DictStruct {
+            count: u32,
+            name: String,
+        }
+
+        let mut dict = Dict::new(&Signature::Str, &Signature::Variant);
+        dict.append(Value::from("count"), Value::new(Value::from(7_u32)))
+            .unwrap();
+        dict.append(Value::from("name"), Value::new(Value::from("dict")))
+            .unwrap();
+        assert_eq!(
+            deserialize_for_property::<DictStruct>(&Value::Dict(dict)).unwrap(),
+            DictStruct {
+                count: 7,
+                name: "dict".to_owned(),
+            }
+        );
+
+        let mut array = Array::new(&Signature::Variant);
+        array.append(Value::new(Value::from("first"))).unwrap();
+        array.append(Value::new(Value::from(42_u32))).unwrap();
+        assert_eq!(
+            deserialize_for_property::<Vec<Value<'_>>>(&Value::Array(array)).unwrap(),
+            [Value::from("first"), Value::from(42_u32)],
+        );
+    }
+
+    #[test]
+    fn deserializes_empty_structs() {
+        #[derive(serde::Deserialize, crate::wire::Type)]
+        struct Empty {}
+
+        deserialize_for_property::<Empty>(&Value::U8(0)).unwrap();
+    }
+
+    #[cfg(feature = "serde_bytes")]
+    #[test]
+    fn deserializes_variant_wrapped_bytes() {
+        let mut values = Array::new(&Signature::Variant);
+        for byte in [1_u8, 2, 3] {
+            values
+                .append(Value::Value(Box::new(Value::from(byte))))
+                .unwrap();
+        }
+
+        assert_eq!(
+            deserialize_for_property::<serde_bytes::ByteBuf>(&Value::Array(values)).unwrap(),
+            serde_bytes::ByteBuf::from(vec![1, 2, 3]),
+        );
+    }
+
+    #[cfg(feature = "option-as-array")]
+    #[test]
+    fn deserializes_option_arrays() {
+        let some = Value::Array(Array::from(vec![42_i32]));
+        let none = Value::Array(Array::new(&Signature::I32));
+        let mut variants = Array::new(&Signature::Variant);
+        variants
+            .append(Value::Value(Box::new(Value::from(42_i32))))
+            .unwrap();
+        assert_eq!(
+            deserialize_for_property::<Option<i32>>(&some).unwrap(),
+            Some(42)
+        );
+        assert_eq!(
+            deserialize_for_property::<Option<i32>>(&none).unwrap(),
+            None
+        );
+        assert_eq!(
+            deserialize_for_property::<Option<i32>>(&Value::Array(variants)).unwrap(),
+            Some(42)
+        );
+    }
+}

--- a/zbus/src/wire/as_value/property.rs
+++ b/zbus/src/wire/as_value/property.rs
@@ -1,0 +1,858 @@
+use serde::de::{self, DeserializeSeed, EnumAccess, MapAccess, SeqAccess, VariantAccess, Visitor};
+
+use crate::wire::{Dict, Signature, Type, Value};
+
+/// Deserializes a property value directly from its in-memory representation.
+#[doc(hidden)]
+pub fn deserialize_for_property<'de, T>(value: &'de Value<'_>) -> crate::Result<T>
+where
+    T: Type + serde::Deserialize<'de>,
+{
+    T::deserialize(ValueDeserializer::new(value, T::SIGNATURE, false))
+}
+
+struct ValueDeserializer<'de, 'sig> {
+    value: &'de Value<'de>,
+    expected: &'sig Signature,
+    unwrap_variant: bool,
+    variant_payload: bool,
+}
+
+impl<'de, 'sig> ValueDeserializer<'de, 'sig> {
+    fn new(value: &'de Value<'de>, expected: &'sig Signature, unwrap_variant: bool) -> Self {
+        Self {
+            value,
+            expected,
+            unwrap_variant,
+            variant_payload: false,
+        }
+    }
+
+    fn actual(&self) -> &'de Value<'de> {
+        if self.unwrap_variant && self.expected != &Signature::Variant {
+            if let Value::Value(value) = self.value {
+                return value;
+            }
+        }
+
+        self.value
+    }
+
+    fn check(&self) -> crate::Result<&'de Value<'de>> {
+        let value = self.actual();
+        if self.expected == &Signature::Variant
+            || signatures_compatible(value.value_signature(), self.expected, self.unwrap_variant)
+        {
+            Ok(value)
+        } else {
+            Err(crate::Error::SignatureMismatch(
+                value.value_signature().clone(),
+                self.expected.to_string(),
+            ))
+        }
+    }
+
+    fn variant_access(&self) -> VariantSeqAccess<'de> {
+        if self.unwrap_variant || self.variant_payload {
+            VariantSeqAccess::new_existing(self.actual())
+        } else {
+            VariantSeqAccess::new(self.actual())
+        }
+    }
+
+    #[cfg(feature = "option-as-array")]
+    fn child(
+        &self,
+        value: &'de Value<'de>,
+        expected: &'sig Signature,
+        unwrap_variant: bool,
+    ) -> Self {
+        Self::new(value, expected, unwrap_variant)
+    }
+
+    fn mismatch(&self, expected: &'static str) -> crate::Error {
+        crate::Error::SignatureMismatch(
+            self.actual().value_signature().clone(),
+            expected.to_owned(),
+        )
+    }
+
+    fn bytes(&self) -> crate::Result<Vec<u8>> {
+        let expected = self.expected_array_element()?;
+        if expected != &Signature::U8 {
+            return Err(self.mismatch("an array of bytes"));
+        }
+
+        let Value::Array(array) = self.check()? else {
+            return Err(self.mismatch("an array of bytes"));
+        };
+        array
+            .inner()
+            .iter()
+            .map(|value| match Self::new(value, expected, true).check()? {
+                Value::U8(value) => Ok(*value),
+                _ => Err(self.mismatch("an array of bytes")),
+            })
+            .collect()
+    }
+
+    fn expected_array_element(&self) -> crate::Result<&'sig Signature> {
+        match self.expected {
+            Signature::Array(element) => Ok(element.signature()),
+            _ => Err(self.mismatch("an array")),
+        }
+    }
+}
+
+impl<'de, 'sig> de::Deserializer<'de> for ValueDeserializer<'de, 'sig> {
+    type Error = crate::Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if self.expected == &Signature::Variant {
+            return visitor.visit_seq(self.variant_access());
+        }
+
+        match self.check()? {
+            Value::U8(value) => visitor.visit_u8(*value),
+            Value::Bool(value) => visitor.visit_bool(*value),
+            Value::I16(value) => visitor.visit_i16(*value),
+            Value::U16(value) => visitor.visit_u16(*value),
+            Value::I32(value) => visitor.visit_i32(*value),
+            Value::U32(value) => visitor.visit_u32(*value),
+            Value::I64(value) => visitor.visit_i64(*value),
+            Value::U64(value) => visitor.visit_u64(*value),
+            Value::F64(value) => visitor.visit_f64(*value),
+            Value::Str(value) => visitor.visit_borrowed_str(value.as_str()),
+            Value::Signature(value) => visitor.visit_string(value.to_string()),
+            Value::ObjectPath(value) => visitor.visit_borrowed_str(value.as_str()),
+            Value::Array(array) => {
+                visitor.visit_seq(ArrayAccess::new(array.inner(), self.expected))
+            }
+            Value::Dict(dict) => visitor.visit_map(DictAccess::new(dict, self.expected)),
+            Value::Structure(structure) => {
+                visitor.visit_seq(StructureAccess::new(structure.fields(), self.expected))
+            }
+            #[cfg(unix)]
+            Value::Fd(fd) => visitor.visit_i32(std::os::fd::AsRawFd::as_raw_fd(fd)),
+            Value::Value(_) => unreachable!("variants are handled above"),
+        }
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.check()? {
+            Value::Bool(value) => visitor.visit_bool(*value),
+            _ => Err(self.mismatch("a boolean")),
+        }
+    }
+
+    fn deserialize_i8<V>(self, visitor: V) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_i16(visitor)
+    }
+
+    fn deserialize_i16<V>(self, visitor: V) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.check()? {
+            Value::I16(value) => visitor.visit_i16(*value),
+            _ => Err(self.mismatch("an int16")),
+        }
+    }
+
+    fn deserialize_i32<V>(self, visitor: V) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.check()? {
+            Value::I32(value) => visitor.visit_i32(*value),
+            #[cfg(unix)]
+            Value::Fd(value) => visitor.visit_i32(std::os::fd::AsRawFd::as_raw_fd(value)),
+            _ => Err(self.mismatch("an int32")),
+        }
+    }
+
+    fn deserialize_i64<V>(self, visitor: V) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.check()? {
+            Value::I64(value) => visitor.visit_i64(*value),
+            _ => Err(self.mismatch("an int64")),
+        }
+    }
+
+    fn deserialize_u8<V>(self, visitor: V) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.check()? {
+            Value::U8(value) => visitor.visit_u8(*value),
+            _ => Err(self.mismatch("a byte")),
+        }
+    }
+
+    fn deserialize_u16<V>(self, visitor: V) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.check()? {
+            Value::U16(value) => visitor.visit_u16(*value),
+            _ => Err(self.mismatch("a uint16")),
+        }
+    }
+
+    fn deserialize_u32<V>(self, visitor: V) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.check()? {
+            Value::U32(value) => visitor.visit_u32(*value),
+            _ => Err(self.mismatch("a uint32")),
+        }
+    }
+
+    fn deserialize_u64<V>(self, visitor: V) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.check()? {
+            Value::U64(value) => visitor.visit_u64(*value),
+            _ => Err(self.mismatch("a uint64")),
+        }
+    }
+
+    fn deserialize_f32<V>(self, visitor: V) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.check()? {
+            Value::F64(value) => {
+                if value.is_finite() && *value > f32::MAX as f64 {
+                    return Err(de::Error::invalid_value(
+                        de::Unexpected::Float(*value),
+                        &"Too large for f32",
+                    ));
+                }
+                visitor.visit_f32(*value as f32)
+            }
+            _ => Err(self.mismatch("a float")),
+        }
+    }
+
+    fn deserialize_f64<V>(self, visitor: V) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.check()? {
+            Value::F64(value) => visitor.visit_f64(*value),
+            _ => Err(self.mismatch("a double")),
+        }
+    }
+
+    fn deserialize_char<V>(self, visitor: V) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.check()? {
+            Value::Str(value) => visitor.visit_borrowed_str(value.as_str()),
+            Value::Signature(value) => visitor.visit_string(value.to_string()),
+            Value::ObjectPath(value) => visitor.visit_borrowed_str(value.as_str()),
+            _ => Err(self.mismatch("a string")),
+        }
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_bytes<V>(self, visitor: V) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        let bytes = self.bytes()?;
+        visitor.visit_byte_buf(bytes)
+    }
+
+    fn deserialize_byte_buf<V>(self, visitor: V) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_bytes(visitor)
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        #[cfg(feature = "option-as-array")]
+        {
+            let value = self.check()?;
+            let array = match value {
+                Value::Array(array) => array,
+                _ => return Err(self.mismatch("an option array")),
+            };
+            let element_signature = self.expected_array_element()?;
+            match array.inner() {
+                [] => visitor.visit_none(),
+                [value] => visitor.visit_some(self.child(value, element_signature, true)),
+                _ => Err(de::Error::invalid_length(
+                    array.len(),
+                    &"an option array of 0 or 1 item",
+                )),
+            }
+        }
+        #[cfg(not(feature = "option-as-array"))]
+        {
+            let _ = visitor;
+            Err(de::Error::custom(
+                "Can only decode Option<T> from a Value if the `option-as-array` feature is \
+                 enabled",
+            ))
+        }
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.check()?;
+        visitor.visit_unit()
+    }
+
+    fn deserialize_unit_struct<V>(self, _name: &'static str, visitor: V) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_unit(visitor)
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.check()?;
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if self.expected == &Signature::Variant {
+            return visitor.visit_seq(self.variant_access());
+        }
+        match self.check()? {
+            Value::Array(array) => {
+                visitor.visit_seq(ArrayAccess::new(array.inner(), self.expected))
+            }
+            Value::Structure(structure) => {
+                visitor.visit_seq(StructureAccess::new(structure.fields(), self.expected))
+            }
+            Value::U8(_) if self.expected == &Signature::U8 => visitor.visit_seq(EmptyAccess),
+            _ => Err(self.mismatch("an array or structure")),
+        }
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.check()? {
+            Value::Dict(dict) => visitor.visit_map(DictAccess::new(dict, self.expected)),
+            _ => Err(self.mismatch("a dictionary")),
+        }
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        if matches!(self.expected, Signature::Dict { .. }) {
+            self.deserialize_map(visitor)
+        } else {
+            self.deserialize_seq(visitor)
+        }
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        let value = self.check()?;
+        let access = match value {
+            Value::Structure(structure) => {
+                ValueEnumAccess::structure(structure.fields(), self.expected)?
+            }
+            _ => ValueEnumAccess::scalar(value, self.expected),
+        };
+        let _ = name;
+        visitor.visit_enum(access)
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_any(visitor)
+    }
+
+    fn deserialize_ignored_any<V>(self, visitor: V) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_any(visitor)
+    }
+
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+}
+
+struct ArrayAccess<'de> {
+    elements: &'de [Value<'de>],
+    index: usize,
+    expected: Signature,
+}
+
+impl<'de> ArrayAccess<'de> {
+    fn new(elements: &'de [Value<'de>], expected: &Signature) -> Self {
+        let expected = match expected {
+            Signature::Array(element) => element.signature().clone(),
+            _ => expected.clone(),
+        };
+        Self {
+            elements,
+            index: 0,
+            expected,
+        }
+    }
+}
+
+impl<'de> SeqAccess<'de> for ArrayAccess<'de> {
+    type Error = crate::Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> crate::Result<Option<T::Value>>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        let Some(value) = self.elements.get(self.index) else {
+            return Ok(None);
+        };
+        self.index += 1;
+        seed.deserialize(ValueDeserializer::new(value, &self.expected, true))
+            .map(Some)
+    }
+}
+
+struct DictAccess<'de> {
+    entries: Box<dyn Iterator<Item = (&'de Value<'de>, &'de Value<'de>)> + 'de>,
+    key: Signature,
+    value: Signature,
+    pending_value: Option<&'de Value<'de>>,
+}
+
+impl<'de> DictAccess<'de> {
+    fn new(dict: &'de Dict<'de, 'de>, expected: &Signature) -> Self {
+        let (key, value) = match expected {
+            Signature::Dict { key, value } => (key.signature().clone(), value.signature().clone()),
+            _ => (Signature::Variant, Signature::Variant),
+        };
+        Self {
+            entries: Box::new(dict.iter()),
+            key,
+            value,
+            pending_value: None,
+        }
+    }
+}
+
+impl<'de> MapAccess<'de> for DictAccess<'de> {
+    type Error = crate::Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> crate::Result<Option<K::Value>>
+    where
+        K: DeserializeSeed<'de>,
+    {
+        let Some((key, value)) = self.entries.next() else {
+            return Ok(None);
+        };
+        self.pending_value = Some(value);
+        seed.deserialize(ValueDeserializer::new(key, &self.key, false))
+            .map(Some)
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> crate::Result<V::Value>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let value = self.pending_value.take().ok_or_else(|| {
+            crate::Error::Failure("map value requested before map key".to_owned())
+        })?;
+        seed.deserialize(ValueDeserializer::new(value, &self.value, true))
+    }
+}
+
+struct StructureAccess<'de> {
+    fields: &'de [Value<'de>],
+    signatures: Vec<Signature>,
+    index: usize,
+}
+
+impl<'de> StructureAccess<'de> {
+    fn new(fields: &'de [Value<'de>], expected: &Signature) -> Self {
+        let signatures = match expected {
+            Signature::Structure(signatures) => signatures.iter().cloned().collect(),
+            _ => vec![],
+        };
+        Self {
+            fields,
+            signatures,
+            index: 0,
+        }
+    }
+}
+
+impl<'de> SeqAccess<'de> for StructureAccess<'de> {
+    type Error = crate::Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> crate::Result<Option<T::Value>>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        let Some(value) = self.fields.get(self.index) else {
+            return Ok(None);
+        };
+        let Some(signature) = self.signatures.get(self.index) else {
+            return Err(de::Error::invalid_length(self.fields.len(), &"a structure"));
+        };
+        self.index += 1;
+        seed.deserialize(ValueDeserializer::new(value, signature, true))
+            .map(Some)
+    }
+}
+
+struct EmptyAccess;
+
+impl<'de> SeqAccess<'de> for EmptyAccess {
+    type Error = crate::Error;
+
+    fn next_element_seed<T>(&mut self, _seed: T) -> crate::Result<Option<T::Value>>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        Ok(None)
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(0)
+    }
+}
+
+struct VariantSeqAccess<'de> {
+    signature: Signature,
+    value: &'de Value<'de>,
+    index: usize,
+}
+
+impl<'de> VariantSeqAccess<'de> {
+    fn new(value: &'de Value<'de>) -> Self {
+        let signature = value.value_signature().clone();
+        Self {
+            signature,
+            value,
+            index: 0,
+        }
+    }
+
+    fn new_existing(value: &'de Value<'de>) -> Self {
+        match value {
+            Value::Value(value) => Self::new(value),
+            value => Self::new(value),
+        }
+    }
+}
+
+impl<'de> SeqAccess<'de> for VariantSeqAccess<'de> {
+    type Error = crate::Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> crate::Result<Option<T::Value>>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        match self.index {
+            0 => {
+                self.index = 1;
+                seed.deserialize(serde::de::value::StringDeserializer::<crate::Error>::new(
+                    self.signature.to_string(),
+                ))
+                .map(Some)
+            }
+            1 => {
+                self.index = 2;
+                let mut de = ValueDeserializer::new(self.value, &self.signature, false);
+                de.variant_payload = self.signature == Signature::Variant;
+                seed.deserialize(de).map(Some)
+            }
+            _ => Ok(None),
+        }
+    }
+}
+
+struct ValueEnumAccess<'de> {
+    discriminant: &'de Value<'de>,
+    discriminant_signature: Signature,
+    payload: Option<&'de Value<'de>>,
+    payload_signature: Option<Signature>,
+}
+
+impl<'de> ValueEnumAccess<'de> {
+    fn scalar(value: &'de Value<'de>, expected: &Signature) -> Self {
+        Self {
+            discriminant: value,
+            discriminant_signature: expected.clone(),
+            payload: None,
+            payload_signature: None,
+        }
+    }
+
+    fn structure(value: &'de [Value<'de>], expected: &Signature) -> crate::Result<Self> {
+        let Signature::Structure(signatures) = expected else {
+            return Err(crate::Error::SignatureMismatch(
+                expected.clone(),
+                "an enum structure".to_owned(),
+            ));
+        };
+        let Some(discriminant) = value.first() else {
+            return Err(de::Error::invalid_length(0, &"an enum discriminant"));
+        };
+        let mut signatures = signatures.iter();
+        let Some(discriminant_signature) = signatures.next() else {
+            return Err(de::Error::invalid_length(0, &"an enum discriminant"));
+        };
+        let payload = value.get(1);
+        let payload_signature = signatures.next();
+        if payload.is_some() != payload_signature.is_some() {
+            return Err(de::Error::invalid_length(value.len(), &"an enum payload"));
+        }
+        Ok(Self {
+            discriminant,
+            discriminant_signature: discriminant_signature.clone(),
+            payload,
+            payload_signature: payload_signature.cloned(),
+        })
+    }
+}
+
+impl<'de> EnumAccess<'de> for ValueEnumAccess<'de> {
+    type Error = crate::Error;
+    type Variant = ValueVariantAccess<'de>;
+
+    fn variant_seed<V>(self, seed: V) -> crate::Result<(V::Value, Self::Variant)>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let variant = seed.deserialize(ValueDeserializer::new(
+            self.discriminant,
+            &self.discriminant_signature,
+            false,
+        ))?;
+        Ok((
+            variant,
+            ValueVariantAccess {
+                payload: self.payload,
+                payload_signature: self.payload_signature,
+            },
+        ))
+    }
+}
+
+struct ValueVariantAccess<'de> {
+    payload: Option<&'de Value<'de>>,
+    payload_signature: Option<Signature>,
+}
+
+impl<'de> VariantAccess<'de> for ValueVariantAccess<'de> {
+    type Error = crate::Error;
+
+    fn unit_variant(self) -> crate::Result<()> {
+        if self.payload.is_none() {
+            Ok(())
+        } else {
+            Err(de::Error::invalid_length(2, &"a unit enum"))
+        }
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> crate::Result<T::Value>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        let Some((value, signature)) = self.payload.zip(self.payload_signature.as_ref()) else {
+            return Err(de::Error::invalid_length(1, &"an enum payload"));
+        };
+        seed.deserialize(ValueDeserializer::new(value, signature, true))
+    }
+
+    fn tuple_variant<V>(self, _len: usize, visitor: V) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.fields_access(visitor)
+    }
+
+    fn struct_variant<V>(
+        self,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.fields_access(visitor)
+    }
+}
+
+impl<'de> ValueVariantAccess<'de> {
+    fn fields_access<V>(self, visitor: V) -> crate::Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        let Some((Value::Structure(structure), Signature::Structure(signatures))) =
+            self.payload.zip(self.payload_signature)
+        else {
+            return Err(de::Error::invalid_type(
+                de::Unexpected::Other("non-structure enum payload"),
+                &"a structure enum payload",
+            ));
+        };
+        visitor.visit_seq(EnumFieldsAccess::new(
+            structure.fields(),
+            signatures.iter().cloned().collect(),
+        ))
+    }
+}
+
+struct EnumFieldsAccess<'de> {
+    fields: &'de [Value<'de>],
+    signatures: Vec<Signature>,
+    index: usize,
+}
+
+impl<'de> EnumFieldsAccess<'de> {
+    fn new(fields: &'de [Value<'de>], signatures: Vec<Signature>) -> Self {
+        Self {
+            fields,
+            signatures,
+            index: 0,
+        }
+    }
+}
+
+impl<'de> SeqAccess<'de> for EnumFieldsAccess<'de> {
+    type Error = crate::Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> crate::Result<Option<T::Value>>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        let Some(value) = self.fields.get(self.index) else {
+            return Ok(None);
+        };
+        let Some(signature) = self.signatures.get(self.index) else {
+            return Err(de::Error::invalid_length(
+                self.fields.len(),
+                &"an enum payload",
+            ));
+        };
+        self.index += 1;
+        seed.deserialize(ValueDeserializer::new(value, signature, true))
+            .map(Some)
+    }
+}
+
+fn signatures_compatible(actual: &Signature, expected: &Signature, unwrap_variant: bool) -> bool {
+    if actual == expected {
+        return true;
+    }
+    if unwrap_variant && actual == &Signature::Variant && expected != &Signature::Variant {
+        return true;
+    }
+
+    match (actual, expected) {
+        (Signature::Array(actual), Signature::Array(expected)) => {
+            signatures_compatible(actual.signature(), expected.signature(), true)
+        }
+        (
+            Signature::Dict {
+                key: actual_key,
+                value: actual_value,
+            },
+            Signature::Dict {
+                key: expected_key,
+                value: expected_value,
+            },
+        ) => {
+            signatures_compatible(actual_key.signature(), expected_key.signature(), false)
+                && signatures_compatible(actual_value.signature(), expected_value.signature(), true)
+        }
+        (Signature::Structure(actual), Signature::Structure(expected)) => {
+            actual.len() == expected.len()
+                && actual
+                    .iter()
+                    .zip(expected.iter())
+                    .all(|(actual, expected)| signatures_compatible(actual, expected, false))
+        }
+        _ => false,
+    }
+}

--- a/zbus/src/wire/as_value/value_serializer.rs
+++ b/zbus/src/wire/as_value/value_serializer.rs
@@ -1,0 +1,704 @@
+//! In-memory serializer for values wrapped by [`super::Serialize`].
+//!
+//! This is deliberately kept separate from `serialize.rs`: the latter is the public Serde
+//! wrapper, while this module is the `Value`-building backend used when no wire representation is
+//! needed.
+
+use serde::{
+    Serialize,
+    ser::{self, SerializeMap, SerializeSeq},
+};
+
+use crate::wire::{
+    Array, Dict, OwnedValue, Signature, StructureBuilder, Type, Value,
+    container_depths::ContainerDepths,
+};
+
+#[cfg(unix)]
+use std::os::fd::BorrowedFd;
+
+/// Serialize `value` directly into an owned D-Bus variant.
+#[doc(hidden)]
+pub fn to_owned_value<T>(value: &T) -> crate::Result<OwnedValue>
+where
+    T: Type + Serialize,
+{
+    Ok(OwnedValue(to_value(value)?))
+}
+
+/// Serialize `value` directly into the payload of an owned D-Bus variant.
+fn to_value<T>(value: &T) -> crate::Result<Value<'static>>
+where
+    T: Type + Serialize,
+{
+    let mut serializer = ValueSerializer::new(Signature::Variant, ContainerDepths::default());
+    let variant = super::Serialize(value).serialize(&mut serializer)?;
+    let Value::Value(value) = variant else {
+        return Err(crate::Error::Failure(
+            "as-value serializer did not produce a variant".to_owned(),
+        ));
+    };
+    Ok(*value)
+}
+
+struct ValueSerializer {
+    signature: Signature,
+    depths: ContainerDepths,
+}
+
+impl ValueSerializer {
+    fn new(signature: Signature, depths: ContainerDepths) -> Self {
+        Self { signature, depths }
+    }
+
+    fn mismatch(&self, expected: &str) -> crate::Error {
+        crate::Error::SignatureMismatch(self.signature.clone(), expected.to_owned())
+    }
+
+    fn expect(&self, signature: Signature) -> crate::Result<()> {
+        if self.signature == signature {
+            Ok(())
+        } else {
+            Err(self.mismatch(&format!("`{signature}`")))
+        }
+    }
+}
+
+impl ser::Serializer for &mut ValueSerializer {
+    type Ok = Value<'static>;
+    type Error = crate::Error;
+    type SerializeSeq = SeqSerializer;
+    type SerializeTuple = StructSeqSerializer;
+    type SerializeTupleStruct = StructSeqSerializer;
+    type SerializeTupleVariant = StructSeqSerializer;
+    type SerializeMap = MapSerializer;
+    type SerializeStruct = StructSeqSerializer;
+    type SerializeStructVariant = StructSeqSerializer;
+
+    fn serialize_bool(self, value: bool) -> crate::Result<Self::Ok> {
+        self.expect(Signature::Bool).map(|()| Value::Bool(value))
+    }
+
+    fn serialize_i8(self, value: i8) -> crate::Result<Self::Ok> {
+        self.expect(Signature::I16)
+            .map(|()| Value::I16(value as i16))
+    }
+
+    fn serialize_i16(self, value: i16) -> crate::Result<Self::Ok> {
+        self.expect(Signature::I16).map(|()| Value::I16(value))
+    }
+
+    fn serialize_i32(self, value: i32) -> crate::Result<Self::Ok> {
+        #[cfg(unix)]
+        if self.signature == Signature::Fd {
+            // SAFETY: `value` is the raw descriptor supplied by the Serialize implementation.
+            // It is borrowed only for the duration of the immediate clone operation.
+            let fd = unsafe { BorrowedFd::borrow_raw(value) }.try_clone_to_owned()?;
+            return Ok(Value::Fd(crate::wire::Fd::Owned(fd)));
+        }
+
+        self.expect(Signature::I32).map(|()| Value::I32(value))
+    }
+
+    fn serialize_i64(self, value: i64) -> crate::Result<Self::Ok> {
+        self.expect(Signature::I64).map(|()| Value::I64(value))
+    }
+
+    fn serialize_u8(self, value: u8) -> crate::Result<Self::Ok> {
+        self.expect(Signature::U8).map(|()| Value::U8(value))
+    }
+
+    fn serialize_u16(self, value: u16) -> crate::Result<Self::Ok> {
+        self.expect(Signature::U16).map(|()| Value::U16(value))
+    }
+
+    fn serialize_u32(self, value: u32) -> crate::Result<Self::Ok> {
+        self.expect(Signature::U32).map(|()| Value::U32(value))
+    }
+
+    fn serialize_u64(self, value: u64) -> crate::Result<Self::Ok> {
+        self.expect(Signature::U64).map(|()| Value::U64(value))
+    }
+
+    fn serialize_f32(self, value: f32) -> crate::Result<Self::Ok> {
+        self.expect(Signature::F64)
+            .map(|()| Value::F64(value as f64))
+    }
+
+    fn serialize_f64(self, value: f64) -> crate::Result<Self::Ok> {
+        self.expect(Signature::F64).map(|()| Value::F64(value))
+    }
+
+    fn serialize_char(self, value: char) -> crate::Result<Self::Ok> {
+        self.serialize_str(&value.to_string())
+    }
+
+    fn serialize_str(self, value: &str) -> crate::Result<Self::Ok> {
+        match self.signature {
+            Signature::Str => Ok(Value::Str(value.to_owned().into())),
+            Signature::ObjectPath => Ok(Value::ObjectPath(crate::wire::ObjectPath::try_from(
+                value.to_owned(),
+            )?)),
+            Signature::Signature => Ok(Value::Signature(value.parse()?)),
+            _ => Err(self.mismatch("a string, signature, or object path")),
+        }
+    }
+
+    fn serialize_bytes(self, value: &[u8]) -> crate::Result<Self::Ok> {
+        let Signature::Array(child) = &self.signature else {
+            return Err(self.mismatch("an array of bytes"));
+        };
+        if child.signature() != &Signature::U8 {
+            return Err(self.mismatch("an array of bytes"));
+        }
+        let mut array = Array::new(&Signature::U8);
+        for byte in value {
+            array.append(Value::U8(*byte))?;
+        }
+        Ok(Value::Array(array))
+    }
+
+    fn serialize_none(self) -> crate::Result<Self::Ok> {
+        #[cfg(feature = "option-as-array")]
+        {
+            self.serialize_seq(Some(0)).and_then(SeqSerializer::end)
+        }
+        #[cfg(not(feature = "option-as-array"))]
+        {
+            Err(crate::Error::Unsupported)
+        }
+    }
+
+    fn serialize_some<T>(self, value: &T) -> crate::Result<Self::Ok>
+    where
+        T: ?Sized + Serialize,
+    {
+        #[cfg(feature = "option-as-array")]
+        {
+            let mut seq = self.serialize_seq(Some(1))?;
+            ser::SerializeSeq::serialize_element(&mut seq, value)?;
+            ser::SerializeSeq::end(seq)
+        }
+        #[cfg(not(feature = "option-as-array"))]
+        {
+            let _ = value;
+            Err(crate::Error::Unsupported)
+        }
+    }
+
+    fn serialize_unit(self) -> crate::Result<Self::Ok> {
+        Err(crate::Error::Unsupported)
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> crate::Result<Self::Ok> {
+        self.serialize_unit()
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+    ) -> crate::Result<Self::Ok> {
+        if self.signature == Signature::Str {
+            return Ok(Value::Str(variant.to_owned().into()));
+        }
+        self.serialize_u32(variant_index)
+    }
+
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> crate::Result<Self::Ok>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        variant_index: u32,
+        _variant: &'static str,
+        value: &T,
+    ) -> crate::Result<Self::Ok>
+    where
+        T: ?Sized + Serialize,
+    {
+        let mut serializer = StructSerializer::enum_variant(self, variant_index)?;
+        serializer.serialize_field(value)?;
+        serializer.end()
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> crate::Result<Self::SerializeSeq> {
+        let child = match &self.signature {
+            Signature::Array(child) => child.signature().clone(),
+            _ => return Err(self.mismatch("an array")),
+        };
+        Ok(SeqSerializer {
+            element_signature: child,
+            array_signature: self.signature.clone(),
+            elements: Vec::new(),
+            depths: self.depths.inc_array()?,
+        })
+    }
+
+    fn serialize_tuple(self, len: usize) -> crate::Result<Self::SerializeTuple> {
+        self.serialize_struct("", len)
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        name: &'static str,
+        len: usize,
+    ) -> crate::Result<Self::SerializeTupleStruct> {
+        self.serialize_struct(name, len)
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> crate::Result<Self::SerializeTupleVariant> {
+        StructSerializer::enum_variant(self, variant_index).map(StructSeqSerializer::Struct)
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> crate::Result<Self::SerializeMap> {
+        let (key_signature, value_signature) = match &self.signature {
+            Signature::Dict { key, value } => (key.signature().clone(), value.signature().clone()),
+            _ => return Err(self.mismatch("a dict")),
+        };
+        Ok(MapSerializer {
+            key_signature,
+            value_signature,
+            dict_signature: self.signature.clone(),
+            entries: Vec::new(),
+            pending_key: None,
+            depths: self.depths.inc_array()?,
+        })
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> crate::Result<Self::SerializeStruct> {
+        match &self.signature {
+            Signature::Variant => Ok(StructSeqSerializer::Variant(VariantSerializer::new(
+                self.depths.inc_variant()?,
+            ))),
+            Signature::Array(_) => self.serialize_seq(Some(len)).map(StructSeqSerializer::Seq),
+            Signature::U8 => Ok(StructSeqSerializer::Struct(StructSerializer::unit(self)?)),
+            Signature::Structure(_) => {
+                StructSerializer::normal(self).map(StructSeqSerializer::Struct)
+            }
+            Signature::Dict { .. } => self.serialize_map(Some(len)).map(StructSeqSerializer::Map),
+            _ => Err(self.mismatch("a struct, array, u8 or variant")),
+        }
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> crate::Result<Self::SerializeStructVariant> {
+        StructSerializer::enum_variant(self, variant_index).map(StructSeqSerializer::Struct)
+    }
+
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+}
+
+struct SeqSerializer {
+    element_signature: Signature,
+    array_signature: Signature,
+    elements: Vec<Value<'static>>,
+    depths: ContainerDepths,
+}
+
+impl ser::SerializeSeq for SeqSerializer {
+    type Ok = Value<'static>;
+    type Error = crate::Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> crate::Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        let mut serializer = ValueSerializer::new(self.element_signature.clone(), self.depths);
+        self.elements.push(value.serialize(&mut serializer)?);
+        Ok(())
+    }
+
+    fn end(self) -> crate::Result<Self::Ok> {
+        let mut array = Array::new(&self.element_signature);
+        for element in self.elements {
+            array.append(element)?;
+        }
+        debug_assert_eq!(array.signature(), &self.array_signature);
+        Ok(Value::Array(array))
+    }
+}
+
+struct MapSerializer {
+    key_signature: Signature,
+    value_signature: Signature,
+    dict_signature: Signature,
+    entries: Vec<(Value<'static>, Value<'static>)>,
+    pending_key: Option<Value<'static>>,
+    depths: ContainerDepths,
+}
+
+impl ser::SerializeMap for MapSerializer {
+    type Ok = Value<'static>;
+    type Error = crate::Error;
+
+    fn serialize_key<T>(&mut self, key: &T) -> crate::Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        if self.pending_key.is_some() {
+            return Err(crate::Error::Failure("map value is missing".to_owned()));
+        }
+        let mut serializer = ValueSerializer::new(self.key_signature.clone(), self.depths);
+        self.pending_key = Some(key.serialize(&mut serializer)?);
+        Ok(())
+    }
+
+    fn serialize_value<T>(&mut self, value: &T) -> crate::Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        let Some(key) = self.pending_key.take() else {
+            return Err(crate::Error::Failure("map key is missing".to_owned()));
+        };
+        let mut serializer = ValueSerializer::new(self.value_signature.clone(), self.depths);
+        self.entries.push((key, value.serialize(&mut serializer)?));
+        Ok(())
+    }
+
+    fn end(self) -> crate::Result<Self::Ok> {
+        if self.pending_key.is_some() {
+            return Err(crate::Error::Failure("map value is missing".to_owned()));
+        }
+        let mut dict = Dict::new(&self.key_signature, &self.value_signature);
+        for (key, value) in self.entries {
+            dict.append(key, value)?;
+        }
+        debug_assert_eq!(dict.signature(), &self.dict_signature);
+        Ok(Value::Dict(dict))
+    }
+}
+
+struct StructSerializer {
+    expected: Signature,
+    fields: Vec<Value<'static>>,
+    field_idx: usize,
+    depths: ContainerDepths,
+    enum_inner: Option<(Signature, Vec<Value<'static>>, usize, ContainerDepths)>,
+}
+
+impl StructSerializer {
+    fn normal(serializer: &ValueSerializer) -> crate::Result<Self> {
+        Ok(Self {
+            expected: serializer.signature.clone(),
+            fields: Vec::new(),
+            field_idx: 0,
+            depths: serializer.depths.inc_structure()?,
+            enum_inner: None,
+        })
+    }
+
+    fn unit(serializer: &ValueSerializer) -> crate::Result<Self> {
+        serializer.expect(Signature::U8)?;
+        Ok(Self {
+            expected: Signature::U8,
+            fields: vec![Value::U8(0)],
+            field_idx: 0,
+            depths: serializer.depths,
+            enum_inner: None,
+        })
+    }
+
+    fn enum_variant(serializer: &ValueSerializer, variant_index: u32) -> crate::Result<Self> {
+        let Signature::Structure(fields) = &serializer.signature else {
+            return Err(serializer.mismatch("a struct"));
+        };
+        let Some(inner) = fields.get(1) else {
+            return Err(serializer.mismatch("an enum structure"));
+        };
+        let outer_depths = serializer.depths.inc_structure()?;
+        let enum_inner = match inner {
+            Signature::Structure(_) => {
+                Some((inner.clone(), Vec::new(), 0, outer_depths.inc_structure()?))
+            }
+            _ => None,
+        };
+        if fields.get(0) != Some(&Signature::U32) {
+            return Err(serializer.mismatch("an enum structure beginning with `u`"));
+        }
+        Ok(Self {
+            expected: serializer.signature.clone(),
+            fields: vec![Value::U32(variant_index)],
+            field_idx: 1,
+            depths: outer_depths,
+            enum_inner,
+        })
+    }
+
+    fn serialize_field<T>(&mut self, value: &T) -> crate::Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        if let Some((inner_signature, inner_fields, inner_idx, depths)) = &mut self.enum_inner {
+            let Signature::Structure(fields) = inner_signature else {
+                unreachable!()
+            };
+            let Some(signature) = fields.get(*inner_idx) else {
+                return Err(crate::Error::SignatureMismatch(
+                    inner_signature.clone(),
+                    "an enum variant with the expected number of fields".to_owned(),
+                ));
+            };
+            *inner_idx += 1;
+            let mut serializer = ValueSerializer::new(signature.clone(), *depths);
+            inner_fields.push(value.serialize(&mut serializer)?);
+            return Ok(());
+        }
+
+        let Signature::Structure(fields) = &self.expected else {
+            return Err(crate::Error::Unsupported);
+        };
+        let Some(signature) = fields.get(self.field_idx) else {
+            return Err(crate::Error::SignatureMismatch(
+                self.expected.clone(),
+                "a struct with the expected number of fields".to_owned(),
+            ));
+        };
+        self.field_idx += 1;
+        let mut serializer = ValueSerializer::new(signature.clone(), self.depths);
+        self.fields.push(value.serialize(&mut serializer)?);
+        Ok(())
+    }
+
+    fn end(mut self) -> crate::Result<Value<'static>> {
+        if let Some((inner_signature, inner_fields, inner_idx, _)) = self.enum_inner.take() {
+            let Signature::Structure(fields) = &inner_signature else {
+                unreachable!()
+            };
+            if inner_idx != fields.len() {
+                return Err(crate::Error::SignatureMismatch(
+                    inner_signature,
+                    "an enum variant with the expected number of fields".to_owned(),
+                ));
+            }
+            let mut builder = StructureBuilder::new();
+            builder.push_value(Value::U32(match self.fields.first() {
+                Some(Value::U32(index)) => *index,
+                _ => unreachable!(),
+            }));
+            let mut inner_builder = StructureBuilder::new();
+            for field in inner_fields {
+                inner_builder.push_value(field);
+            }
+            builder.push_value(Value::Structure(
+                inner_builder.build_with_signature(&inner_signature),
+            ));
+            return Ok(Value::Structure(
+                builder.build_with_signature(&self.expected),
+            ));
+        }
+
+        if let Signature::Structure(fields) = &self.expected {
+            if self.fields.len() != fields.len() {
+                return Err(crate::Error::SignatureMismatch(
+                    self.expected,
+                    "a struct with the expected number of fields".to_owned(),
+                ));
+            }
+        }
+        if self.expected == Signature::U8 && self.fields.len() == 1 {
+            return Ok(self.fields.pop().expect("unit field is present"));
+        }
+        let mut builder = StructureBuilder::new();
+        for field in self.fields {
+            builder.push_value(field);
+        }
+        Ok(Value::Structure(
+            builder.build_with_signature(&self.expected),
+        ))
+    }
+}
+
+struct VariantSerializer {
+    signature: Option<Signature>,
+    value: Option<Value<'static>>,
+    depths: ContainerDepths,
+}
+
+impl VariantSerializer {
+    fn new(depths: ContainerDepths) -> Self {
+        Self {
+            signature: None,
+            value: None,
+            depths,
+        }
+    }
+
+    fn serialize_field<T>(&mut self, value: &T) -> crate::Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        if self.signature.is_none() {
+            let mut serializer = ValueSerializer::new(Signature::Signature, self.depths);
+            let Value::Signature(signature) = value.serialize(&mut serializer)? else {
+                unreachable!()
+            };
+            self.signature = Some(signature);
+            return Ok(());
+        }
+        if self.value.is_some() {
+            return Err(crate::Error::Failure(
+                "variant has too many fields".to_owned(),
+            ));
+        }
+        let signature = self.signature.clone().expect("checked above");
+        let mut serializer = ValueSerializer::new(signature, self.depths);
+        self.value = Some(value.serialize(&mut serializer)?);
+        Ok(())
+    }
+
+    fn end(self) -> crate::Result<Value<'static>> {
+        let Some(signature) = self.signature else {
+            return Err(crate::Error::Failure(
+                "variant is missing its signature".to_owned(),
+            ));
+        };
+        let Some(value) = self.value else {
+            return Err(crate::Error::Failure(
+                "variant is missing its value".to_owned(),
+            ));
+        };
+        if value.value_signature() != &signature {
+            return Err(crate::Error::SignatureMismatch(
+                value.value_signature().clone(),
+                format!("`{signature}`"),
+            ));
+        }
+        Ok(Value::Value(Box::new(value)))
+    }
+}
+
+enum StructSeqSerializer {
+    Struct(StructSerializer),
+    Seq(SeqSerializer),
+    Map(MapSerializer),
+    Variant(VariantSerializer),
+}
+
+impl ser::SerializeTuple for StructSeqSerializer {
+    type Ok = Value<'static>;
+    type Error = crate::Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> crate::Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        match self {
+            Self::Struct(serializer) => serializer.serialize_field(value),
+            Self::Seq(serializer) => serializer.serialize_element(value),
+            Self::Map(serializer) => {
+                let _ = serializer;
+                Err(crate::Error::Failure("tuple cannot be a map".to_owned()))
+            }
+            Self::Variant(serializer) => serializer.serialize_field(value),
+        }
+    }
+
+    fn end(self) -> crate::Result<Self::Ok> {
+        match self {
+            Self::Struct(serializer) => serializer.end(),
+            Self::Seq(serializer) => serializer.end(),
+            Self::Map(serializer) => {
+                let _ = serializer;
+                Err(crate::Error::Failure("tuple cannot be a map".to_owned()))
+            }
+            Self::Variant(serializer) => serializer.end(),
+        }
+    }
+}
+
+impl ser::SerializeTupleStruct for StructSeqSerializer {
+    type Ok = Value<'static>;
+    type Error = crate::Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> crate::Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        ser::SerializeTuple::serialize_element(self, value)
+    }
+
+    fn end(self) -> crate::Result<Self::Ok> {
+        ser::SerializeTuple::end(self)
+    }
+}
+
+impl ser::SerializeTupleVariant for StructSeqSerializer {
+    type Ok = Value<'static>;
+    type Error = crate::Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> crate::Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        ser::SerializeTuple::serialize_element(self, value)
+    }
+
+    fn end(self) -> crate::Result<Self::Ok> {
+        ser::SerializeTuple::end(self)
+    }
+}
+
+impl ser::SerializeStruct for StructSeqSerializer {
+    type Ok = Value<'static>;
+    type Error = crate::Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> crate::Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        match self {
+            Self::Map(serializer) => {
+                serializer.serialize_key(&key)?;
+                serializer.serialize_value(value)
+            }
+            _ => ser::SerializeTuple::serialize_element(self, value),
+        }
+    }
+
+    fn end(self) -> crate::Result<Self::Ok> {
+        match self {
+            Self::Map(serializer) => serializer.end(),
+            serializer => ser::SerializeTuple::end(serializer),
+        }
+    }
+}
+
+impl ser::SerializeStructVariant for StructSeqSerializer {
+    type Ok = Value<'static>;
+    type Error = crate::Error;
+
+    fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> crate::Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        ser::SerializeTuple::serialize_element(self, value)
+    }
+
+    fn end(self) -> crate::Result<Self::Ok> {
+        ser::SerializeTuple::end(self)
+    }
+}

--- a/zbus/src/wire/as_value/value_serializer.rs
+++ b/zbus/src/wire/as_value/value_serializer.rs
@@ -702,3 +702,109 @@ impl ser::SerializeStructVariant for StructSeqSerializer {
         ser::SerializeTuple::end(self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::wire::{LE, serialized::Context, to_bytes};
+
+    #[derive(Debug, PartialEq, serde::Serialize, crate::wire::Type)]
+    struct Pair(u32, String);
+
+    #[derive(serde::Serialize, crate::wire::Type)]
+    struct Empty {}
+
+    #[derive(crate::wire::SerializeDict, crate::wire::Type)]
+    #[zvariant(signature = "dict")]
+    struct DictStruct {
+        count: u32,
+        name: String,
+    }
+
+    #[derive(Debug, PartialEq, serde::Serialize, crate::wire::Type)]
+    enum Enum {
+        First(u32, String),
+        Second(u32, String),
+    }
+
+    #[derive(serde::Serialize, crate::wire::Type)]
+    enum UnitEnum {
+        First,
+        Second,
+    }
+
+    #[derive(serde::Serialize, crate::wire::Type)]
+    #[zvariant(signature = "s")]
+    #[serde(rename_all = "snake_case")]
+    enum StringEnum {
+        FirstValue,
+        SecondValue,
+    }
+
+    #[repr(u32)]
+    #[derive(serde_repr::Serialize_repr, crate::wire::Type)]
+    enum ReprEnum {
+        First = 1,
+        Second = 2,
+    }
+
+    fn assert_matches_wire<T>(value: &T)
+    where
+        T: Type + Serialize,
+    {
+        let direct = to_owned_value(value).unwrap();
+        let encoded = to_bytes(Context::new(LE, 0), &super::super::Serialize(value)).unwrap();
+        let wire: OwnedValue = encoded.deserialize().unwrap().0;
+        assert_eq!(Value::from(direct), Value::from(wire));
+    }
+
+    #[test]
+    fn plain_value_matches_wire_round_trip() {
+        let pair = Pair(42, "hello".to_owned());
+        assert_matches_wire(&pair);
+    }
+
+    #[test]
+    fn nested_variant_matches_wire_round_trip() {
+        let value = Value::new(Value::new(42_u32));
+        assert_matches_wire(&value);
+    }
+
+    #[test]
+    fn supported_values_match_wire_round_trip() {
+        assert_matches_wire(&Empty {});
+        assert_matches_wire(&vec![1_u32, 2, 3]);
+        let map = HashMap::from([
+            ("hi".to_owned(), "hello".to_owned()),
+            ("bye".to_owned(), "now".to_owned()),
+        ]);
+        assert_matches_wire(&map);
+        let value = Value::from(to_owned_value(&map).unwrap());
+        let decoded: HashMap<String, String> =
+            super::super::deserialize_for_property(&value).unwrap();
+        assert_eq!(decoded, map);
+        assert_matches_wire(&DictStruct {
+            count: 7,
+            name: "dict".to_owned(),
+        });
+        assert_matches_wire(&Enum::First(7, "first".to_owned()));
+        assert_matches_wire(&Enum::Second(42, "hello".to_owned()));
+        assert_matches_wire(&UnitEnum::First);
+        assert_matches_wire(&UnitEnum::Second);
+        assert_matches_wire(&StringEnum::FirstValue);
+        assert_matches_wire(&StringEnum::SecondValue);
+        assert_matches_wire(&ReprEnum::First);
+        assert_matches_wire(&ReprEnum::Second);
+
+        #[cfg(feature = "option-as-array")]
+        {
+            assert_matches_wire(&Some(42_u32));
+            assert_matches_wire(&None::<u32>);
+        }
+
+        #[cfg(feature = "serde_bytes")]
+        assert_matches_wire(&serde_bytes::ByteBuf::from(vec![1, 2, 3]));
+    }
+}

--- a/zbus/tests/iface_and_proxy/client.rs
+++ b/zbus/tests/iface_and_proxy/client.rs
@@ -13,7 +13,7 @@ use zbus::{
 use super::{
     helpers::{check_hash_map, check_ipv4_address, check_ipv4_address_hashmap},
     iface::MyIfaceProxy,
-    types::{ArgStructTest, IP4Adress, MyIfaceError},
+    types::{ArgStructTest, IP4Adress, MyIfaceError, RefType},
 };
 
 #[instrument]
@@ -169,6 +169,14 @@ pub async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> 
     proxy.set_str_prop("This is an str ref").await?;
     check_ipv4_address(proxy.address_data().await?);
     check_ipv4_address_hashmap(proxy.address_data2().await?);
+
+    let expected_ref_prop = ("Hello".to_string(),);
+    assert_eq!(proxy.ref_prop::<(String,)>().await?, expected_ref_prop);
+    proxy
+        .set_ref_prop(RefType {
+            field1: "borrowed setter".into(),
+        })
+        .await?;
 
     proxy.test_no_reply().await?;
     proxy.test_no_autostart().await?;

--- a/zbus/tests/iface_and_proxy/types.rs
+++ b/zbus/tests/iface_and_proxy/types.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use zbus::{
     DBusError,
-    wire::{DeserializeDict, OwnedValue, SerializeDict, Str, Type, Value},
+    wire::{DeserializeDict, SerializeDict, Str, Type},
 };
 
 // Tests the `crate` attribute with a path to the wire module.
@@ -15,7 +15,7 @@ pub struct ArgStructTest {
 // Mimic a NetworkManager interface property that's a dict. This tests ability to use a custom
 // dict type using the `Type` And `*Dict` macros (issue #241).
 // Also tests the `crate` attribute with a path to the wire module.
-#[derive(DeserializeDict, SerializeDict, Type, Debug, Value, OwnedValue, PartialEq, Eq)]
+#[derive(DeserializeDict, SerializeDict, Type, Debug, PartialEq, Eq)]
 #[zvariant(signature = "dict", crate = "zbus::wire")]
 pub struct IP4Adress {
     pub prefix: u32,
@@ -24,7 +24,7 @@ pub struct IP4Adress {
 
 // To test property setter for types with lifetimes.
 // Also tests the `crate` attribute with a path to the wire module.
-#[derive(Serialize, Deserialize, Type, Debug, Value, OwnedValue, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Type, Debug, PartialEq, Eq)]
 #[zvariant(crate = "zbus::wire")]
 pub struct RefType<'a> {
     #[serde(borrow)]

--- a/zbus/tests/uncached_propert.rs
+++ b/zbus/tests/uncached_propert.rs
@@ -86,3 +86,130 @@ async fn test_uncached_property() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+#[timeout(15000)]
+fn serde_property() {
+    block_on(test_serde_property()).unwrap();
+}
+
+async fn test_serde_property() -> Result<()> {
+    use std::collections::HashMap;
+
+    use futures_util::StreamExt;
+    use serde::{Deserialize, Serialize};
+    use zbus::{
+        names::OwnedUniqueName,
+        wire::{Optional, OwnedValue, Str, Type},
+    };
+
+    #[derive(Debug, Deserialize, Serialize, Type, PartialEq)]
+    #[zvariant(signature = "s")]
+    struct CustomString(String);
+
+    struct Service(String);
+
+    #[zbus::interface(name = "org.freedesktop.zbus.SerdePropertyTest")]
+    impl Service {
+        #[zbus(property)]
+        fn cached_prop(&self) -> String {
+            self.0.clone()
+        }
+
+        #[zbus(property)]
+        fn set_cached_prop(&mut self, value: String) {
+            self.0 = value;
+        }
+
+        #[zbus(property(emits_changed_signal = "false"))]
+        fn uncached_prop(&self) -> String {
+            self.0.clone()
+        }
+
+        #[zbus(property)]
+        fn optional_name(&self) -> Optional<OwnedUniqueName> {
+            Optional::default()
+        }
+
+        #[zbus(property)]
+        fn dynamic_array(&self) -> Vec<OwnedValue> {
+            vec![OwnedValue::from(Str::from("array value"))]
+        }
+
+        #[zbus(property)]
+        fn dynamic_dict(&self) -> HashMap<String, OwnedValue> {
+            HashMap::from([("key".to_string(), OwnedValue::from(Str::from("dict value")))])
+        }
+    }
+
+    #[zbus::proxy(
+        interface = "org.freedesktop.zbus.SerdePropertyTest",
+        default_path = "/org/freedesktop/zbus/SerdePropertyTest"
+    )]
+    trait SerdePropertyTest {
+        #[zbus(property)]
+        fn cached_prop(&self) -> zbus::Result<CustomString>;
+
+        #[zbus(property)]
+        fn set_cached_prop(&self, value: CustomString) -> zbus::Result<()>;
+
+        #[zbus(property(emits_changed_signal = "false"))]
+        fn uncached_prop(&self) -> zbus::Result<CustomString>;
+
+        #[zbus(property)]
+        fn optional_name(&self) -> zbus::Result<Optional<OwnedUniqueName>>;
+
+        #[zbus(property)]
+        fn dynamic_array(&self) -> zbus::Result<Vec<String>>;
+
+        #[zbus(property)]
+        fn dynamic_dict(&self) -> zbus::Result<HashMap<String, String>>;
+    }
+
+    let service = zbus::connection::Builder::session()?
+        .serve_at(
+            "/org/freedesktop/zbus/SerdePropertyTest",
+            Service("before".to_string()),
+        )?
+        .build()
+        .await?;
+    let client_conn = zbus::Connection::session().await?;
+    let client = SerdePropertyTestProxy::builder(&client_conn)
+        .destination(service.unique_name().unwrap())?
+        .build()
+        .await?;
+
+    assert_eq!(
+        client.cached_prop().await?,
+        CustomString("before".to_string())
+    );
+    assert_eq!(
+        client.uncached_prop().await?,
+        CustomString("before".to_string())
+    );
+    assert!(Option::<OwnedUniqueName>::from(client.optional_name().await?).is_none());
+    assert_eq!(client.dynamic_array().await?, ["array value"]);
+    assert_eq!(client.dynamic_dict().await?["key"], "dict value");
+
+    let mut changes = client.receive_cached_prop_changed().await;
+    assert_eq!(
+        changes.next().await.unwrap().get().await?,
+        CustomString("before".to_string())
+    );
+
+    let (changed, ()) = futures_util::try_join!(
+        async { changes.next().await.unwrap().get().await },
+        client.set_cached_prop(CustomString("after".to_string())),
+    )?;
+    assert_eq!(changed, CustomString("after".to_string()));
+    assert_eq!(
+        client.cached_prop().await?,
+        CustomString("after".to_string())
+    );
+    assert_eq!(
+        client.uncached_prop().await?,
+        CustomString("after".to_string())
+    );
+
+    Ok(())
+}

--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -7,6 +7,7 @@ use syn::{
     Lit::Str,
     Meta, MetaNameValue, PatType, PathArguments, ReturnType, Signature, Token, Type, TypePath,
     TypeReference, Visibility,
+    fold::Fold,
     parse::{Parse, ParseStream},
     parse_quote, parse_str,
     punctuated::Punctuated,
@@ -1569,6 +1570,16 @@ impl Proxy {
             .cloned()
             .collect();
         let zbus = &self.zbus;
+        let proxy_object = method_info
+            .proxy_attrs
+            .as_ref()
+            .is_some_and(|attrs| attrs.object.is_some());
+        let generic_property = matches!(
+            method_info.method_type,
+            MethodType::Property(PropertyType::Getter)
+        ) && !proxy_object
+            && type_borrows(get_return_type(&method_info.output)?);
+        let generic_type = format_ident!("__ZbusProxyProperty");
         let ret = match &method_info.output {
             ReturnType::Type(_, ty) => {
                 let ty = ty.as_ref();
@@ -1600,6 +1611,27 @@ impl Proxy {
             }
             ReturnType::Default => quote! { #zbus::Result<()> },
         };
+        let (generics, ret, where_clause) = if generic_property {
+            (
+                quote! { <#generic_type> },
+                quote! { #zbus::Result<#generic_type> },
+                quote! {
+                    where
+                        #generic_type: #zbus::export::serde::de::DeserializeOwned
+                            + #zbus::wire::Type
+                },
+            )
+        } else {
+            (quote! {}, ret, quote! {})
+        };
+        let generic_property_doc = generic_property.then(|| {
+            let doc = concat!(
+                "Callers select a `DeserializeOwned + Type` result with the same D-Bus ",
+                "signature as the interface property.",
+            );
+
+            quote! { #[doc = #doc] }
+        });
         let ident = &method_info.ident;
         let member_name = method_info.member_name;
         let mut proxy_method_attrs = quote! { name = #member_name, };
@@ -1645,8 +1677,10 @@ impl Proxy {
         self.methods.extend(quote! {
             #(#cfg_attrs)*
             #(#doc_attrs)*
+            #generic_property_doc
             #[zbus(#proxy_method_attrs)]
-            fn #ident(&self, #inputs) -> #ret;
+            fn #ident #generics(&self, #inputs) -> #ret
+            #where_clause;
         });
 
         Ok(())
@@ -1720,6 +1754,29 @@ impl Proxy {
             }
         })
     }
+}
+
+fn type_borrows(ty: &Type) -> bool {
+    struct FindBorrow(bool);
+
+    impl Fold for FindBorrow {
+        fn fold_type_reference(&mut self, node: TypeReference) -> TypeReference {
+            self.0 = true;
+
+            node
+        }
+
+        fn fold_lifetime(&mut self, lifetime: syn::Lifetime) -> syn::Lifetime {
+            self.0 |= lifetime.ident != "static";
+
+            lifetime
+        }
+    }
+
+    let mut finder = FindBorrow(false);
+    finder.fold_type(ty.clone());
+
+    finder.0
 }
 
 #[cfg(test)]

--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -2,8 +2,8 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use std::collections::BTreeMap;
 use syn::{
-    AngleBracketedGenericArguments, Attribute, Error, Expr, ExprLit, FnArg, GenericArgument, Ident,
-    ImplItem, ImplItemFn, ItemImpl,
+    AngleBracketedGenericArguments, Attribute, Error, Expr, ExprLit, FnArg, Ident, ImplItem,
+    ImplItemFn, ItemImpl,
     Lit::Str,
     Meta, MetaNameValue, PatType, PathArguments, ReturnType, Signature, Token, Type, TypePath,
     TypeReference, Visibility,
@@ -535,39 +535,6 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                         )
                     };
 
-                    // * For reference arg, we convert from `&Value` (so `TryFrom<&Value<'_>>` is
-                    //   required).
-                    //
-                    // * For argument type with lifetimes, we convert from `Value` (so
-                    //   `TryFrom<Value<'_>>` is required).
-                    //
-                    // * For all other arg types, we convert the passed value to `OwnedValue` first
-                    //   and then pass it as `Value` (so `TryFrom<OwnedValue>` is required).
-                    let value_to_owned = quote! {
-                        match #zbus::wire::Value::try_to_owned(value) {
-                            ::std::result::Result::Ok(val) => #zbus::wire::Value::from(val),
-                            ::std::result::Result::Err(e) => {
-                                return ::std::result::Result::Err(
-                                    ::std::convert::Into::into(
-                                        ::std::convert::Into::<#zbus::Error>::into(e),
-                                    )
-                                );
-                            }
-                        }
-                    };
-                    let value_cloned = quote! {
-                        match #zbus::wire::Value::try_clone(value) {
-                            ::std::result::Result::Ok(val) => val,
-                            ::std::result::Result::Err(e) => {
-                                return ::std::result::Result::Err(
-                                    ::std::convert::Into::into(
-                                        ::std::convert::Into::<#zbus::Error>::into(e),
-                                    )
-                                );
-                            }
-                        }
-                    };
-
                     let value_param = typed_inputs
                         .iter()
                         .find(|input| {
@@ -583,26 +550,17 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                         p.emits_changed_signal = PropertyEmitsChangedSignal::False;
                     }
 
-                    let value_arg = match &*value_param.ty {
-                        Type::Reference(_) => quote!(value),
-                        Type::Path(path) => path
-                            .path
-                            .segments
-                            .first()
-                            .map(|segment| match &segment.arguments {
-                                PathArguments::AngleBracketed(angled) => angled
-                                    .args
-                                    .first()
-                                    .filter(|arg| matches!(arg, GenericArgument::Lifetime(_)))
-                                    .map(|_| value_cloned.clone())
-                                    .unwrap_or_else(|| value_to_owned.clone()),
-                                _ => value_to_owned.clone(),
-                            })
-                            .unwrap_or_else(|| value_to_owned.clone()),
-                        _ => value_to_owned,
-                    };
-
                     let value_param_name = &value_param.pat;
+                    let value_ty = maybe_unref_ty(&value_param.ty).unwrap_or(&value_param.ty);
+                    let value_arg = if maybe_unref_ty(&value_param.ty).is_some() {
+                        quote! {
+                            let #value_param_name = &__zbus__value;
+                        }
+                    } else {
+                        quote! {
+                            let #value_param_name = __zbus__value;
+                        }
+                    };
                     let prop_changed_method = match p.emits_changed_signal {
                         PropertyEmitsChangedSignal::True => {
                             quote!({
@@ -626,26 +584,23 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                     };
                     let do_set = quote!({
                         #args_from_msg
-                        let value = #value_arg;
-                        match ::std::convert::TryInto::try_into(value) {
-                            ::std::result::Result::Ok(val) => {
-                                let #value_param_name = val;
+                        match #zbus::wire::as_value::deserialize_for_property::<#value_ty>(value) {
+                            ::std::result::Result::Ok(__zbus__value) => {
+                                #value_arg
                                 match #set_call {
                                     ::std::result::Result::Ok(set_result) => {
                                         (#prop_changed_method)
                                             .map_err(|e| #zbus::fdo::Error::from(e))
                                     }
                                     ::std::result::Result::Err(e) => {
-                                        ::std::result::Result::Err(#zbus::fdo::Error::from(e))
+                                        ::std::result::Result::Err(
+                                            #zbus::fdo::Error::from(e),
+                                        )
                                     }
                                 }
                             }
                             ::std::result::Result::Err(e) => {
-                                ::std::result::Result::Err(
-                                    ::std::convert::Into::into(
-                                        ::std::convert::Into::<#zbus::Error>::into(e),
-                                    ),
-                                )
+                                ::std::result::Result::Err(#zbus::fdo::Error::from(e))
                             }
                         }
                     });
@@ -681,12 +636,8 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                     p.ty = Some(get_return_type(output)?.clone());
 
                     let value_convert = quote!(
-                        <#zbus::wire::OwnedValue as ::std::convert::TryFrom<_>>::try_from(
-                            <#zbus::wire::Value as ::std::convert::From<_>>::from(
-                                value,
-                            ),
-                        )
-                        .map_err(|e| #zbus::fdo::Error::Failed(e.to_string()))
+                        #zbus::wire::as_value::to_owned_value(&value)
+                            .map_err(|e| #zbus::fdo::Error::Failed(e.to_string()))
                     );
                     let inner = if is_fallible_property {
                         quote!(self.#ident(#args_names) #method_await .and_then(|value| #value_convert))
@@ -712,12 +663,8 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                             if let Ok(prop) = self.#ident(#args_names)#method_await {
                             props.insert(
                                 ::std::string::ToString::to_string(#member_name),
-                                <#zbus::wire::OwnedValue as ::std::convert::TryFrom<_>>::try_from(
-                                    <#zbus::wire::Value as ::std::convert::From<_>>::from(
-                                        prop,
-                                    ),
-                                )
-                                .map_err(|e| #zbus::fdo::Error::Failed(e.to_string()))?,
+                                #zbus::wire::as_value::to_owned_value(&prop)
+                                    .map_err(|e| #zbus::fdo::Error::Failed(e.to_string()))?,
                             );
                         }})
                     } else {
@@ -725,12 +672,11 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                             #args_from_msg
                             props.insert(
                                 ::std::string::ToString::to_string(#member_name),
-                                <#zbus::wire::OwnedValue as ::std::convert::TryFrom<_>>::try_from(
-                                    <#zbus::wire::Value as ::std::convert::From<_>>::from(
-                                        self.#ident(#args_names)#method_await,
-                                    ),
-                                )
-                                .map_err(|e| #zbus::fdo::Error::Failed(e.to_string()))?,
+                                {
+                                    let value = self.#ident(#args_names)#method_await;
+                                    #zbus::wire::as_value::to_owned_value(&value)
+                                        .map_err(|e| #zbus::fdo::Error::Failed(e.to_string()))?
+                                },
                             );
                         })
                     };
@@ -760,14 +706,22 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                                 let __zbus__connection = __zbus__signal_emitter.connection();
                                 let __zbus__object_server = __zbus__connection.object_server();
                                 #args_from_msg
+                                let value = #prop_value_handled;
                                 let mut changed = ::std::collections::HashMap::new();
-                                let value = <#zbus::wire::Value as ::std::convert::From<_>>::from(#prop_value_handled);
-                                changed.insert(#member_name, value);
-                                #zbus::fdo::Properties::properties_changed(
-                                    __zbus__signal_emitter,
-                                    #zbus::names::InterfaceName::from_static_str_unchecked(#iface_name),
-                                    changed,
-                                    ::std::borrow::Cow::Borrowed(&[]),
+                                changed.insert(
+                                    #member_name,
+                                    #zbus::wire::as_value::Serialize(&value),
+                                );
+                                __zbus__signal_emitter.emit(
+                                    "org.freedesktop.DBus.Properties",
+                                    "PropertiesChanged",
+                                    &(
+                                        #zbus::names::InterfaceName::from_static_str_unchecked(
+                                            #iface_name,
+                                        ),
+                                        changed,
+                                        ::std::borrow::Cow::<[&str]>::Borrowed(&[]),
+                                    ),
                                 ).await
                             }
                         );
@@ -1807,12 +1761,8 @@ mod tests {
             "generated code names ::zbus instead of the requested crate: {expanded}"
         );
         assert!(
-            expanded.contains(":: mybus :: wire :: Value :: try_to_owned"),
-            "generated code lost the owned-value conversion: {expanded}"
-        );
-        assert!(
-            expanded.contains(":: mybus :: wire :: Value :: try_clone"),
-            "generated code lost the borrowed-value conversion: {expanded}"
+            expanded.contains(":: mybus :: wire :: as_value :: deserialize_for_property"),
+            "generated code lost the value deserialization: {expanded}"
         );
     }
 }

--- a/zbus_macros/src/proxy.rs
+++ b/zbus_macros/src/proxy.rs
@@ -861,6 +861,7 @@ fn gen_proxy_property(
             PropertyEmitsChangedSignal::True
             | PropertyEmitsChangedSignal::Invalidates
             | PropertyEmitsChangedSignal::Const => {
+                let (generics, _, where_clause) = m.sig.generics.split_for_impl();
                 let cached_getter = format_ident!("cached_{}", rust_method_name);
                 let cached_doc = format!(
                     " Get the cached value of the `{property_name}` property, or `None` if the property is not cached.",
@@ -868,9 +869,10 @@ fn gen_proxy_property(
                 quote! {
                     #(#other_attrs)*
                     #[doc = #cached_doc]
-                    pub fn #cached_getter(&self) -> ::std::result::Result<
+                    pub fn #cached_getter #generics(&self) -> ::std::result::Result<
                         ::std::option::Option<<#ret_type as #zbus::ResultAdapter>::Ok>,
                         <#ret_type as #zbus::ResultAdapter>::Err>
+                    #where_clause
                     {
                         self.0.cached_property(#property_name).map_err(::std::convert::Into::into)
                     }

--- a/zbus_macros/tests/tests.rs
+++ b/zbus_macros/tests/tests.rs
@@ -7,7 +7,7 @@ use zbus::{block_on, fdo, object_server::SignalEmitter, proxy::CacheProperties};
 use zbus_macros::{DBusError, interface, proxy};
 
 // `::mybus` only resolves because of this alias; the test below exercises the `crate` attribute
-// on a `Value`-taking property setter.
+// on property setters.
 extern crate zbus as mybus;
 
 mod param {
@@ -132,10 +132,7 @@ fn test_derive_error() {
 #[test]
 fn test_interface() {
     use serde::{Deserialize, Serialize};
-    use zbus::{
-        object_server::Interface,
-        wire::{Type, Value},
-    };
+    use zbus::{object_server::Interface, wire::Type};
 
     // Test write-only property
     struct TestWriteOnlyProperty;
@@ -163,7 +160,7 @@ fn test_interface() {
         generic: T,
     }
 
-    #[derive(Serialize, Deserialize, Type, Value)]
+    #[derive(Serialize, Deserialize, Type)]
     struct MyCustomPropertyType(u32);
 
     #[interface(name = "org.freedesktop.zbus.Test", spawn = false)]
@@ -528,36 +525,13 @@ fn interface_property_setter_with_crate_attr() {
     );
 }
 
-// The generated setter reports the value-conversion failure through `Into`, so an error type
-// that only implements `Into<zbus::Error>` — without the `From` impl the blanket conversion
-// would need — is enough.
 #[test]
-fn interface_property_setter_with_into_only_error() {
-    use zbus::{
-        object_server::Interface,
-        wire::{Type, Value},
-    };
+fn interface_property_setter_with_serde() {
+    use serde::{Deserialize, Serialize};
+    use zbus::{object_server::Interface, wire::Type};
 
-    struct ConversionError;
-
-    // `Into` rather than `From` is the point of this test.
-    #[allow(clippy::from_over_into)]
-    impl Into<zbus::Error> for ConversionError {
-        fn into(self) -> zbus::Error {
-            zbus::Error::Failure("not a Fahrenheit reading".to_string())
-        }
-    }
-
-    #[derive(Type)]
+    #[derive(Deserialize, Serialize, Type)]
     struct Fahrenheit(u32);
-
-    impl TryFrom<Value<'_>> for Fahrenheit {
-        type Error = ConversionError;
-
-        fn try_from(_value: Value<'_>) -> Result<Self, Self::Error> {
-            Err(ConversionError)
-        }
-    }
 
     struct Thermostat;
 

--- a/zbus_utils/src/signature/mod.rs
+++ b/zbus_utils/src/signature/mod.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use core::fmt;
 use std::{
+    borrow::Cow,
     fmt::{Display, Formatter},
     hash::Hash,
     str::FromStr,
@@ -823,8 +824,8 @@ impl Serialize for Signature {
 
 impl<'de> Deserialize<'de> for Signature {
     fn deserialize<D: serde::de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        <&str>::deserialize(deserializer).and_then(|s| {
-            Signature::from_str(s).map_err(|e| serde::de::Error::custom(e.to_string()))
+        Cow::<str>::deserialize(deserializer).and_then(|s| {
+            Signature::from_str(s.as_ref()).map_err(|e| serde::de::Error::custom(e.to_string()))
         })
     }
 }

--- a/zbus_xmlgen/src/lib.rs
+++ b/zbus_xmlgen/src/lib.rs
@@ -1144,10 +1144,9 @@ fn to_rust_type(ty: &Signature, input: bool, as_ref: bool) -> String {
 
 // Like `to_rust_type` for an input parameter, but tailored to property setters.
 //
-// `Proxy::set_property` requires the value to satisfy `T: Into<Value<'t>>`. For most
-// types, the `&T` form already implements this (via `From<&T> for Value`). For `Variant`
-// and `Structure`, the `&T` form does not, so the owned form is emitted instead, also
-// when these appear nested inside an `Array` or `Dict`.
+// Both owned and borrowed forms satisfy `set_property`'s `Serialize + Type` bounds. Keep `Variant`
+// and `Structure` types (including nested forms) owned to preserve the generated API; other inputs
+// retain the borrowed forms emitted by `to_rust_type`.
 fn to_property_setter_type(ty: &Signature) -> String {
     fn inner(signature: &Signature) -> String {
         match signature {


### PR DESCRIPTION
## Summary

- Use Serde and `Type` for proxy and interface properties, matching ordinary methods.
- Deserialize property values directly from `Value`, including concrete types stored in variant
  arrays and dictionaries.
- Serialize property-change signals directly with `as_value::Serialize`; build `OwnedValue` only
  at the type-erased `Get` and `GetAll` interface boundary.
- Preserve borrowing interface getters and setter inputs while requiring owned proxy results.
- Make optional owned-name types compatible with `DeserializeOwned`.
- Document the migration and remove the redundant property-bound sections.

## Validation

- All-feature and wire-only in-memory conversion tests.
- `zbus_macros` unit, integration, and documentation tests.
- Session-bus and peer-to-peer interface/property integration tests.
- `cargo clippy --all-features -- -D warnings`.
- `cargo +nightly fmt --all -- --check`.
- Rust 1.87 locked wire-only check.
- Windows, macOS, and FreeBSD cross-target checks.
- Rustdoc and mdBook builds.
- The repository commit-message linter with zero warnings on all six commits.
- Independent production, code-reuse, and atomic-history reviews.

Closes #1361.

Generated by GPT-5.
