### PR TITLE
🩹 zb: Fix a small build issue for unix targets

### DIFF
--- a/zbus/src/address/mod.rs
+++ b/zbus/src/address/mod.rs
@@ -69,7 +69,9 @@ impl Address {
             Ok(val) => Self::from_str(&val),
             _ => {
                 #[cfg(windows)]
-                return Self::from_str("autolaunch:");
+                {
+                    Self::from_str("autolaunch:")
+                }
 
                 #[cfg(all(unix, not(target_os = "macos")))]
                 {
@@ -81,7 +83,9 @@ impl Address {
                 }
 
                 #[cfg(target_os = "macos")]
-                return Self::from_str("launchd:env=DBUS_LAUNCHD_SESSION_BUS_SOCKET");
+                {
+                    Self::from_str("launchd:env=DBUS_LAUNCHD_SESSION_BUS_SOCKET")
+                }
             }
         }
     }


### PR DESCRIPTION
I don't know why this wasn't breaking the build in general but at least
the latest rust-analyzer wasn't happy with different expressions at the
end of differently gated code.

<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/z-galaxy/zbus/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
