### PR TITLE
🚩 zb: Feature-gate proxy and service API

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,6 +91,21 @@ jobs:
           cargo --locked clippy -p zbus --no-default-features --target x86_64-unknown-netbsd
           cargo --locked clippy -p zbus --no-default-features --target x86_64-pc-windows-gnu
           cargo --locked clippy -p zbus --no-default-features --target aarch64-linux-android
+          # The proxy and service API can be disabled independently. `--all-targets` covers the
+          # tests, examples and benchmarks, whose `required-features` must match what they use.
+          cargo --locked clippy -p zbus --no-default-features --all-targets \
+            --features async-io,blocking-api,p2p
+          cargo --locked clippy -p zbus --no-default-features --all-targets \
+            --features async-io,blocking-api,p2p,proxy
+          cargo --locked clippy -p zbus --no-default-features --all-targets \
+            --features async-io,blocking-api,p2p,service
+          cargo --locked clippy -p zbus --no-default-features --all-targets \
+            --features tokio,p2p,proxy
+          cargo --locked clippy -p zbus --no-default-features --all-targets \
+            --features tokio,p2p,service
+          # The service-only fixture has to be built on its own: in a workspace-wide build, the
+          # features of its `zbus` dependency are unified with those of the other members.
+          cargo --locked clippy -p service_only_fixture
 
   linux_test:
     runs-on: ubuntu-latest
@@ -137,7 +152,7 @@ jobs:
           # Test tokio support.
           dbus-run-session --config-file /tmp/dbus-session.conf -- \
             cargo --locked test --release --verbose --tests -p zbus --no-default-features \
-              --features tokio-vsock -- --skip fdpass_systemd
+              --features tokio-vsock,proxy,service -- --skip fdpass_systemd
           # Test tokio and async-io enabled together (additive features): the backend is then
           # chosen at run time. `vsock` is included as it pulls in `async-io` alongside `tokio`.
           dbus-run-session --config-file /tmp/dbus-session.conf -- \
@@ -148,7 +163,21 @@ jobs:
           # `--no-default-features` is undone by zbus_xmlgen's default-featured zbus dependency.
           dbus-run-session --config-file /tmp/dbus-session.conf -- \
             cargo --locked test --release --verbose --doc -p zbus --no-default-features \
-              --features tokio connection::Connection::executor
+              --features tokio,service connection::Connection::executor
+          # The doc examples with the proxy or service API disabled, with and without the blocking
+          # API.
+          dbus-run-session --config-file /tmp/dbus-session.conf -- \
+            cargo --locked test --release --verbose --doc -p zbus --no-default-features \
+              --features async-io,proxy
+          dbus-run-session --config-file /tmp/dbus-session.conf -- \
+            cargo --locked test --release --verbose --doc -p zbus --no-default-features \
+              --features async-io,service
+          dbus-run-session --config-file /tmp/dbus-session.conf -- \
+            cargo --locked test --release --verbose --doc -p zbus --no-default-features \
+              --features async-io,blocking-api,proxy
+          dbus-run-session --config-file /tmp/dbus-session.conf -- \
+            cargo --locked test --release --verbose --doc -p zbus --no-default-features \
+              --features async-io,blocking-api,service
           # The wire-format-only build. No D-Bus API, so no session bus is needed.
           cargo --locked test --release --verbose -p zbus --no-default-features
           cargo --locked test --release --verbose -p zbus --no-default-features \
@@ -204,7 +233,7 @@ jobs:
           # The tokio-only build. `-p zbus` is load-bearing: a workspace-wide
           # `--no-default-features` is undone by zbus_xmlgen's default-featured zbus dependency.
           # `--tests` because the doc examples assume the async-io runtime.
-          cargo --locked test -p zbus --no-default-features --features tokio --tests
+          cargo --locked test -p zbus --no-default-features --features tokio,proxy,service --tests
           # The wire-format-only build.
           cargo --locked test -p zbus --no-default-features
           cargo --locked test -p zbus --no-default-features `
@@ -245,6 +274,12 @@ jobs:
         run: cargo --locked doc --all-features -p zbus
       - name: Check wire-format-only documentation build
         run: cargo --locked doc --no-default-features -p zbus
+      - name: Check documentation build with the proxy or service API disabled
+        run: |
+          cargo --locked doc --no-default-features --features async-io,proxy -p zbus
+          cargo --locked doc --no-default-features --features async-io,service -p zbus
+          cargo --locked doc --no-default-features --features async-io,blocking-api,proxy -p zbus
+          cargo --locked doc --no-default-features --features async-io,blocking-api,service -p zbus
       - name: Check zbus_xml documentation build
         run: cargo --locked doc --all-features -p zbus_xml
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1443,6 +1443,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "service_only_fixture"
+version = "0.0.0"
+dependencies = [
+ "zbus",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "zbus_xml",
     "zbus_xmlgen",
     "test_fixtures/renamed_zbus",
+    "test_fixtures/service_only",
     "test_fixtures/zbus_only",
 ]
 resolver = "3"

--- a/book/src/upgrading-to-6.md
+++ b/book/src/upgrading-to-6.md
@@ -39,8 +39,20 @@ zbus users change the version and nothing else:
 zbus = "6"
 ```
 
-The `default-features = false, features = ["tokio"]` idiom is unaffected: `tokio` enables
-`comms`, which is the whole D-Bus API.
+The `default-features = false, features = ["tokio"]` idiom needs one more feature or two:
+`tokio` enables `comms`, the D-Bus connection layer, but the client-side proxy API and the
+service-side object server API are now behind the `proxy` and `service` features (see
+[below](#proxy-and-service-api-are-separate-features)):
+
+```toml
+# Before
+[dependencies]
+zbus = { version = "5", default-features = false, features = ["tokio"] }
+
+# After
+[dependencies]
+zbus = { version = "6", default-features = false, features = ["tokio", "proxy", "service"] }
+```
 
 Wire-format-only users replace the crate. Every `zvariant` feature kept its name, except
 `gvariant` and `ostree-tests`, which are gone:
@@ -83,11 +95,12 @@ Four things to know about the features:
   That is a build-size question only; nothing behaves differently.
 
 A crate that depends on `zbus_macros` directly keeps `proxy`, `interface` and `DBusError`
-without doing anything: `comms` is a default feature there, and `blocking-api` implies it. Only a
-direct dependency that had turned the (previously empty) defaults off *and* uses those three
-macros needs `features = ["comms"]` now, or drops the `default-features = false`; the wire-format
-derives and `signature!` never needed it. zbus's own dependency on the macro crate is such a
-defaults-off one, and its `comms` feature switches the macro crate's `comms` back on.
+without doing anything: `comms`, `proxy` and `service` are default features there. Only a
+direct dependency that had turned the (previously empty) defaults off *and* uses those macros
+needs `features = ["proxy"]` and/or `features = ["service"]` now (`DBusError` alone needs
+`comms`), or drops the `default-features = false`; the wire-format derives and `signature!` never
+needed it. zbus's own dependency on the macro crate is such a defaults-off one, and its `comms`,
+`proxy` and `service` features switch the macro crate's back on.
 
 ## Paths
 
@@ -296,7 +309,7 @@ The compatibility module is removed in zbus 7.0.
 
 ## Other changes in 6.0
 
-Six more things break in 6.0 without being a consequence of the crate merge. They reach code
+Seven more things break in 6.0 without being a consequence of the crate merge. They reach code
 that never mentioned `zvariant` or `zbus_names`.
 
 ### Property methods use Serde traits
@@ -431,6 +444,26 @@ the empty string, and the sentinel now maps to `None` without being converted at
 The public `NoneValue::NoneType` associated type for each owned name type is now `String` rather
 than `&'static str`. This allows `Optional<Owned*Name>` to implement `DeserializeOwned` without
 changing its wire encoding.
+
+### Proxy and service API are separate features
+
+The client-side proxy API (`zbus::proxy`, `zbus::Proxy`, `#[proxy]`, the `fdo::*Proxy` types)
+and the service-side object server API (`zbus::object_server`, `zbus::ObjectServer`,
+`#[interface]`, `Connection::object_server`, `Builder::serve_at`) are behind the `proxy` and
+`service` features respectively. Both are default features, so a plain `zbus = "6"` dependency
+is unaffected. A `default-features = false` build has to ask for the half it uses:
+
+```toml
+[dependencies]
+# A pure client.
+zbus = { version = "6", default-features = false, features = ["tokio", "proxy"] }
+# A pure service.
+zbus = { version = "6", default-features = false, features = ["tokio", "service"] }
+```
+
+Leaving out the half you don't use keeps its code out of your binary, which even fat LTO could
+not do before. Everything else in the D-Bus API (`Connection`, `Message`, `MessageStream`,
+`MatchRule`, the plain `fdo` types and errors, `Connection::request_name`) needs neither.
 
 ## A stale zvariant in the dependency graph
 

--- a/test_fixtures/service_only/Cargo.toml
+++ b/test_fixtures/service_only/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "service_only_fixture"
+version = "0.0.0"
+edition = { workspace = true }
+rust-version = { workspace = true }
+publish = false
+
+description = "Compile-only fixture: a service-only crate whose build script pulls in the proxy API"
+
+[dependencies]
+# Only the service side of the D-Bus API. Whether the `proxy` attribute of the `interface` macro
+# generates a proxy must follow this feature set.
+zbus = { path = "../../zbus", default-features = false, features = ["async-io", "service"] }
+
+[build-dependencies]
+# The whole point of this fixture: Cargo unifies the features of host dependencies separately from
+# the target ones, so this enables `proxy` in the (host) `zbus_macros` but not in the (target)
+# `zbus` above. The macros must not act on their own features.
+zbus = { path = "../../zbus", default-features = false, features = ["async-io", "proxy"] }
+
+[lints]
+workspace = true

--- a/test_fixtures/service_only/build.rs
+++ b/test_fixtures/service_only/build.rs
@@ -1,0 +1,3 @@
+//! The build script only exists so that the `build-dependencies` are compiled.
+
+fn main() {}

--- a/test_fixtures/service_only/src/lib.rs
+++ b/test_fixtures/service_only/src/lib.rs
@@ -1,0 +1,28 @@
+//! Compile-only fixture: a downstream crate that only enables the `service` feature of `zbus`,
+//! while its build script depends on `zbus` with the `proxy` feature.
+//!
+//! Cargo unifies the features of host dependencies (build scripts and proc-macros) separately
+//! from the target ones, so `zbus_macros` is compiled with `proxy` enabled here even though the
+//! `zbus` this crate links against is not. The `proxy` attribute of the `interface` macro must
+//! therefore decide on the `zbus` side whether to generate a proxy.
+
+#![allow(dead_code)]
+
+use zbus::interface;
+
+struct ServiceOnly;
+
+#[interface(
+    name = "org.freedesktop.ServiceOnlyFixture",
+    proxy(gen_blocking = false)
+)]
+impl ServiceOnly {
+    fn some_method(&self) -> String {
+        "some".to_string()
+    }
+
+    #[zbus(property)]
+    fn some_property(&self) -> u32 {
+        42
+    }
+}

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["os::unix-apis"]
 readme = "README.md"
 
 [features]
-default = ["async-io", "blocking-api", "proxy"]
+default = ["async-io", "blocking-api", "proxy", "service"]
 
 # Wire-format optional impls — the former zvariant features, same names.
 arrayvec = ["dep:arrayvec"]
@@ -68,6 +68,8 @@ tokio-vsock = ["dep:tokio-vsock", "tokio"]
 blocking-api = ["comms"]
 # The client-side (proxy) API (default).
 proxy = ["comms", "zbus_macros/proxy"]
+# The service-side (object server) API (default).
+service = ["comms", "zbus_macros/service"]
 # Enables API that is only needed for peer-to-peer (p2p) connections.
 p2p = ["comms", "uuid?/v4"]
 # Enables API that is only needed for bus implementations (enables `p2p`).
@@ -215,7 +217,7 @@ required-features = ["comms"]
 [[bench]]
 name = "concurrent_method_calls"
 harness = false
-required-features = ["p2p"]
+required-features = ["p2p", "service"]
 
 [[bench]]
 name = "names"

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["os::unix-apis"]
 readme = "README.md"
 
 [features]
-default = ["async-io", "blocking-api"]
+default = ["async-io", "blocking-api", "proxy"]
 
 # Wire-format optional impls — the former zvariant features, same names.
 arrayvec = ["dep:arrayvec"]
@@ -66,6 +66,8 @@ vsock = ["dep:vsock", "async-io"]
 tokio-vsock = ["dep:tokio-vsock", "tokio"]
 # Enable blocking API (default).
 blocking-api = ["comms"]
+# The client-side (proxy) API (default).
+proxy = ["comms", "zbus_macros/proxy"]
 # Enables API that is only needed for peer-to-peer (p2p) connections.
 p2p = ["comms", "uuid?/v4"]
 # Enables API that is only needed for bus implementations (enables `p2p`).
@@ -231,4 +233,4 @@ required-features = ["blocking-api"]
 [[example]]
 name = "watch-systemd-jobs"
 path = "examples/watch-systemd-jobs.rs"
-required-features = ["async-io"]
+required-features = ["async-io", "proxy"]

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -65,7 +65,7 @@ tokio = ["comms", "dep:tokio"]
 vsock = ["dep:vsock", "async-io"]
 tokio-vsock = ["dep:tokio-vsock", "tokio"]
 # Enable blocking API (default).
-blocking-api = ["comms", "zbus_macros/blocking-api"]
+blocking-api = ["comms"]
 # Enables API that is only needed for peer-to-peer (p2p) connections.
 p2p = ["comms", "uuid?/v4"]
 # Enables API that is only needed for bus implementations (enables `p2p`).

--- a/zbus/README.md
+++ b/zbus/README.md
@@ -28,7 +28,7 @@ That build compiles `zbus::wire` and `zbus::names` and nothing else — no conne
 object server. The optional wire-format features keep zvariant's names (`arrayvec`, `camino`,
 `chrono`, `enumflags2`, `heapless`, `option-as-array`, `serde_bytes`, `time`, `url`, `uuid`),
 and enabling any D-Bus feature (`comms`, `async-io`, `tokio`, `blocking-api`, `p2p`,
-`bus-impl`, `vsock`, `tokio-vsock`) brings the full API back.
+`bus-impl`, `vsock`, `tokio-vsock`, `proxy`, `service`) brings the D-Bus API back.
 
 ## Example code
 
@@ -117,6 +117,13 @@ async fn main() -> Result<()> {
 While zbus is primarily asynchronous (since 2.0), [blocking wrappers][bw] are provided for
 convenience. Since zbus 5.0, blocking API can be disabled by disabling the `blocking-api` cargo
 feature.
+
+## Proxy and service API
+
+Since zbus 6.0, the client-side proxy API and the service-side object server API live behind the
+`proxy` and `service` cargo features, respectively. Both are enabled by default. If you are
+writing a pure service or a pure client, you can disable the API you don't need to reduce the
+size of your binary.
 
 ## Compatibility with async runtimes
 

--- a/zbus/src/abstractions/async_lock.rs
+++ b/zbus/src/abstractions/async_lock.rs
@@ -1,7 +1,11 @@
 #[cfg(feature = "async-io")]
-pub(crate) use async_lock::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
+pub(crate) use async_lock::Mutex;
+#[cfg(all(feature = "async-io", feature = "service"))]
+pub(crate) use async_lock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 #[cfg(all(feature = "tokio", not(feature = "async-io")))]
-pub(crate) use tokio::sync::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
+pub(crate) use tokio::sync::Mutex;
+#[cfg(all(feature = "tokio", not(feature = "async-io"), feature = "service"))]
+pub(crate) use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 /// An abstraction over async semaphore API.
 #[cfg(feature = "async-io")]

--- a/zbus/src/address/transport/ibus.rs
+++ b/zbus/src/address/transport/ibus.rs
@@ -117,7 +117,7 @@ mod tests {
 
     #[test]
     fn test_ibus_default() {
-        let ibus = Ibus::default();
+        let ibus: Ibus = Default::default();
         assert_eq!(ibus.to_string(), "ibus:");
     }
 

--- a/zbus/src/blocking/connection/builder.rs
+++ b/zbus/src/blocking/connection/builder.rs
@@ -10,9 +10,10 @@ use uds_windows::UnixStream as AsyncIoUnixStream;
 use crate::Guid;
 use crate::{
     Error, Result, address::Address, blocking::Connection, conn::AuthMechanism,
-    connection::socket::BoxedSplit, names::WellKnownName, object_server::Interface,
-    utils::block_on, wire::ObjectPath,
+    connection::socket::BoxedSplit, names::WellKnownName, utils::block_on,
 };
+#[cfg(feature = "service")]
+use crate::{object_server::Interface, wire::ObjectPath};
 
 /// A builder for [`zbus::blocking::Connection`].
 #[derive(Debug)]
@@ -215,6 +216,7 @@ impl<'a> Builder<'a> {
     /// your interfaces available immediately after the connection is established. Typically, this
     /// is exactly what you'd want. Also in contrast to [`zbus::blocking::ObjectServer::at`], this
     /// method will replace any previously added interface with the same name at the same path.
+    #[cfg(feature = "service")]
     pub fn serve_at<P, I>(self, path: P, iface: I) -> Result<Self>
     where
         I: Interface,
@@ -228,7 +230,15 @@ impl<'a> Builder<'a> {
     ///
     /// This is similar to [`zbus::blocking::Connection::request_name`], except the name is
     /// requested as part of the connection setup ([`Builder::build`]), immediately after
-    /// interfaces registered (through [`Builder::serve_at`]) are advertised. Typically
+    #[cfg_attr(
+        feature = "service",
+        doc = "interfaces registered (through [`Builder::serve_at`]) are advertised. Typically"
+    )]
+    #[cfg_attr(
+        not(feature = "service"),
+        doc = "interfaces registered (through `Builder::serve_at`, which requires the `service`",
+        doc = "feature) are advertised. Typically"
+    )]
     /// this is exactly what you want.
     pub fn name<W>(self, well_known_name: W) -> Result<Self>
     where

--- a/zbus/src/blocking/connection/mod.rs
+++ b/zbus/src/blocking/connection/mod.rs
@@ -2,11 +2,14 @@
 
 use enumflags2::BitFlags;
 use event_listener::EventListener;
-use std::{io, ops::Deref, sync::Arc};
+#[cfg(feature = "service")]
+use std::ops::Deref;
+use std::{io, sync::Arc};
 
+#[cfg(feature = "service")]
+use crate::blocking::ObjectServer;
 use crate::{
     DBusError, Error, Result,
-    blocking::ObjectServer,
     fdo::{ConnectionCredentials, RequestNameFlags, RequestNameReply},
     message::Message,
     names::{BusName, ErrorName, InterfaceName, MemberName, OwnedUniqueName, WellKnownName},
@@ -220,6 +223,7 @@ impl Connection {
     /// Get a reference to the associated [`ObjectServer`].
     ///
     /// The `ObjectServer` is created on-demand.
+    #[cfg(feature = "service")]
     pub fn object_server(&self) -> impl Deref<Target = ObjectServer> + '_ {
         struct Wrapper(ObjectServer);
         impl Deref for Wrapper {

--- a/zbus/src/blocking/message_iterator.rs
+++ b/zbus/src/blocking/message_iterator.rs
@@ -37,8 +37,13 @@ impl MessageIterator {
     /// # Example
     ///
     /// ```
+    /// # // The example decodes the signal with the `NameOwnerChanged` type of the `DBusProxy`.
+    /// # #[cfg(feature = "proxy")]
     /// use zbus::{blocking::{Connection, MessageIterator}, MatchRule, fdo::NameOwnerChanged};
     ///
+    /// # #[cfg(not(feature = "proxy"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "proxy")]
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let conn = Connection::session()?;
     /// let rule = MatchRule::builder()

--- a/zbus/src/blocking/mod.rs
+++ b/zbus/src/blocking/mod.rs
@@ -27,7 +27,10 @@ mod message_iterator;
 pub use message_iterator::*;
 pub mod object_server;
 pub use object_server::ObjectServer;
+#[cfg(feature = "proxy")]
 pub mod proxy;
+#[cfg(feature = "proxy")]
 pub use proxy::Proxy;
 
+#[cfg(feature = "proxy")]
 pub mod fdo;

--- a/zbus/src/blocking/mod.rs
+++ b/zbus/src/blocking/mod.rs
@@ -11,8 +11,17 @@
 //!
 //! Since methods provided by these types run their own little runtime (`block_on`), you must not
 //! use them in async contexts because of the infamous [async sandwich footgun][asf]. This is
-//! an especially important fact to keep in mind for [`crate::interface`]. While `interface` allows
-//! non-async methods for convenience, these methods are called from an async context. The
+#![cfg_attr(
+    feature = "service",
+    doc = " an especially important fact to keep in mind for [`crate::interface`]. While",
+    doc = " `interface`"
+)]
+#![cfg_attr(
+    not(feature = "service"),
+    doc = " an especially important fact to keep in mind for the `interface` macro (requires the",
+    doc = " `service` feature). While `interface`"
+)]
+//! allows non-async methods for convenience, these methods are called from an async context. The
 //! [`blocking` crate] provides an easy way around this problem though.
 //!
 //! [asf]: https://rust-lang.github.io/wg-async/vision/shiny_future/users_manual.html#caveat-beware-the-async-sandwich
@@ -25,7 +34,9 @@ pub use connection::Connection;
 
 mod message_iterator;
 pub use message_iterator::*;
+#[cfg(feature = "service")]
 pub mod object_server;
+#[cfg(feature = "service")]
 pub use object_server::ObjectServer;
 #[cfg(feature = "proxy")]
 pub mod proxy;

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -2,11 +2,11 @@ use async_broadcast::Receiver as ActiveReceiver;
 #[cfg(feature = "async-io")]
 use async_io::Async;
 use enumflags2::BitFlags;
+#[cfg(feature = "service")]
 use event_listener::Event;
-use std::{
-    collections::{HashMap, HashSet},
-    mem, vec,
-};
+#[cfg(feature = "service")]
+use std::collections::HashMap;
+use std::{collections::HashSet, mem, vec};
 
 // Feature-independent stream types for the `async_io_*_stream` builders: these always take the
 // blocking/`async-io` stream, so enabling `tokio` elsewhere can't change what they accept.
@@ -24,7 +24,11 @@ use crate::{
     address::{self, Address},
     fdo::RequestNameFlags,
     message::Message,
-    names::{InterfaceName, WellKnownName},
+    names::WellKnownName,
+};
+#[cfg(feature = "service")]
+use crate::{
+    names::InterfaceName,
     object_server::{ArcInterface, Interface},
     wire::ObjectPath,
 };
@@ -55,6 +59,7 @@ enum Target {
     AuthenticatedSocket(Split<Box<dyn ReadHalf>, Box<dyn WriteHalf>>),
 }
 
+#[cfg(feature = "service")]
 type Interfaces<'a> = HashMap<ObjectPath<'a>, HashMap<InterfaceName<'static>, ArcInterface>>;
 
 /// A builder for [`zbus::Connection`].
@@ -87,6 +92,7 @@ pub struct Builder<'a> {
     #[cfg(feature = "p2p")]
     p2p: bool,
     internal_executor: bool,
+    #[cfg(feature = "service")]
     interfaces: Interfaces<'a>,
     names: HashSet<WellKnownName<'a>>,
     auth_mechanism: Option<AuthMechanism>,
@@ -392,6 +398,7 @@ impl<'a> Builder<'a> {
     ///
     /// Standard interfaces (Peer, Introspectable, Properties) are added on your behalf. If you
     /// attempt to add yours, [`Builder::build()`] will fail.
+    #[cfg(feature = "service")]
     pub fn serve_at<P, I>(mut self, path: P, iface: I) -> Result<Self>
     where
         I: Interface,
@@ -408,7 +415,15 @@ impl<'a> Builder<'a> {
     ///
     /// This is similar to [`zbus::Connection::request_name`], except the name is requested as part
     /// of the connection setup ([`Builder::build`]), immediately after interfaces
-    /// registered (through [`Builder::serve_at`]) are advertised. Typically this is
+    #[cfg_attr(
+        feature = "service",
+        doc = "registered (through [`Builder::serve_at`]) are advertised. Typically this is"
+    )]
+    #[cfg_attr(
+        not(feature = "service"),
+        doc = "registered (through `Builder::serve_at`, which requires the `service` feature) are",
+        doc = "advertised. Typically this is"
+    )]
     /// exactly what you want.
     ///
     /// The methods [`Builder::allow_name_replacements`] and [`Builder::replace_existing_names`]
@@ -591,6 +606,7 @@ impl<'a> Builder<'a> {
         let mut conn = Connection::new(auth, is_bus_conn, executor, self.method_timeout).await?;
         conn.set_max_queued(self.max_queued.unwrap_or(DEFAULT_MAX_QUEUED));
 
+        #[cfg(feature = "service")]
         if !self.interfaces.is_empty() {
             let object_server = conn.ensure_object_server(false);
             for (path, interfaces) in self.interfaces {
@@ -639,6 +655,7 @@ impl<'a> Builder<'a> {
             max_queued: None,
             guid: None,
             internal_executor: true,
+            #[cfg(feature = "service")]
             interfaces: HashMap::new(),
             names: HashSet::new(),
             auth_mechanism: None,

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -65,10 +65,18 @@ type Interfaces<'a> = HashMap<ObjectPath<'a>, HashMap<InterfaceName<'static>, Ar
 ///
 /// 1. There is no indication given to the caller of [`Self::build`] that the name(s) request was
 ///    enqueued and that the requested name might not be available right after building.
-///
-/// 2. The name may be acquired in between the time the name is requested and the
-///    [`crate::fdo::NameAcquiredStream`] is constructed. As a result the service can miss the
-///    [`crate::fdo::NameAcquired`] signal.
+#[cfg_attr(
+    feature = "proxy",
+    doc = "2. The name may be acquired in between the time the name is requested and the",
+    doc = "   [`crate::fdo::NameAcquiredStream`] is constructed. As a result the service can miss",
+    doc = "   the [`crate::fdo::NameAcquired`] signal."
+)]
+#[cfg_attr(
+    not(feature = "proxy"),
+    doc = "2. The name may be acquired in between the time the name is requested and the",
+    doc = "   `fdo::NameAcquiredStream` (requires the `proxy` feature) is constructed. As a result",
+    doc = "   the service can miss the `NameAcquired` signal."
+)]
 #[derive(Debug)]
 #[must_use]
 pub struct Builder<'a> {

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -105,13 +105,30 @@ pub(crate) type MsgBroadcaster = Broadcaster<Result<Message>>;
 ///
 /// For higher-level message handling (typed functions, introspection, documentation reasons etc),
 /// it is recommended to wrap the low-level D-Bus messages into Rust functions with the
-/// [`macro@crate::proxy`] and [`macro@crate::interface`] macros instead of doing it directly on a
-/// `Connection`.
+#[cfg_attr(
+    feature = "proxy",
+    doc = "[`macro@crate::proxy`] and [`macro@crate::interface`] macros instead of doing it",
+    doc = "directly on a `Connection`."
+)]
+#[cfg_attr(
+    not(feature = "proxy"),
+    doc = "`proxy` (requires the `proxy` feature) and [`macro@crate::interface`] macros instead",
+    doc = "of doing it directly on a `Connection`."
+)]
 ///
 /// Typically, a connection is made to the session bus with [`Connection::session`], or to the
-/// system bus with [`Connection::system`]. Then the connection is used with [`crate::Proxy`]
-/// instances or the on-demand [`ObjectServer`] instance that can be accessed through
-/// [`Connection::object_server`].
+#[cfg_attr(
+    feature = "proxy",
+    doc = "system bus with [`Connection::system`]. Then the connection is used with",
+    doc = "[`crate::Proxy`] instances or the on-demand [`ObjectServer`] instance that can be",
+    doc = "accessed through [`Connection::object_server`]."
+)]
+#[cfg_attr(
+    not(feature = "proxy"),
+    doc = "system bus with [`Connection::system`]. Then the connection is used with `Proxy`",
+    doc = "instances (requires the `proxy` feature) or the on-demand [`ObjectServer`] instance",
+    doc = "that can be accessed through [`Connection::object_server`]."
+)]
 ///
 /// `Connection` implements [`Clone`] and cloning it is a very cheap operation, as the underlying
 /// data is not cloned. This makes it very convenient to share the connection between different
@@ -121,9 +138,17 @@ pub(crate) type MsgBroadcaster = Broadcaster<Result<Message>>;
 /// `Connection` keeps internal queues of incoming message. The default capacity of each of these is
 /// 64. The capacity of the main (unfiltered) queue is configurable through the [`set_max_queued`]
 /// method. When the queue is full, no more messages can be received until room is created for more.
-/// This is why it's important to ensure that all [`crate::MessageStream`] and
-/// [`crate::blocking::MessageIterator`] instances are continuously polled and iterated on,
-/// respectively.
+#[cfg_attr(
+    feature = "blocking-api",
+    doc = "This is why it's important to ensure that all [`crate::MessageStream`] and",
+    doc = "[`crate::blocking::MessageIterator`] instances are continuously polled and iterated on,",
+    doc = "respectively."
+)]
+#[cfg_attr(
+    not(feature = "blocking-api"),
+    doc = "This is why it's important to ensure that all [`crate::MessageStream`] instances are",
+    doc = "continuously polled."
+)]
 ///
 /// For sending messages you can use the [`Connection::send`] method.
 ///
@@ -475,19 +500,35 @@ impl Connection {
     ///
     /// This is the same as [`Connection::request_name`] but allows to specify the flags to use when
     /// requesting the name.
-    ///
-    /// If the [`RequestNameFlags::DoNotQueue`] flag is not specified and request ends up in the
-    /// queue, you can use [`crate::fdo::NameAcquiredStream`] to be notified when the name is
-    /// acquired. A queued name request can be cancelled using [`Connection::release_name`].
-    ///
-    /// If the [`RequestNameFlags::AllowReplacement`] flag is specified, the requested name can be
-    /// lost if another peer requests the same name. You can use [`crate::fdo::NameLostStream`] to
-    /// be notified when the name is lost
+    #[cfg_attr(
+        feature = "proxy",
+        doc = "If the [`RequestNameFlags::DoNotQueue`] flag is not specified and request ends up",
+        doc = "in the queue, you can use [`crate::fdo::NameAcquiredStream`] to be notified when",
+        doc = "the name is acquired. A queued name request can be cancelled using",
+        doc = "[`Connection::release_name`].",
+        doc = "",
+        doc = "If the [`RequestNameFlags::AllowReplacement`] flag is specified, the requested name",
+        doc = "can be lost if another peer requests the same name. You can use",
+        doc = "[`crate::fdo::NameLostStream`] to be notified when the name is lost"
+    )]
+    #[cfg_attr(
+        not(feature = "proxy"),
+        doc = "If the [`RequestNameFlags::DoNotQueue`] flag is not specified and request ends up",
+        doc = "in the queue, you can use `fdo::NameAcquiredStream` (requires the `proxy` feature)",
+        doc = "to be notified when the name is acquired. A queued name request can be cancelled",
+        doc = "using [`Connection::release_name`].",
+        doc = "",
+        doc = "If the [`RequestNameFlags::AllowReplacement`] flag is specified, the requested name",
+        doc = "can be lost if another peer requests the same name. You can use",
+        doc = "`fdo::NameLostStream` (requires the `proxy` feature) to be notified when the name",
+        doc = "is lost"
+    )]
     ///
     /// # Example
     ///
     /// ```
-    /// #
+    /// # // The example waits for name acquisition and loss through the `DBusProxy` signals.
+    /// # #[cfg(feature = "proxy")]
     /// # zbus::block_on(async {
     /// use zbus::{Connection, fdo::{DBusProxy, RequestNameFlags, RequestNameReply}};
     /// use enumflags2::BitFlags;
@@ -540,10 +581,22 @@ impl Connection {
     /// # Caveats
     ///
     /// * Same as that of [`Connection::request_name`].
-    /// * If you wish to track changes to name ownership after this call, make sure that the
-    ///   [`crate::fdo::NameAcquired`] and/or [`crate::fdo::NameLostStream`] instance(s) are created
-    ///   **before** calling this method. Otherwise, you may loose the signal if it's emitted after
-    ///   this call but just before the stream instance get created.
+    #[cfg_attr(
+        feature = "proxy",
+        doc = "* If you wish to track changes to name ownership after this call, make sure that",
+        doc = "  the [`crate::fdo::NameAcquiredStream`] and/or [`crate::fdo::NameLostStream`]",
+        doc = "  instance(s) are created **before** calling this method. Otherwise, you may loose",
+        doc = "  the signal if it's emitted after this call but just before the stream instance",
+        doc = "  get created."
+    )]
+    #[cfg_attr(
+        not(feature = "proxy"),
+        doc = "* If you wish to track changes to name ownership after this call, make sure that",
+        doc = "  the `fdo::NameAcquiredStream` and/or `fdo::NameLostStream` instance(s) (requiring",
+        doc = "  the `proxy` feature) are created **before** calling this method. Otherwise, you",
+        doc = "  may loose the signal if it's emitted after this call but just before the stream",
+        doc = "  instance get created."
+    )]
     pub async fn request_name_with_flags<'w, W>(
         &self,
         well_known_name: W,
@@ -1368,9 +1421,11 @@ async fn acquire_serial_num_semaphore() -> Option<SemaphorePermit<'static>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "proxy")]
     use crate::fdo::DBusProxy;
     use ntest::timeout;
     use std::{pin::pin, time::Duration};
+    #[cfg(feature = "proxy")]
     use test_log::test;
 
     #[cfg(windows)]
@@ -1395,6 +1450,7 @@ mod tests {
         .expect("Unable to connect to session bus");
     }
 
+    #[cfg(feature = "proxy")]
     #[test]
     #[timeout(15000)]
     fn disconnect_on_drop() {
@@ -1403,6 +1459,7 @@ mod tests {
         crate::utils::block_on(test_disconnect_on_drop());
     }
 
+    #[cfg(feature = "proxy")]
     async fn test_disconnect_on_drop() {
         #[derive(Default)]
         struct MyInterface {}

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -12,13 +12,17 @@ use std::{
     },
     time::Duration,
 };
-use tracing::{Instrument, debug, info_span, instrument, trace, trace_span, warn};
+use tracing::{Instrument, info_span, trace, trace_span, warn};
+#[cfg(feature = "service")]
+use tracing::{debug, instrument};
 
 use futures_lite::StreamExt;
 use ordered_stream::OrderedFuture;
 
+#[cfg(feature = "service")]
+use crate::ObjectServer;
 use crate::{
-    DBusError, Error, Executor, MatchRule, ObjectServer, OwnedGuid, OwnedMatchRule, Result, Task,
+    DBusError, Error, Executor, MatchRule, OwnedGuid, OwnedMatchRule, Result, Task,
     async_lock::{Mutex, Semaphore, SemaphorePermit},
     fdo::{ConnectionCredentials, ReleaseNameReply, RequestNameFlags, RequestNameReply},
     is_flatpak,
@@ -73,7 +77,9 @@ pub(crate) struct ConnectionInner {
 
     subscriptions: Mutex<Subscriptions>,
 
+    #[cfg(feature = "service")]
     object_server: OnceLock<ObjectServer>,
+    #[cfg(feature = "service")]
     object_server_dispatch_task: OnceLock<Task<()>>,
 
     drop_event: Event,
@@ -106,28 +112,28 @@ pub(crate) type MsgBroadcaster = Broadcaster<Result<Message>>;
 /// For higher-level message handling (typed functions, introspection, documentation reasons etc),
 /// it is recommended to wrap the low-level D-Bus messages into Rust functions with the
 #[cfg_attr(
-    feature = "proxy",
+    all(feature = "proxy", feature = "service"),
     doc = "[`macro@crate::proxy`] and [`macro@crate::interface`] macros instead of doing it",
     doc = "directly on a `Connection`."
 )]
 #[cfg_attr(
-    not(feature = "proxy"),
-    doc = "`proxy` (requires the `proxy` feature) and [`macro@crate::interface`] macros instead",
-    doc = "of doing it directly on a `Connection`."
+    not(all(feature = "proxy", feature = "service")),
+    doc = "`proxy` and `interface` macros (requiring the `proxy` and `service` features",
+    doc = "respectively) instead of doing it directly on a `Connection`."
 )]
 ///
 /// Typically, a connection is made to the session bus with [`Connection::session`], or to the
 #[cfg_attr(
-    feature = "proxy",
+    all(feature = "proxy", feature = "service"),
     doc = "system bus with [`Connection::system`]. Then the connection is used with",
     doc = "[`crate::Proxy`] instances or the on-demand [`ObjectServer`] instance that can be",
     doc = "accessed through [`Connection::object_server`]."
 )]
 #[cfg_attr(
-    not(feature = "proxy"),
+    not(all(feature = "proxy", feature = "service")),
     doc = "system bus with [`Connection::system`]. Then the connection is used with `Proxy`",
-    doc = "instances (requires the `proxy` feature) or the on-demand [`ObjectServer`] instance",
-    doc = "that can be accessed through [`Connection::object_server`]."
+    doc = "instances (requires the `proxy` feature) or the on-demand `ObjectServer` instance that",
+    doc = "can be accessed through `Connection::object_server` (requires the `service` feature)."
 )]
 ///
 /// `Connection` implements [`Clone`] and cloning it is a very cheap operation, as the underlying
@@ -610,6 +616,7 @@ impl Connection {
 
         // Warn if requesting a name before setting up the object server, as this can cause
         // method calls to be lost.
+        #[cfg(feature = "service")]
         if self.is_bus() && self.inner.object_server.get().is_none() {
             warn!(
                 "Requesting name `{well_known_name}` before setting up the object server. \
@@ -876,23 +883,21 @@ impl Connection {
     /// use zbus::connection::Builder;
     /// use tokio::task::spawn;
     ///
+    /// # #[cfg(feature = "service")]
     /// # struct SomeIface;
     /// #
+    /// # #[cfg(feature = "service")]
     /// # #[zbus::interface]
     /// # impl SomeIface {
     /// # }
     /// #
     /// #[tokio::main]
     /// async fn main() {
-    ///     let conn = Builder::session()
-    ///         .unwrap()
-    ///         .internal_executor(false)
-    /// #         // This is only for testing a deadlock that used to happen with this combo.
-    /// #         .serve_at("/some/iface", SomeIface)
-    /// #         .unwrap()
-    ///         .build()
-    ///         .await
-    ///         .unwrap();
+    ///     let builder = Builder::session().unwrap().internal_executor(false);
+    /// #   // This is only for testing a deadlock that used to happen with this combo.
+    /// #   #[cfg(feature = "service")]
+    /// #   let builder = builder.serve_at("/some/iface", SomeIface).unwrap();
+    ///     let conn = builder.build().await.unwrap();
     ///     {
     ///        let conn = conn.clone();
     ///        spawn(async move {
@@ -924,16 +929,19 @@ impl Connection {
     /// **Note**: Once the `ObjectServer` is created, it will be replying to all method calls
     /// received on `self`. If you want to manually reply to method calls, do not use this
     /// method (or any of the `ObjectServer` related API).
+    #[cfg(feature = "service")]
     pub fn object_server(&self) -> &ObjectServer {
         self.ensure_object_server(true)
     }
 
+    #[cfg(feature = "service")]
     pub(crate) fn ensure_object_server(&self, start: bool) -> &ObjectServer {
         self.inner
             .object_server
             .get_or_init(move || self.setup_object_server(start, None))
     }
 
+    #[cfg(feature = "service")]
     fn setup_object_server(&self, start: bool, started_event: Option<Event>) -> ObjectServer {
         if start {
             self.start_object_server(started_event);
@@ -942,6 +950,7 @@ impl Connection {
         ObjectServer::new(self)
     }
 
+    #[cfg(feature = "service")]
     #[instrument(skip(self))]
     pub(crate) fn start_object_server(&self, started_event: Option<Event>) {
         self.inner.object_server_dispatch_task.get_or_init(|| {
@@ -1173,7 +1182,9 @@ impl Connection {
                 bus_conn: bus_connection,
                 unique_name: OnceLock::new(),
                 subscriptions,
+                #[cfg(feature = "service")]
                 object_server: OnceLock::new(),
+                #[cfg(feature = "service")]
                 object_server_dispatch_task: OnceLock::new(),
                 executor,
                 socket_reader_task: OnceLock::new(),
@@ -1302,17 +1313,26 @@ impl Connection {
     /// # Example
     ///
     /// ```
+    /// # #[cfg(feature = "service")]
     /// # use std::error::Error;
+    /// # #[cfg(feature = "service")]
     /// # use zbus::connection::Builder;
+    /// # #[cfg(feature = "service")]
     /// # use zbus::interface;
     /// #
+    /// # #[cfg(feature = "service")]
     /// # struct MyInterface;
     /// #
+    /// # #[cfg(feature = "service")]
     /// # #[interface(name = "foo.bar.baz")]
     /// # impl MyInterface {
     /// #     async fn do_thing(&self) {}
     /// # }
     /// #
+    /// # // The example serves an interface, which needs the `service` feature.
+    /// # #[cfg(not(feature = "service"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "service")]
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn Error>> {
     /// let conn = Builder::session()?
@@ -1420,12 +1440,15 @@ async fn acquire_serial_num_semaphore() -> Option<SemaphorePermit<'static>> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "service")]
     use super::*;
-    #[cfg(feature = "proxy")]
+    #[cfg(all(feature = "proxy", feature = "service"))]
     use crate::fdo::DBusProxy;
+    #[cfg(feature = "service")]
     use ntest::timeout;
+    #[cfg(feature = "service")]
     use std::{pin::pin, time::Duration};
-    #[cfg(feature = "proxy")]
+    #[cfg(all(feature = "proxy", feature = "service"))]
     use test_log::test;
 
     #[cfg(windows)]
@@ -1450,7 +1473,7 @@ mod tests {
         .expect("Unable to connect to session bus");
     }
 
-    #[cfg(feature = "proxy")]
+    #[cfg(all(feature = "proxy", feature = "service"))]
     #[test]
     #[timeout(15000)]
     fn disconnect_on_drop() {
@@ -1459,7 +1482,7 @@ mod tests {
         crate::utils::block_on(test_disconnect_on_drop());
     }
 
-    #[cfg(feature = "proxy")]
+    #[cfg(all(feature = "proxy", feature = "service"))]
     async fn test_disconnect_on_drop() {
         #[derive(Default)]
         struct MyInterface {}
@@ -1496,6 +1519,7 @@ mod tests {
         assert!(!name_has_owner);
     }
 
+    #[cfg(feature = "service")]
     #[tokio::test(start_paused = true)]
     #[timeout(15000)]
     async fn test_graceful_shutdown() {

--- a/zbus/src/fdo/dbus.rs
+++ b/zbus/src/fdo/dbus.rs
@@ -5,31 +5,51 @@
 
 #[cfg(unix)]
 use crate::wire::OwnedFd;
-use enumflags2::{BitFlags, bitflags};
+#[cfg(feature = "proxy")]
+use enumflags2::BitFlags;
+use enumflags2::bitflags;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
+#[cfg(feature = "proxy")]
 use std::collections::HashMap;
 
 use super::Result;
+use crate::wire::{DeserializeDict, SerializeDict, Type};
+#[cfg(feature = "proxy")]
 use crate::{
     OwnedGuid,
     names::{
         BusName, OwnedBusName, OwnedInterfaceName, OwnedUniqueName, UniqueName, WellKnownName,
     },
     proxy,
-    wire::{DeserializeDict, Optional, SerializeDict, Type},
+    wire::Optional,
 };
 
-/// The flags used by the [`DBusProxy::request_name`] method.
+#[cfg_attr(
+    feature = "proxy",
+    doc = "The flags used by the [`DBusProxy::request_name`] method."
+)]
+#[cfg_attr(
+    not(feature = "proxy"),
+    doc = "The flags used by `DBusProxy::request_name` (requires the `proxy` feature)."
+)]
 ///
-/// The default flags (returned by [`BitFlags::default`]) are `AllowReplacement`, `ReplaceExisting`,
-/// and `DoNotQueue`.
+/// The default flags (returned by [`BitFlags::default`](enumflags2::BitFlags::default)) are
+/// `AllowReplacement`, `ReplaceExisting`, and `DoNotQueue`.
 #[bitflags(default = AllowReplacement | ReplaceExisting | DoNotQueue)]
 #[repr(u32)]
 #[derive(Type, Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
 pub enum RequestNameFlags {
     /// If an application A specifies this flag and succeeds in becoming the owner of the name, and
-    /// another application B later calls [`DBusProxy::request_name`] with the `ReplaceExisting`
+    #[cfg_attr(
+        feature = "proxy",
+        doc = "another application B later calls [`DBusProxy::request_name`] with the"
+    )]
+    #[cfg_attr(
+        not(feature = "proxy"),
+        doc = "another application B later calls `DBusProxy::request_name` with the"
+    )]
+    /// `ReplaceExisting`
     /// flag, then application A will lose ownership and receive a `org.freedesktop.DBus.NameLost`
     /// signal, and application B will become the new owner. If `AllowReplacement` is not specified
     /// by application A, or `ReplaceExisting` is not specified by application B, then application
@@ -50,7 +70,14 @@ pub enum RequestNameFlags {
     DoNotQueue = 0x04,
 }
 
-/// The return code of the [`DBusProxy::request_name`] method.
+#[cfg_attr(
+    feature = "proxy",
+    doc = "The return code of the [`DBusProxy::request_name`] method."
+)]
+#[cfg_attr(
+    not(feature = "proxy"),
+    doc = "The return code of `DBusProxy::request_name` (requires the `proxy` feature)."
+)]
 #[repr(u32)]
 #[derive(Deserialize_repr, Serialize_repr, Type, Debug, PartialEq, Eq)]
 pub enum RequestNameReply {
@@ -81,7 +108,14 @@ impl std::fmt::Display for RequestNameReply {
     }
 }
 
-/// The return code of the [`DBusProxy::release_name`] method.
+#[cfg_attr(
+    feature = "proxy",
+    doc = "The return code of the [`DBusProxy::release_name`] method."
+)]
+#[cfg_attr(
+    not(feature = "proxy"),
+    doc = "The return code of `DBusProxy::release_name` (requires the `proxy` feature)."
+)]
 #[repr(u32)]
 #[derive(Deserialize_repr, Serialize_repr, Type, Debug, PartialEq, Eq)]
 pub enum ReleaseNameReply {
@@ -107,7 +141,14 @@ impl std::fmt::Display for ReleaseNameReply {
     }
 }
 
-/// The return code of the [`DBusProxy::start_service_by_name`] method.
+#[cfg_attr(
+    feature = "proxy",
+    doc = "The return code of the [`DBusProxy::start_service_by_name`] method."
+)]
+#[cfg_attr(
+    not(feature = "proxy"),
+    doc = "The return code of `DBusProxy::start_service_by_name` (requires the `proxy` feature)."
+)]
 ///
 /// In zbus 6.0, this will become the return type of `start_service_by_name`.
 /// For now, it's provided separately with a `TryFrom<u32>` implementation
@@ -313,6 +354,7 @@ impl ConnectionCredentials {
 }
 
 /// Proxy for the `org.freedesktop.DBus` interface.
+#[cfg(feature = "proxy")]
 #[proxy(
     default_service = "org.freedesktop.DBus",
     default_path = "/org/freedesktop/DBus",
@@ -425,7 +467,7 @@ pub trait DBus {
     fn interfaces(&self) -> Result<Vec<OwnedInterfaceName>>;
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "proxy"))]
 mod test {
     use super::*;
 

--- a/zbus/src/fdo/introspectable.rs
+++ b/zbus/src/fdo/introspectable.rs
@@ -3,14 +3,19 @@
 //! The D-Bus specification defines the message bus messages and some standard interfaces that may
 //! be useful across various D-Bus applications. This module provides their proxy.
 
-use super::{Error, Result};
+#[cfg(feature = "service")]
+use super::Error;
+use super::Result;
+#[cfg(feature = "service")]
 use crate::{ObjectServer, interface, message::Header};
 
 /// Service-side implementation for the `org.freedesktop.DBus.Introspectable` interface.
 /// This interface is implemented automatically for any object registered to the
 /// [ObjectServer](crate::ObjectServer).
+#[cfg(feature = "service")]
 pub(crate) struct Introspectable;
 
+#[cfg(feature = "service")]
 #[interface(
     name = "org.freedesktop.DBus.Introspectable",
     introspection_docs = false

--- a/zbus/src/fdo/introspectable.rs
+++ b/zbus/src/fdo/introspectable.rs
@@ -13,8 +13,7 @@ pub(crate) struct Introspectable;
 
 #[interface(
     name = "org.freedesktop.DBus.Introspectable",
-    introspection_docs = false,
-    proxy(default_path = "/", visibility = "pub")
+    introspection_docs = false
 )]
 impl Introspectable {
     /// Returns an XML description of the object, including its interfaces (with signals and
@@ -32,4 +31,12 @@ impl Introspectable {
 
         Ok(node.introspect().await)
     }
+}
+
+/// Proxy for the `org.freedesktop.DBus.Introspectable` interface.
+#[crate::proxy(interface = "org.freedesktop.DBus.Introspectable", default_path = "/")]
+pub trait Introspectable {
+    /// Returns an XML description of the object, including its interfaces (with signals and
+    /// methods), objects below it in the object path tree, and its properties.
+    fn introspect(&self) -> Result<String>;
 }

--- a/zbus/src/fdo/introspectable.rs
+++ b/zbus/src/fdo/introspectable.rs
@@ -34,6 +34,7 @@ impl Introspectable {
 }
 
 /// Proxy for the `org.freedesktop.DBus.Introspectable` interface.
+#[cfg(feature = "proxy")]
 #[crate::proxy(interface = "org.freedesktop.DBus.Introspectable", default_path = "/")]
 pub trait Introspectable {
     /// Returns an XML description of the object, including its interfaces (with signals and

--- a/zbus/src/fdo/mod.rs
+++ b/zbus/src/fdo/mod.rs
@@ -11,7 +11,9 @@ pub use dbus::{
     NameLostStream, NameOwnerChanged, NameOwnerChangedArgs, NameOwnerChangedStream,
 };
 
+#[cfg(any(feature = "proxy", feature = "service"))]
 pub(crate) mod introspectable;
+#[cfg(feature = "service")]
 pub(crate) use introspectable::Introspectable;
 #[cfg(feature = "proxy")]
 pub use introspectable::IntrospectableProxy;
@@ -22,19 +24,25 @@ pub(crate) mod monitoring;
 pub use monitoring::MonitoringProxy;
 
 pub(crate) mod object_manager;
+pub use object_manager::ManagedObjects;
+#[cfg(feature = "service")]
+pub use object_manager::ObjectManager;
 #[cfg(feature = "proxy")]
 pub use object_manager::{
     InterfacesAdded, InterfacesAddedArgs, InterfacesAddedStream, InterfacesRemoved,
     InterfacesRemovedArgs, InterfacesRemovedStream, ObjectManagerProxy,
 };
-pub use object_manager::{ManagedObjects, ObjectManager};
 
+#[cfg(any(feature = "proxy", feature = "service"))]
 pub(crate) mod peer;
+#[cfg(feature = "service")]
 pub(crate) use peer::Peer;
 #[cfg(feature = "proxy")]
 pub use peer::PeerProxy;
 
+#[cfg(any(feature = "proxy", feature = "service"))]
 pub(crate) mod properties;
+#[cfg(feature = "service")]
 pub use properties::Properties;
 #[cfg(feature = "proxy")]
 pub use properties::{
@@ -46,7 +54,7 @@ pub(crate) mod stats;
 #[cfg(feature = "proxy")]
 pub use stats::StatsProxy;
 
-#[cfg(all(test, feature = "proxy"))]
+#[cfg(all(test, feature = "proxy", feature = "service"))]
 mod tests {
     use crate::{DBusError, Error, fdo, interface, message::Message, names::WellKnownName};
     use futures_util::StreamExt;

--- a/zbus/src/fdo/mod.rs
+++ b/zbus/src/fdo/mod.rs
@@ -3,38 +3,50 @@ pub use error::{Error, Result};
 
 pub(crate) mod dbus;
 pub use dbus::{
-    ConnectionCredentials, DBusProxy, NameAcquired, NameAcquiredArgs, NameAcquiredStream, NameLost,
-    NameLostArgs, NameLostStream, NameOwnerChanged, NameOwnerChangedArgs, NameOwnerChangedStream,
-    ReleaseNameReply, RequestNameFlags, RequestNameReply, StartServiceReply,
+    ConnectionCredentials, ReleaseNameReply, RequestNameFlags, RequestNameReply, StartServiceReply,
+};
+#[cfg(feature = "proxy")]
+pub use dbus::{
+    DBusProxy, NameAcquired, NameAcquiredArgs, NameAcquiredStream, NameLost, NameLostArgs,
+    NameLostStream, NameOwnerChanged, NameOwnerChangedArgs, NameOwnerChangedStream,
 };
 
 pub(crate) mod introspectable;
 pub(crate) use introspectable::Introspectable;
+#[cfg(feature = "proxy")]
 pub use introspectable::IntrospectableProxy;
 
+#[cfg(feature = "proxy")]
 pub(crate) mod monitoring;
+#[cfg(feature = "proxy")]
 pub use monitoring::MonitoringProxy;
 
 pub(crate) mod object_manager;
+#[cfg(feature = "proxy")]
 pub use object_manager::{
     InterfacesAdded, InterfacesAddedArgs, InterfacesAddedStream, InterfacesRemoved,
-    InterfacesRemovedArgs, InterfacesRemovedStream, ManagedObjects, ObjectManager,
-    ObjectManagerProxy,
+    InterfacesRemovedArgs, InterfacesRemovedStream, ObjectManagerProxy,
 };
+pub use object_manager::{ManagedObjects, ObjectManager};
 
 pub(crate) mod peer;
 pub(crate) use peer::Peer;
+#[cfg(feature = "proxy")]
 pub use peer::PeerProxy;
 
 pub(crate) mod properties;
+pub use properties::Properties;
+#[cfg(feature = "proxy")]
 pub use properties::{
-    Properties, PropertiesChanged, PropertiesChangedArgs, PropertiesChangedStream, PropertiesProxy,
+    PropertiesChanged, PropertiesChangedArgs, PropertiesChangedStream, PropertiesProxy,
 };
 
+#[cfg(feature = "proxy")]
 pub(crate) mod stats;
+#[cfg(feature = "proxy")]
 pub use stats::StatsProxy;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "proxy"))]
 mod tests {
     use crate::{DBusError, Error, fdo, interface, message::Message, names::WellKnownName};
     use futures_util::StreamExt;

--- a/zbus/src/fdo/object_manager.rs
+++ b/zbus/src/fdo/object_manager.rs
@@ -17,7 +17,15 @@ use crate::{
     wire::{ObjectPath, OwnedObjectPath, OwnedValue, Value},
 };
 
-/// The type returned by the [`ObjectManagerProxy::get_managed_objects`] method.
+#[cfg_attr(
+    feature = "proxy",
+    doc = "The type returned by the [`ObjectManagerProxy::get_managed_objects`] method."
+)]
+#[cfg_attr(
+    not(feature = "proxy"),
+    doc = "The type returned by `ObjectManagerProxy::get_managed_objects` (requires the `proxy`",
+    doc = "feature)."
+)]
 pub type ManagedObjects =
     HashMap<OwnedObjectPath, BTreeMap<OwnedInterfaceName, HashMap<String, OwnedValue>>>;
 
@@ -133,6 +141,7 @@ impl ObjectManager {
 }
 
 /// Proxy for the `org.freedesktop.DBus.ObjectManager` interface.
+#[cfg(feature = "proxy")]
 #[crate::proxy(interface = "org.freedesktop.DBus.ObjectManager")]
 pub trait ObjectManager {
     /// The return value of this method is a dict whose keys are object paths. All returned object

--- a/zbus/src/fdo/object_manager.rs
+++ b/zbus/src/fdo/object_manager.rs
@@ -3,18 +3,24 @@
 //! The D-Bus specification defines the message bus messages and some standard interfaces that may
 //! be useful across various D-Bus applications. This module provides their proxy.
 
-use std::{
-    borrow::Cow,
-    collections::{BTreeMap, HashMap},
-};
+#[cfg(any(feature = "proxy", feature = "service"))]
+use std::borrow::Cow;
+use std::collections::{BTreeMap, HashMap};
 
-use super::{Error, Result};
+#[cfg(feature = "service")]
+use super::Error;
+#[cfg(any(feature = "proxy", feature = "service"))]
+use super::Result;
+#[cfg(feature = "service")]
+use crate::{Connection, ObjectServer, interface, message::Header, object_server::SignalEmitter};
+#[cfg(any(feature = "proxy", feature = "service"))]
 use crate::{
-    Connection, ObjectServer, interface,
-    message::Header,
-    names::{InterfaceName, OwnedInterfaceName},
-    object_server::SignalEmitter,
-    wire::{ObjectPath, OwnedObjectPath, OwnedValue, Value},
+    names::InterfaceName,
+    wire::{ObjectPath, Value},
+};
+use crate::{
+    names::OwnedInterfaceName,
+    wire::{OwnedObjectPath, OwnedValue},
 };
 
 #[cfg_attr(
@@ -89,9 +95,11 @@ pub type ManagedObjects =
 /// ```
 ///
 /// [om]: https://dbus.freedesktop.org/doc/dbus-specification.html#standard-interfaces-objectmanager
+#[cfg(feature = "service")]
 #[derive(Debug, Clone)]
 pub struct ObjectManager;
 
+#[cfg(feature = "service")]
 #[interface(
     name = "org.freedesktop.DBus.ObjectManager",
     introspection_docs = false

--- a/zbus/src/fdo/object_manager.rs
+++ b/zbus/src/fdo/object_manager.rs
@@ -86,8 +86,7 @@ pub struct ObjectManager;
 
 #[interface(
     name = "org.freedesktop.DBus.ObjectManager",
-    introspection_docs = false,
-    proxy(visibility = "pub")
+    introspection_docs = false
 )]
 impl ObjectManager {
     /// The return value of this method is a dict whose keys are object paths. All returned object
@@ -128,6 +127,39 @@ impl ObjectManager {
     #[zbus(signal)]
     pub async fn interfaces_removed(
         emitter: &SignalEmitter<'_>,
+        object_path: ObjectPath<'_>,
+        interfaces: Cow<'_, [InterfaceName<'_>]>,
+    ) -> zbus::Result<()>;
+}
+
+/// Proxy for the `org.freedesktop.DBus.ObjectManager` interface.
+#[crate::proxy(interface = "org.freedesktop.DBus.ObjectManager")]
+pub trait ObjectManager {
+    /// The return value of this method is a dict whose keys are object paths. All returned object
+    /// paths are children of the object path implementing this interface, i.e. their object paths
+    /// start with the ObjectManager's object path plus '/'.
+    ///
+    /// Each value is a dict whose keys are interfaces names. Each value in this inner dict is the
+    /// same dict that would be returned by the org.freedesktop.DBus.Properties.GetAll() method for
+    /// that combination of object path and interface. If an interface has no properties, the empty
+    /// dict is returned.
+    fn get_managed_objects(&self) -> Result<ManagedObjects>;
+
+    /// This signal is emitted when either a new object is added or when an existing object gains
+    /// one or more interfaces. The `interfaces_and_properties` argument contains a map with the
+    /// interfaces and properties (if any) that have been added to the given object path.
+    #[zbus(signal)]
+    fn interfaces_added(
+        &self,
+        object_path: ObjectPath<'_>,
+        interfaces_and_properties: HashMap<InterfaceName<'_>, HashMap<&str, Value<'_>>>,
+    ) -> zbus::Result<()>;
+
+    /// This signal is emitted whenever an object is removed or it loses one or more interfaces.
+    /// The `interfaces` parameters contains a list of the interfaces that were removed.
+    #[zbus(signal)]
+    fn interfaces_removed(
+        &self,
         object_path: ObjectPath<'_>,
         interfaces: Cow<'_, [InterfaceName<'_>]>,
     ) -> zbus::Result<()>;

--- a/zbus/src/fdo/peer.rs
+++ b/zbus/src/fdo/peer.rs
@@ -10,11 +10,7 @@ pub(crate) struct Peer;
 /// Service-side implementation for the `org.freedesktop.DBus.Peer` interface.
 /// This interface is implemented automatically for any object registered to the
 /// [ObjectServer](crate::ObjectServer).
-#[crate::interface(
-    name = "org.freedesktop.DBus.Peer",
-    introspection_docs = false,
-    proxy(visibility = "pub")
-)]
+#[crate::interface(name = "org.freedesktop.DBus.Peer", introspection_docs = false)]
 impl Peer {
     /// On receipt, an application should do nothing other than reply as usual. It does not matter
     /// which object path a ping is sent to.
@@ -46,6 +42,28 @@ impl Peer {
 
         get_platform_machine_id()
     }
+}
+
+/// Proxy for the `org.freedesktop.DBus.Peer` interface.
+#[crate::proxy(interface = "org.freedesktop.DBus.Peer")]
+pub trait Peer {
+    /// On receipt, an application should do nothing other than reply as usual. It does not matter
+    /// which object path a ping is sent to.
+    fn ping(&self) -> zbus::Result<()>;
+
+    /// An application should reply the containing a hex-encoded UUID representing the identity of
+    /// the machine the process is running on. This UUID must be the same for all processes on a
+    /// single system at least until that system next reboots. It should be the same across reboots
+    /// if possible, but this is not always possible to implement and is not guaranteed. It does not
+    /// matter which object path a GetMachineId is sent to.
+    ///
+    /// This method is implemented for:
+    /// - Linux: Reads from `/var/lib/dbus/machine-id` or `/etc/machine-id`
+    /// - macOS: Uses `gethostuuid()` system call
+    /// - FreeBSD/DragonFlyBSD: Reads from standard D-Bus locations, falls back to `kern.hostuuid`
+    /// - OpenBSD/NetBSD: Reads from standard D-Bus locations (`/var/db/dbus/machine-id`, etc.)
+    /// - Windows: Uses Windows hardware profile GUID
+    fn get_machine_id(&self) -> Result<String>;
 }
 
 #[cfg(target_os = "linux")]

--- a/zbus/src/fdo/peer.rs
+++ b/zbus/src/fdo/peer.rs
@@ -3,13 +3,17 @@
 //! The D-Bus specification defines the message bus messages and some standard interfaces that may
 //! be useful across various D-Bus applications. This module provides their proxy.
 
-use super::{Error, Result};
+#[cfg(feature = "service")]
+use super::Error;
+use super::Result;
 
+#[cfg(feature = "service")]
 pub(crate) struct Peer;
 
 /// Service-side implementation for the `org.freedesktop.DBus.Peer` interface.
 /// This interface is implemented automatically for any object registered to the
 /// [ObjectServer](crate::ObjectServer).
+#[cfg(feature = "service")]
 #[crate::interface(name = "org.freedesktop.DBus.Peer", introspection_docs = false)]
 impl Peer {
     /// On receipt, an application should do nothing other than reply as usual. It does not matter
@@ -67,6 +71,7 @@ pub trait Peer {
     fn get_machine_id(&self) -> Result<String>;
 }
 
+#[cfg(feature = "service")]
 #[cfg(target_os = "linux")]
 fn get_platform_machine_id() -> Result<String> {
     let mut id = match std::fs::read_to_string("/var/lib/dbus/machine-id") {
@@ -87,6 +92,7 @@ fn get_platform_machine_id() -> Result<String> {
     Ok(id)
 }
 
+#[cfg(feature = "service")]
 #[cfg(target_os = "macos")]
 fn get_platform_machine_id() -> Result<String> {
     unsafe extern "C" {
@@ -112,6 +118,7 @@ fn get_platform_machine_id() -> Result<String> {
 
 /// Get the machine ID on FreeBSD or DragonFlyBSD using the kern.hostuuid sysctl.
 /// This returns a UUID that is typically generated at install time and persists across reboots.
+#[cfg(feature = "service")]
 #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
 fn get_platform_machine_id() -> Result<String> {
     use std::ffi::CStr;
@@ -159,6 +166,7 @@ fn get_platform_machine_id() -> Result<String> {
 /// Try to read machine ID from standard D-Bus locations.
 /// Used on *BSD platforms as the primary method before falling back to platform-specific
 /// mechanisms.
+#[cfg(feature = "service")]
 #[cfg(any(
     target_os = "freebsd",
     target_os = "dragonfly",
@@ -184,6 +192,7 @@ fn read_dbus_machine_id() -> Option<String> {
     None
 }
 
+#[cfg(feature = "service")]
 #[cfg(any(target_os = "openbsd", target_os = "netbsd"))]
 fn get_platform_machine_id() -> Result<String> {
     // OpenBSD and NetBSD don't have a built-in machine UUID mechanism.
@@ -196,6 +205,7 @@ fn get_platform_machine_id() -> Result<String> {
 }
 
 /// Fallback for other Unix platforms not explicitly supported.
+#[cfg(feature = "service")]
 #[cfg(all(
     unix,
     not(any(
@@ -213,12 +223,13 @@ fn get_platform_machine_id() -> Result<String> {
     ))
 }
 
+#[cfg(feature = "service")]
 #[cfg(windows)]
 fn get_platform_machine_id() -> Result<String> {
     crate::win32::machine_id().map_err(|e| Error::IOError(e.to_string()))
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "service"))]
 mod tests {
     #[allow(unused)]
     use super::*;

--- a/zbus/src/fdo/peer.rs
+++ b/zbus/src/fdo/peer.rs
@@ -45,6 +45,7 @@ impl Peer {
 }
 
 /// Proxy for the `org.freedesktop.DBus.Peer` interface.
+#[cfg(feature = "proxy")]
 #[crate::proxy(interface = "org.freedesktop.DBus.Peer")]
 pub trait Peer {
     /// On receipt, an application should do nothing other than reply as usual. It does not matter

--- a/zbus/src/fdo/properties.rs
+++ b/zbus/src/fdo/properties.rs
@@ -5,20 +5,23 @@
 
 use std::{borrow::Cow, collections::HashMap};
 
-use super::{Error, Result};
+#[cfg(feature = "service")]
+use super::Error;
+use super::Result;
+#[cfg(feature = "service")]
+use crate::{Connection, ObjectServer, interface, message::Header, object_server::SignalEmitter};
 use crate::{
-    Connection, ObjectServer, interface,
-    message::Header,
     names::InterfaceName,
-    object_server::SignalEmitter,
     wire::{OwnedValue, Value},
 };
 
 /// Service-side implementation for the `org.freedesktop.DBus.Properties` interface.
 /// This interface is implemented automatically for any object registered to the
 /// [ObjectServer].
+#[cfg(feature = "service")]
 pub struct Properties;
 
+#[cfg(feature = "service")]
 #[interface(name = "org.freedesktop.DBus.Properties", introspection_docs = false)]
 impl Properties {
     /// Get a property value.

--- a/zbus/src/fdo/properties.rs
+++ b/zbus/src/fdo/properties.rs
@@ -19,11 +19,7 @@ use crate::{
 /// [ObjectServer].
 pub struct Properties;
 
-#[interface(
-    name = "org.freedesktop.DBus.Properties",
-    introspection_docs = false,
-    proxy(visibility = "pub")
-)]
+#[interface(name = "org.freedesktop.DBus.Properties", introspection_docs = false)]
 impl Properties {
     /// Get a property value.
     async fn get(
@@ -148,6 +144,33 @@ impl Properties {
     #[rustfmt::skip]
     pub async fn properties_changed(
         emitter: &SignalEmitter<'_>,
+        interface_name: InterfaceName<'_>,
+        changed_properties: HashMap<&str, Value<'_>>,
+        invalidated_properties: Cow<'_, [&str]>,
+    ) -> zbus::Result<()>;
+}
+
+/// Proxy for the `org.freedesktop.DBus.Properties` interface.
+#[crate::proxy(interface = "org.freedesktop.DBus.Properties")]
+pub trait Properties {
+    /// Get a property value.
+    fn get(&self, interface_name: InterfaceName<'_>, property_name: &str) -> Result<OwnedValue>;
+
+    /// Set a property value.
+    fn set(
+        &self,
+        interface_name: InterfaceName<'_>,
+        property_name: &str,
+        value: &Value<'_>,
+    ) -> Result<()>;
+
+    /// Get all properties.
+    fn get_all(&self, interface_name: InterfaceName<'_>) -> Result<HashMap<String, OwnedValue>>;
+
+    /// Emit the `org.freedesktop.DBus.Properties.PropertiesChanged` signal.
+    #[zbus(signal)]
+    fn properties_changed(
+        &self,
         interface_name: InterfaceName<'_>,
         changed_properties: HashMap<&str, Value<'_>>,
         invalidated_properties: Cow<'_, [&str]>,

--- a/zbus/src/fdo/properties.rs
+++ b/zbus/src/fdo/properties.rs
@@ -151,6 +151,7 @@ impl Properties {
 }
 
 /// Proxy for the `org.freedesktop.DBus.Properties` interface.
+#[cfg(feature = "proxy")]
 #[crate::proxy(interface = "org.freedesktop.DBus.Properties")]
 pub trait Properties {
     /// Get a property value.

--- a/zbus/src/lib.rs
+++ b/zbus/src/lib.rs
@@ -3,9 +3,16 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/z-galaxy/zbus/9f7a90d2b594ddc48b7a5f39fda5e00cd56a7dfb/logo.png"
 )]
-// The README's examples need a D-Bus connection, so it can only be the crate documentation
-// when the D-Bus API is compiled in.
-#![cfg_attr(feature = "comms", doc = include_str!("../README.md"))]
+// The README's examples need a D-Bus connection and a proxy, so it can only be the crate
+// documentation when the client-side D-Bus API is compiled in.
+#![cfg_attr(feature = "proxy", doc = include_str!("../README.md"))]
+#![cfg_attr(
+    all(feature = "comms", not(feature = "proxy")),
+    doc = "# zbus",
+    doc = "",
+    doc = "This build has the client-side D-Bus API (the `proxy` feature) disabled. See the",
+    doc = "[README](https://github.com/z-galaxy/zbus#readme) for an overview of the crate."
+)]
 #![cfg_attr(
     not(feature = "comms"),
     doc = "# zbus\n\nThis build has the D-Bus API (the `comms` feature) disabled: only the \
@@ -25,8 +32,10 @@
 #[cfg(all(doctest, feature = "comms"))]
 mod doctests {
     // Repo README.
+    #[cfg(feature = "proxy")]
     doc_comment::doctest!("../../README.md");
     // Book markdown checks
+    #[cfg(feature = "proxy")]
     doc_comment::doctest!("../../book/src/client.md");
     doc_comment::doctest!("../../book/src/concepts.md");
     // The connection chapter contains a p2p example.
@@ -34,10 +43,13 @@ mod doctests {
     doc_comment::doctest!("../../book/src/connection.md");
     doc_comment::doctest!("../../book/src/contributors.md");
     doc_comment::doctest!("../../book/src/introduction.md");
+    #[cfg(feature = "proxy")]
     doc_comment::doctest!("../../book/src/service.md");
-    #[cfg(feature = "blocking-api")]
+    #[cfg(all(feature = "blocking-api", feature = "proxy"))]
     doc_comment::doctest!("../../book/src/blocking.md");
+    #[cfg(feature = "proxy")]
     doc_comment::doctest!("../../book/src/upgrading-to-6.md");
+    #[cfg(feature = "proxy")]
     doc_comment::doctest!("../../book/src/faq.md");
 }
 
@@ -115,9 +127,9 @@ pub mod match_rule;
 #[cfg(feature = "comms")]
 pub use match_rule::{MatchRule, OwnedMatchRule};
 
-#[cfg(feature = "comms")]
+#[cfg(feature = "proxy")]
 pub mod proxy;
-#[cfg(feature = "comms")]
+#[cfg(feature = "proxy")]
 pub use proxy::Proxy;
 
 #[cfg(feature = "comms")]
@@ -137,13 +149,15 @@ pub mod fdo;
 #[cfg(feature = "blocking-api")]
 pub mod blocking;
 
+#[cfg(feature = "proxy")]
+pub use zbus_macros::proxy;
 #[cfg(feature = "comms")]
-pub use zbus_macros::{DBusError, interface, proxy};
+pub use zbus_macros::{DBusError, interface};
 
-// The `proxy` macro emits the blocking proxy through this macro, so that whether it is generated
-// follows the `blocking-api` feature of the `zbus` the generated code is compiled against. The
-// features of `zbus_macros` can differ from it: Cargo unifies the features of host dependencies,
-// such as proc-macros and build scripts, separately from the target ones.
+// The macros emit feature-dependent code through these macros, so that the decision follows the
+// features of the `zbus` the generated code is compiled against. The features of `zbus_macros`
+// can differ from them: Cargo unifies the features of host dependencies, such as proc-macros and
+// build scripts, separately from the target ones.
 #[cfg(feature = "blocking-api")]
 #[doc(hidden)]
 #[macro_export]
@@ -154,6 +168,18 @@ macro_rules! __if_blocking_api_feature {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __if_blocking_api_feature {
+    ($($item:tt)*) => {};
+}
+#[cfg(feature = "proxy")]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __if_proxy_feature {
+    ($($item:tt)*) => { $($item)* };
+}
+#[cfg(not(feature = "proxy"))]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __if_proxy_feature {
     ($($item:tt)*) => {};
 }
 

--- a/zbus/src/lib.rs
+++ b/zbus/src/lib.rs
@@ -3,15 +3,16 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/z-galaxy/zbus/9f7a90d2b594ddc48b7a5f39fda5e00cd56a7dfb/logo.png"
 )]
-// The README's examples need a D-Bus connection and a proxy, so it can only be the crate
-// documentation when the client-side D-Bus API is compiled in.
-#![cfg_attr(feature = "proxy", doc = include_str!("../README.md"))]
+// The README's examples need a D-Bus connection, a proxy and an object server, so it can only be
+// the crate documentation when all of the D-Bus API is compiled in.
+#![cfg_attr(all(feature = "proxy", feature = "service"), doc = include_str!("../README.md"))]
 #![cfg_attr(
-    all(feature = "comms", not(feature = "proxy")),
+    all(feature = "comms", not(all(feature = "proxy", feature = "service"))),
     doc = "# zbus",
     doc = "",
-    doc = "This build has the client-side D-Bus API (the `proxy` feature) disabled. See the",
-    doc = "[README](https://github.com/z-galaxy/zbus#readme) for an overview of the crate."
+    doc = "This build has the client-side (the `proxy` feature) or the service-side (the `service`",
+    doc = "feature) D-Bus API disabled. See the [README](https://github.com/z-galaxy/zbus#readme)",
+    doc = "for an overview of the crate."
 )]
 #![cfg_attr(
     not(feature = "comms"),
@@ -32,7 +33,7 @@
 #[cfg(all(doctest, feature = "comms"))]
 mod doctests {
     // Repo README.
-    #[cfg(feature = "proxy")]
+    #[cfg(all(feature = "proxy", feature = "service"))]
     doc_comment::doctest!("../../README.md");
     // Book markdown checks
     #[cfg(feature = "proxy")]
@@ -43,13 +44,13 @@ mod doctests {
     doc_comment::doctest!("../../book/src/connection.md");
     doc_comment::doctest!("../../book/src/contributors.md");
     doc_comment::doctest!("../../book/src/introduction.md");
-    #[cfg(feature = "proxy")]
+    #[cfg(all(feature = "proxy", feature = "service"))]
     doc_comment::doctest!("../../book/src/service.md");
-    #[cfg(all(feature = "blocking-api", feature = "proxy"))]
+    #[cfg(all(feature = "blocking-api", feature = "proxy", feature = "service"))]
     doc_comment::doctest!("../../book/src/blocking.md");
-    #[cfg(feature = "proxy")]
+    #[cfg(all(feature = "proxy", feature = "service"))]
     doc_comment::doctest!("../../book/src/upgrading-to-6.md");
-    #[cfg(feature = "proxy")]
+    #[cfg(all(feature = "proxy", feature = "service"))]
     doc_comment::doctest!("../../book/src/faq.md");
 }
 
@@ -132,9 +133,9 @@ pub mod proxy;
 #[cfg(feature = "proxy")]
 pub use proxy::Proxy;
 
-#[cfg(feature = "comms")]
+#[cfg(feature = "service")]
 pub mod object_server;
-#[cfg(feature = "comms")]
+#[cfg(feature = "service")]
 pub use object_server::ObjectServer;
 
 #[cfg(feature = "comms")]
@@ -149,10 +150,12 @@ pub mod fdo;
 #[cfg(feature = "blocking-api")]
 pub mod blocking;
 
+#[cfg(feature = "comms")]
+pub use zbus_macros::DBusError;
+#[cfg(feature = "service")]
+pub use zbus_macros::interface;
 #[cfg(feature = "proxy")]
 pub use zbus_macros::proxy;
-#[cfg(feature = "comms")]
-pub use zbus_macros::{DBusError, interface};
 
 // The macros emit feature-dependent code through these macros, so that the decision follows the
 // features of the `zbus` the generated code is compiled against. The features of `zbus_macros`

--- a/zbus/src/lib.rs
+++ b/zbus/src/lib.rs
@@ -140,6 +140,23 @@ pub mod blocking;
 #[cfg(feature = "comms")]
 pub use zbus_macros::{DBusError, interface, proxy};
 
+// The `proxy` macro emits the blocking proxy through this macro, so that whether it is generated
+// follows the `blocking-api` feature of the `zbus` the generated code is compiled against. The
+// features of `zbus_macros` can differ from it: Cargo unifies the features of host dependencies,
+// such as proc-macros and build scripts, separately from the target ones.
+#[cfg(feature = "blocking-api")]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __if_blocking_api_feature {
+    ($($item:tt)*) => { $($item)* };
+}
+#[cfg(not(feature = "blocking-api"))]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __if_blocking_api_feature {
+    ($($item:tt)*) => {};
+}
+
 // Required for the macros to function within this crate.
 extern crate self as zbus;
 

--- a/zbus/src/message_stream.rs
+++ b/zbus/src/message_stream.rs
@@ -53,10 +53,15 @@ impl MessageStream {
     /// # Example
     ///
     /// ```
+    /// # // The example decodes the signal with the `NameOwnerChanged` type of the `DBusProxy`.
+    /// # #[cfg(feature = "proxy")]
     /// use async_io::Timer;
+    /// # #[cfg(feature = "proxy")]
     /// use zbus::{AsyncDrop, Connection, MatchRule, MessageStream, fdo::NameOwnerChanged};
+    /// # #[cfg(feature = "proxy")]
     /// use futures_util::{TryStreamExt, future::select, future::Either::{Left, Right}, pin_mut};
     ///
+    /// # #[cfg(feature = "proxy")]
     /// # zbus::block_on(async {
     /// let conn = Connection::session().await?;
     /// let rule = MatchRule::builder()

--- a/zbus/src/object_server/interface/mod.rs
+++ b/zbus/src/object_server/interface/mod.rs
@@ -31,7 +31,14 @@ use crate::{
 /// this trait. The [`crate::interface`] macro implements it for you.
 ///
 /// If you have an advanced use case where `interface` is inadequate, consider using
-/// [`crate::MessageStream`] or [`crate::blocking::MessageIterator`] instead.
+#[cfg_attr(
+    feature = "blocking-api",
+    doc = "[`crate::MessageStream`] or [`crate::blocking::MessageIterator`] instead."
+)]
+#[cfg_attr(
+    not(feature = "blocking-api"),
+    doc = "[`crate::MessageStream`] instead."
+)]
 #[async_trait]
 pub trait Interface: Any + Send + Sync {
     /// Return the name of the interface. Ex: "org.foo.MyInterface"

--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -1381,7 +1381,7 @@ enum Either<L, R> {
     Right(R),
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "service"))]
 mod tests {
     use super::*;
     use crate::{connection, interface, object_server::SignalEmitter, proxy, utils::block_on};

--- a/zbus/src/win32.rs
+++ b/zbus/src/win32.rs
@@ -9,6 +9,8 @@ use std::{
     ptr,
 };
 
+#[cfg(feature = "service")]
+use windows_sys::Win32::System::WindowsProgramming::{GetCurrentHwProfileA, HW_PROFILE_INFOA};
 use windows_sys::Win32::{
     Foundation::{
         ERROR_INSUFFICIENT_BUFFER, FALSE, HANDLE, LocalFree, NO_ERROR, WAIT_ABANDONED,
@@ -27,7 +29,6 @@ use windows_sys::Win32::{
             PROCESS_ACCESS_RIGHTS, PROCESS_QUERY_LIMITED_INFORMATION, ReleaseMutex,
             WaitForSingleObject,
         },
-        WindowsProgramming::{GetCurrentHwProfileA, HW_PROFILE_INFOA},
     },
 };
 
@@ -320,6 +321,7 @@ pub fn autolaunch_bus_address() -> Result<Address, crate::Error> {
 /// Get the machine ID using the hardware profile GUID.
 ///
 /// As per the D-Bus specification, on Windows we use the `GetCurrentHwProfile` API.
+#[cfg(feature = "service")]
 pub fn machine_id() -> Result<String, Error> {
     let mut hw_profile: HW_PROFILE_INFOA = unsafe { std::mem::zeroed() };
 
@@ -353,6 +355,7 @@ mod tests {
         assert!(!sid.is_empty());
     }
 
+    #[cfg(feature = "service")]
     #[test]
     fn machine_id() {
         let id = super::machine_id().expect("machine_id should succeed");

--- a/zbus/tests/basic.rs
+++ b/zbus/tests/basic.rs
@@ -328,7 +328,7 @@ async fn test_freedesktop_api() -> Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, feature = "proxy"))]
 #[tokio::test]
 #[timeout(15000)]
 #[instrument]

--- a/zbus/tests/e2e.rs
+++ b/zbus/tests/e2e.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "proxy")]
+#![cfg(all(feature = "proxy", feature = "service"))]
 #![allow(clippy::disallowed_names)]
 
 mod iface_and_proxy;

--- a/zbus/tests/e2e.rs
+++ b/zbus/tests/e2e.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "comms")]
+#![cfg(feature = "proxy")]
 #![allow(clippy::disallowed_names)]
 
 mod iface_and_proxy;

--- a/zbus/tests/iface_and_proxy/iface.rs
+++ b/zbus/tests/iface_and_proxy/iface.rs
@@ -46,7 +46,7 @@ impl MyIface {
     #[instrument]
     async fn ping(&mut self, #[zbus(signal_emitter)] emitter: SignalEmitter<'_>) -> u32 {
         self.count += 1;
-        if self.count % 3 == 0 {
+        if self.count.is_multiple_of(3) {
             emitter
                 .alert_count(self.count)
                 .await

--- a/zbus/tests/issue/mod.rs
+++ b/zbus/tests/issue/mod.rs
@@ -1,17 +1,17 @@
 #[cfg(unix)]
 mod issue_1003;
-#[cfg(feature = "proxy")]
+#[cfg(all(feature = "proxy", feature = "service"))]
 mod issue_1015;
-#[cfg(feature = "proxy")]
+#[cfg(all(feature = "proxy", feature = "service"))]
 mod issue_104;
 #[cfg(feature = "proxy")]
 mod issue_121;
 #[cfg(feature = "blocking-api")]
 mod issue_122;
 mod issue_1478;
-#[cfg(feature = "proxy")]
+#[cfg(all(feature = "proxy", feature = "service"))]
 mod issue_173;
-#[cfg(feature = "proxy")]
+#[cfg(all(feature = "proxy", feature = "service"))]
 mod issue_1916;
 #[cfg(feature = "proxy")]
 mod issue_260;
@@ -19,7 +19,7 @@ mod issue_260;
 mod issue_466;
 #[cfg(feature = "proxy")]
 mod issue_68;
-#[cfg(feature = "proxy")]
+#[cfg(all(feature = "proxy", feature = "service"))]
 mod issue_799;
 #[cfg(feature = "proxy")]
 mod issue_81;
@@ -27,10 +27,10 @@ mod issue_81;
 // Issues specific to tokio runtime.
 #[cfg(all(unix, feature = "tokio", feature = "p2p"))]
 mod issue_279;
-#[cfg(all(unix, feature = "tokio", feature = "proxy"))]
+#[cfg(all(unix, feature = "tokio", feature = "proxy", feature = "service"))]
 mod issue_310;
-#[cfg(all(unix, feature = "tokio", feature = "proxy"))]
+#[cfg(all(unix, feature = "tokio", feature = "proxy", feature = "service"))]
 mod issue_356;
 
-#[cfg(all(unix, feature = "p2p", feature = "proxy"))]
+#[cfg(all(unix, feature = "p2p", feature = "proxy", feature = "service"))]
 mod issue_813;

--- a/zbus/tests/issue/mod.rs
+++ b/zbus/tests/issue/mod.rs
@@ -1,26 +1,36 @@
 #[cfg(unix)]
 mod issue_1003;
+#[cfg(feature = "proxy")]
 mod issue_1015;
+#[cfg(feature = "proxy")]
 mod issue_104;
+#[cfg(feature = "proxy")]
 mod issue_121;
 #[cfg(feature = "blocking-api")]
 mod issue_122;
 mod issue_1478;
+#[cfg(feature = "proxy")]
 mod issue_173;
+#[cfg(feature = "proxy")]
 mod issue_1916;
+#[cfg(feature = "proxy")]
 mod issue_260;
+#[cfg(feature = "proxy")]
 mod issue_466;
+#[cfg(feature = "proxy")]
 mod issue_68;
+#[cfg(feature = "proxy")]
 mod issue_799;
+#[cfg(feature = "proxy")]
 mod issue_81;
 
 // Issues specific to tokio runtime.
 #[cfg(all(unix, feature = "tokio", feature = "p2p"))]
 mod issue_279;
-#[cfg(all(unix, feature = "tokio"))]
+#[cfg(all(unix, feature = "tokio", feature = "proxy"))]
 mod issue_310;
-#[cfg(all(unix, feature = "tokio"))]
+#[cfg(all(unix, feature = "tokio", feature = "proxy"))]
 mod issue_356;
 
-#[cfg(all(unix, feature = "p2p"))]
+#[cfg(all(unix, feature = "p2p", feature = "proxy"))]
 mod issue_813;

--- a/zbus/tests/uncached_propert.rs
+++ b/zbus/tests/uncached_propert.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "comms")]
+#![cfg(feature = "proxy")]
 
 use ntest::timeout;
 use test_log::test;

--- a/zbus/tests/uncached_propert.rs
+++ b/zbus/tests/uncached_propert.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "proxy")]
+#![cfg(all(feature = "proxy", feature = "service"))]
 
 use ntest::timeout;
 use test_log::test;

--- a/zbus_macros/Cargo.toml
+++ b/zbus_macros/Cargo.toml
@@ -21,8 +21,6 @@ default = ["comms"]
 # The D-Bus macros: `proxy`, `interface` and `DBusError` (default). The wire-format derives are
 # always compiled.
 comms = ["syn/fold"]
-# Enable blocking API. It only makes sense together with the D-Bus macros.
-blocking-api = ["comms"]
 
 [lib]
 proc-macro = true

--- a/zbus_macros/Cargo.toml
+++ b/zbus_macros/Cargo.toml
@@ -17,10 +17,12 @@ categories = ["data-structures", "encoding", "parsing"]
 readme = "README.md"
 
 [features]
-default = ["comms"]
-# The D-Bus macros: `proxy`, `interface` and `DBusError` (default). The wire-format derives are
-# always compiled.
+default = ["comms", "proxy"]
+# The D-Bus macro infrastructure, the `interface` macro and the `DBusError` derive (default). The
+# wire-format derives are always compiled.
 comms = ["syn/fold"]
+# The `proxy` macro and proxy generation from the `interface` macro (default).
+proxy = ["comms"]
 
 [lib]
 proc-macro = true

--- a/zbus_macros/Cargo.toml
+++ b/zbus_macros/Cargo.toml
@@ -17,12 +17,14 @@ categories = ["data-structures", "encoding", "parsing"]
 readme = "README.md"
 
 [features]
-default = ["comms", "proxy"]
-# The D-Bus macro infrastructure, the `interface` macro and the `DBusError` derive (default). The
-# wire-format derives are always compiled.
+default = ["comms", "proxy", "service"]
+# The D-Bus macro infrastructure and the `DBusError` derive (default). The wire-format derives
+# are always compiled.
 comms = ["syn/fold"]
 # The `proxy` macro and proxy generation from the `interface` macro (default).
 proxy = ["comms"]
+# The `interface` macro (default).
+service = ["comms"]
 
 [lib]
 proc-macro = true

--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -338,6 +338,8 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
     };
     let with_spawn = impl_attrs.spawn.unwrap_or(true);
     let crate_attr = impl_attrs.crate_path.clone();
+    // Whether the proxy is actually generated is decided by the `proxy` feature of `zbus`, not by
+    // the features of this crate. See `Proxy::gen`.
     let mut proxy = impl_attrs
         .proxy
         .map(|p| Proxy::new(ty, &iface_name, p, &zbus, crate_attr));
@@ -1690,21 +1692,27 @@ impl Proxy {
             .as_ref()
             .map(|value| quote! { crate = #value, });
         let proxy_doc = format!("Proxy for the `{iface_name}` interface.");
+        // The `proxy` feature of the `zbus` the generated code is compiled against decides whether
+        // the proxy is generated, through a `zbus` macro that either forwards or drops its input.
+        // The `proxy` feature of this crate can differ from it: Cargo unifies the features of host
+        // dependencies, such as proc-macros and build scripts, separately from the target ones.
         Ok(quote! {
-            #[doc = #proxy_doc]
-            #[#zbus::proxy(
-                name = #iface_name,
-                #crate_path
-                #assume_defaults
-                #default_path
-                #default_service
-                #async_name
-                #blocking_name
-                #gen_async
-                #gen_blocking
-            )]
-            #vis trait #ty {
-                #methods
+            #zbus::__if_proxy_feature! {
+                #[doc = #proxy_doc]
+                #[#zbus::proxy(
+                    name = #iface_name,
+                    #crate_path
+                    #assume_defaults
+                    #default_path
+                    #default_service
+                    #async_name
+                    #blocking_name
+                    #gen_async
+                    #gen_blocking
+                )]
+                #vis trait #ty {
+                    #methods
+                }
             }
         })
     }

--- a/zbus_macros/src/lib.rs
+++ b/zbus_macros/src/lib.rs
@@ -13,14 +13,16 @@
 
 use proc_macro::TokenStream;
 use syn::DeriveInput;
+#[cfg(feature = "proxy")]
+use syn::ItemTrait;
 #[cfg(feature = "comms")]
-use syn::{ItemImpl, ItemTrait, Meta, Token, parse_macro_input, punctuated::Punctuated};
+use syn::{ItemImpl, Meta, Token, parse_macro_input, punctuated::Punctuated};
 
 #[cfg(feature = "comms")]
 mod error;
 #[cfg(feature = "comms")]
 mod iface;
-#[cfg(feature = "comms")]
+#[cfg(feature = "proxy")]
 mod proxy;
 mod utils;
 
@@ -213,7 +215,7 @@ mod utils;
 /// [`zbus::blocking::SignalIterator`]: https://docs.rs/zbus/latest/zbus/blocking/proxy/struct.SignalIterator.html
 /// [`ObjectPath`]: https://docs.rs/zbus/latest/zbus/wire/struct.ObjectPath.html
 /// [dbus_emits_changed_signal]: https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format
-#[cfg(feature = "comms")]
+#[cfg(feature = "proxy")]
 #[proc_macro_attribute]
 pub fn proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr with Punctuated<Meta, Token![,]>::parse_terminated);
@@ -249,8 +251,18 @@ pub fn proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     methods when this setting is false, as it may lead to deadlocks under certain conditions.
 ///
 /// * `proxy` - If specified, a proxy type will also be generated for the interface. This attribute
-///   supports all the [`macro@proxy`]-specific sub-attributes (e.g `gen_async`). The common
-///   sub-attributes (e.g `name`) are automatically forwarded to the [`macro@proxy`] macro.
+#[cfg_attr(
+    feature = "proxy",
+    doc = "  supports all the [`macro@proxy`]-specific sub-attributes (e.g `gen_async`). The common",
+    doc = "  sub-attributes (e.g `name`) are automatically forwarded to the [`macro@proxy`] macro."
+)]
+#[cfg_attr(
+    not(feature = "proxy"),
+    doc = "  supports all the `proxy` macro-specific sub-attributes (e.g `gen_async`). The common",
+    doc = "  sub-attributes (e.g `name`) are automatically forwarded to the `proxy` macro."
+)]
+///   If the `proxy` cargo feature of `zbus` is disabled, the attribute is accepted but no proxy
+///   type is generated.
 ///
 /// * `introspection_docs` - whether to include the documentation in the introspection data
 ///   (Default: `true`). If your interface is well-known or well-documented, you may want to set
@@ -289,11 +301,20 @@ pub fn proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// * `out_args` - When returning multiple values from a method, naming the out arguments become
 ///   important. You can use `out_args` to specify their names.
-///
-/// * `proxy` - Use this to specify the [`macro@proxy`]-specific method sub-attributes (e.g
-///   `object`). The common sub-attributes (e.g `name`) are automatically forworded to the
-///   [`macro@proxy`] macro. Moreover, you can use `visibility` sub-attribute to specify the
-///   visibility of the generated proxy type(s).
+#[cfg_attr(
+    feature = "proxy",
+    doc = "* `proxy` - Use this to specify the [`macro@proxy`]-specific method sub-attributes (e.g",
+    doc = "  `object`). The common sub-attributes (e.g `name`) are automatically forworded to the",
+    doc = "  [`macro@proxy`] macro. Moreover, you can use `visibility` sub-attribute to specify the",
+    doc = "  visibility of the generated proxy type(s)."
+)]
+#[cfg_attr(
+    not(feature = "proxy"),
+    doc = "* `proxy` - Use this to specify the `proxy` macro-specific method sub-attributes (e.g",
+    doc = "  `object`). The common sub-attributes (e.g `name`) are automatically forworded to the",
+    doc = "  `proxy` macro. Moreover, you can use `visibility` sub-attribute to specify the",
+    doc = "  visibility of the generated proxy type(s)."
+)]
 ///
 ///   In such case, your method must return a tuple containing
 ///   your out arguments, in the same order as passed to `out_args`.

--- a/zbus_macros/src/lib.rs
+++ b/zbus_macros/src/lib.rs
@@ -45,7 +45,8 @@ mod utils;
 /// * `gen_async` - Whether or not to generate the asynchronous Proxy type.
 ///
 /// * `gen_blocking` - Whether or not to generate the blocking Proxy type. If the `blocking-api`
-///   cargo feature is disabled, this attribute is ignored and blocking Proxy type is not generated.
+///   cargo feature of `zbus` is disabled, this attribute is ignored and blocking Proxy type is not
+///   generated.
 ///
 /// * `async_name` - Specify the exact name of the asynchronous proxy type.
 ///

--- a/zbus_macros/src/lib.rs
+++ b/zbus_macros/src/lib.rs
@@ -13,14 +13,18 @@
 
 use proc_macro::TokenStream;
 use syn::DeriveInput;
+#[cfg(feature = "service")]
+use syn::ItemImpl;
 #[cfg(feature = "proxy")]
 use syn::ItemTrait;
 #[cfg(feature = "comms")]
-use syn::{ItemImpl, Meta, Token, parse_macro_input, punctuated::Punctuated};
+use syn::parse_macro_input;
+#[cfg(any(feature = "proxy", feature = "service"))]
+use syn::{Meta, Token, punctuated::Punctuated};
 
 #[cfg(feature = "comms")]
 mod error;
-#[cfg(feature = "comms")]
+#[cfg(feature = "service")]
 mod iface;
 #[cfg(feature = "proxy")]
 mod proxy;
@@ -417,7 +421,7 @@ pub fn proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// [`SignalEmitter`]: https://docs.rs/zbus/latest/zbus/object_server/struct.SignalEmitter.html
 /// [`Interface`]: https://docs.rs/zbus/latest/zbus/object_server/trait.Interface.html
 /// [dbus_emits_changed_signal]: https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format
-#[cfg(feature = "comms")]
+#[cfg(feature = "service")]
 #[proc_macro_attribute]
 pub fn interface(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr with Punctuated<Meta, Token![,]>::parse_terminated);

--- a/zbus_macros/src/proxy.rs
+++ b/zbus_macros/src/proxy.rs
@@ -77,10 +77,9 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, input: ItemTrait) -> Result<Tok
         )),
     }?;
     let gen_async = attrs.gen_async.unwrap_or(true);
-    #[cfg(feature = "blocking-api")]
+    // Whether the blocking proxy is actually generated is decided by the `blocking-api` feature
+    // of `zbus`, not by the features of this crate. See below.
     let gen_blocking = attrs.gen_blocking.unwrap_or(true);
-    #[cfg(not(feature = "blocking-api"))]
-    let gen_blocking = false;
 
     // Some sanity checks
     assert!(
@@ -105,7 +104,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, input: ItemTrait) -> Result<Tok
                 format!("{}Proxy", input.ident)
             }
         });
-        create_proxy(
+        let blocking_proxy = create_proxy(
             &input,
             iface_name.as_deref(),
             attrs.assume_defaults,
@@ -117,7 +116,19 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, input: ItemTrait) -> Result<Tok
             // async proxy only unless async proxy generation is disabled.
             !gen_async,
             crate_path.as_ref(),
-        )?
+        )?;
+        let zbus = zbus_path(crate_path.as_ref());
+
+        // The `blocking-api` feature of the `zbus` the generated code is compiled against decides
+        // whether the blocking proxy is generated, through a `zbus` macro that either forwards or
+        // drops its input. The `blocking-api` feature of this crate can differ from it: Cargo
+        // unifies the features of host dependencies, such as proc-macros and build scripts,
+        // separately from the target ones.
+        quote! {
+            #zbus::__if_blocking_api_feature! {
+                #blocking_proxy
+            }
+        }
     } else {
         quote! {}
     };

--- a/zbus_macros/src/utils.rs
+++ b/zbus_macros/src/utils.rs
@@ -1,12 +1,14 @@
-#[cfg(feature = "comms")]
+#[cfg(any(feature = "proxy", feature = "service"))]
 use std::fmt::Display;
 
-#[cfg(feature = "comms")]
+#[cfg(any(feature = "proxy", feature = "service"))]
 use proc_macro2::Span;
 use proc_macro2::TokenStream;
 use quote::quote;
-#[cfg(feature = "comms")]
-use syn::{Attribute, FnArg, Ident, Pat, PatIdent, PatType};
+#[cfg(feature = "service")]
+use syn::Attribute;
+#[cfg(any(feature = "proxy", feature = "service"))]
+use syn::{FnArg, Ident, Pat, PatIdent, PatType};
 
 /// Parses the `crate` attribute value into a path.
 #[cfg(feature = "comms")]
@@ -43,7 +45,7 @@ pub fn wire_path() -> TokenStream {
     quote! { #zbus::wire }
 }
 
-#[cfg(feature = "comms")]
+#[cfg(any(feature = "proxy", feature = "service"))]
 pub fn typed_arg(arg: &FnArg) -> Option<&PatType> {
     match arg {
         FnArg::Typed(t) => Some(t),
@@ -51,7 +53,7 @@ pub fn typed_arg(arg: &FnArg) -> Option<&PatType> {
     }
 }
 
-#[cfg(feature = "comms")]
+#[cfg(any(feature = "proxy", feature = "service"))]
 pub fn pat_ident(pat: &PatType) -> Option<&Ident> {
     match &*pat.pat {
         Pat::Ident(PatIdent { ident, .. }) => Some(ident),
@@ -59,14 +61,14 @@ pub fn pat_ident(pat: &PatType) -> Option<&Ident> {
     }
 }
 
-#[cfg(feature = "comms")]
+#[cfg(feature = "service")]
 pub fn get_doc_attrs(attrs: &[Attribute]) -> Vec<&Attribute> {
     attrs.iter().filter(|x| x.path().is_ident("doc")).collect()
 }
 
 // Convert to pascal case, assuming snake case.
 // If `s` is already in pascal case, should yield the same result.
-#[cfg(feature = "comms")]
+#[cfg(feature = "service")]
 pub fn pascal_case(s: &str) -> String {
     let mut pascal = String::new();
     let mut capitalize = true;
@@ -83,7 +85,7 @@ pub fn pascal_case(s: &str) -> String {
     pascal
 }
 
-#[cfg(feature = "comms")]
+#[cfg(feature = "service")]
 pub fn is_blank(s: &str) -> bool {
     s.trim().is_empty()
 }
@@ -91,7 +93,7 @@ pub fn is_blank(s: &str) -> bool {
 /// Standard annotation `org.freedesktop.DBus.Property.EmitsChangedSignal`.
 ///
 /// See <https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format>.
-#[cfg(feature = "comms")]
+#[cfg(any(feature = "proxy", feature = "service"))]
 #[derive(Debug, Default, Clone, PartialEq)]
 pub enum PropertyEmitsChangedSignal {
     #[default]
@@ -101,7 +103,7 @@ pub enum PropertyEmitsChangedSignal {
     False,
 }
 
-#[cfg(feature = "comms")]
+#[cfg(any(feature = "proxy", feature = "service"))]
 impl Display for PropertyEmitsChangedSignal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let emits_changed_signal = match self {
@@ -114,7 +116,7 @@ impl Display for PropertyEmitsChangedSignal {
     }
 }
 
-#[cfg(feature = "comms")]
+#[cfg(any(feature = "proxy", feature = "service"))]
 impl PropertyEmitsChangedSignal {
     pub fn parse(s: &str, span: Span) -> syn::Result<Self> {
         use PropertyEmitsChangedSignal::*;


### PR DESCRIPTION
Fixes #1135.

Pure services (e.g. busd) still ended up carrying all the proxy code even with fat LTO, and vice versa for pure clients. This puts the two halves of the high-level API behind two new default cargo features, both implying `comms`, so that either can be disabled:

* `proxy`: `zbus::proxy`, `zbus::Proxy`, the `#[proxy]` macro, the `fdo::*Proxy` types with their signal streams, and the blocking counterparts.
* `service`: `zbus::object_server`, `zbus::ObjectServer`, the `#[interface]` macro, `Connection::object_server`, `Builder::serve_at`, the standard interface implementations in `fdo`, and the blocking counterparts.

`zbus_macros` gains matching `proxy` and `service` features (default there and forwarded by `zbus`) that gate the two macros. No `zbus_macros` feature influences the generated code: whether the `interface` macro's `proxy(..)` sub-attribute generates a proxy, and whether the `proxy` macro generates the blocking proxies, is decided through hidden `zbus` macros by the features of the `zbus` the code is compiled against, because Cargo unifies the features of host dependencies (proc-macros, build scripts) separately from the target ones. A fixture crate with a service-only `zbus` dependency and a build script depending on `zbus` with `proxy` guards against regressions; CI builds it on its own since a workspace-wide build unifies the features away.

The generated public API is unchanged when both features are enabled (verified by diffing the expanded public signatures against `main`). Everything else in the D-Bus API (connections, messages, match rules, plain `fdo` types and errors) stays behind `comms` alone.

Commits, each building and passing on its own:

1. Two pre-existing clippy warnings in tests, so that the lint job passes.
2. The pre-existing host/target instance of the feature problem for `blocking-api`: a tokio-only crate with `zbus_xmlgen` as a build-dependency fails to compile `zbus` on `main`. The `blocking-api` feature of `zbus_macros` is removed since it has no purpose left.
3. Declare the standard interface proxies in `fdo` separately from the interface implementations, so that either side can be compiled without the other. API unchanged.
4. The `proxy` feature, across both crates.
5. The `service` feature, across both crates, with the fixture.
6. README.
7. Upgrade guide.
8. CI: clippy across all targets on the reduced feature combinations with both runtimes, doc builds and doctests with either half disabled, and the fixture on its own.

The remaining `--all-targets` clippy failures in the `zbus_xmlgen` generated fixtures are tracked in #1943.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015PfUDc6LiN3tqpco7Uq3JZ