### PR TITLE
🚸 zb,zm,zu,zx,xmlgen: Expose common wire types at the crate root

### DIFF
--- a/book/src/blocking.md
+++ b/book/src/blocking.md
@@ -29,7 +29,7 @@ Similar to `blocking::Connection`, you use `blocking::Proxy` type. Its construct
 to use the blocking connection and proxy:
 
 ```rust,no_run
-use zbus::{blocking::Connection, wire::ObjectPath, proxy, Result};
+use zbus::{blocking::Connection, ObjectPath, proxy, Result};
 
 #[proxy(
     default_service = "org.freedesktop.GeoClue2",

--- a/book/src/client.md
+++ b/book/src/client.md
@@ -60,7 +60,7 @@ zbus `Connection` has a `call_method()` method, which you can use directly:
 use std::collections::HashMap;
 use std::error::Error;
 
-use zbus::{wire::Value, Connection};
+use zbus::{Value, Connection};
 
 // Although we use `tokio` here, you can use any async runtime of choice.
 #[tokio::main]
@@ -99,7 +99,7 @@ calls:
 use std::collections::HashMap;
 use std::error::Error;
 
-use zbus::{wire::Value, proxy, Connection};
+use zbus::{Value, proxy, Connection};
 
 #[proxy(
     default_service = "org.freedesktop.Notifications",
@@ -164,7 +164,7 @@ Let's look at this API in action, with an example where we monitor started syste
 ```rust,no_run
 # // NOTE: When changing this, please also keep `zbus/examples/watch-systemd-jobs.rs` in sync.
 use futures_util::stream::StreamExt;
-use zbus::{wire::OwnedObjectPath, proxy, Connection};
+use zbus::{OwnedObjectPath, proxy, Connection};
 
 # fn main() {
 #     async_io::block_on(watch_systemd_jobs()).expect("Error listening to signal");
@@ -208,7 +208,7 @@ Here is a more elaborate example, where we get our location from
 [Geoclue](https://gitlab.freedesktop.org/geoclue/geoclue/-/blob/master/README.md):
 
 ```rust,no_run
-use zbus::{wire::ObjectPath, proxy, Connection, Result};
+use zbus::{ObjectPath, proxy, Connection, Result};
 use futures_util::stream::StreamExt;
 
 #[proxy(
@@ -542,7 +542,7 @@ trait Notifications {
         arg_3: &str,
         arg_4: &str,
         arg_5: &[&str],
-        arg_6: std::collections::HashMap<&str, zbus::wire::Value<'_>>,
+        arg_6: std::collections::HashMap<&str, zbus::Value<'_>>,
         arg_7: i32,
     ) -> zbus::Result<u32>;
 
@@ -564,7 +564,7 @@ For example, the generated `GetServerInformation` method can be improved to a ni
 
 ```rust,noplayground
 use serde::{Serialize, Deserialize};
-use zbus::{wire::Type, proxy};
+use zbus::{Type, proxy};
 
 #[derive(Debug, Type, Serialize, Deserialize)]
 pub struct ServerInformation {

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -10,7 +10,7 @@ a struct, you might find yourself wanting to use a struct as a dictionary.
 
 It's possible to do so, using either of the following methods:
 
-1. Using the `SerializeDict` and `DeserializeDict` derive macros from `zbus::wire`. This is the best
+1. Using the `SerializeDict` and `DeserializeDict` derive macros from `zbus`. This is the best
   option for simple cases.
 2. Using the `Serialize` and `Deserialize` derive macros from the `serde` crate. This is the best
   option for more complex cases, where you need more fine-grained control over the serialization
@@ -21,7 +21,7 @@ Here is a simple example using `SerializeDict` and `DeserializeDict`:
 ```rust,noplayground
 use zbus::{
     proxy, interface, fdo::Result,
-    wire::{Type, SerializeDict, DeserializeDict},
+    DeserializeDict, SerializeDict, Type,
 };
 
 #[derive(DeserializeDict, SerializeDict, Type)]
@@ -62,7 +62,7 @@ struct. You can not do that with `DeserializeDict` but you can with `serde::Dese
 
 ```rust,noplayground
 use std::collections::HashMap;
-use zbus::wire::{Type, OwnedValue, as_value::{self, optional}};
+use zbus::{as_value::{self, optional}, OwnedValue, Type};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Type)]
@@ -83,15 +83,15 @@ pub struct Dictionary {
 }
 ```
 
-Since the fields have to be transformed from/into `zbus::wire::Value`, make sure to use the
-`with` attribute with the appropriate helper module from the `zbus::wire::as_value` module.
+Since the fields have to be transformed from/into `zbus::Value`, make sure to use the
+`with` attribute with the appropriate helper module from the `zbus::as_value` module.
 
 Moreover, since D-Bus does not have a concept of nullable types, it's important to ensure that
 `skip_serializing_if` and `default` attributes are used for optional fields. Fortunately, you can
 make use of the `default` container attribute if your struct can implemented the `Default` trait:
 
 ```rust,noplayground
-# use zbus::wire::{Type, as_value::{self, optional}};
+# use zbus::{as_value::{self, optional}, Type};
 # use serde::{Deserialize, Serialize};
 #
 #[derive(Default, Deserialize, Serialize, Type)]
@@ -116,7 +116,7 @@ You can mirror that shape by nesting one `*Dict` struct inside another. The oute
 struct as their type:
 
 ```rust,noplayground
-use zbus::wire::{DeserializeDict, SerializeDict, Type};
+use zbus::{DeserializeDict, SerializeDict, Type};
 
 
 #[derive(DeserializeDict, SerializeDict, Type, PartialEq, Debug, Default, Clone)]
@@ -249,7 +249,7 @@ all types. However, it does come with some caveats and limitations:
     methods.
   3. Both the sender and receiver must agree on use of this encoding. If the sender sends `T`, the
     receiver will not be able to decode it successfully as `Option<T>` and vice versa.
-  4. While `zbus::wire::Value` can be converted into `Option<T>`, the reverse is currently not
+  4. While `zbus::Value` can be converted into `Option<T>`, the reverse is currently not
     possible.
 
 Due to these limitations, `option-as-array` feature is not enabled by default and must be explicitly
@@ -266,7 +266,7 @@ of fields. Names of fields don't matter though. You can make use of [`Value`] or
 you want to encode different data in different fields. Here is a simple example:
 
 ```rust,noplayground
-use zbus::wire::{serialized::Context, to_bytes, Type, LE};
+use zbus::{Type, wire::{serialized::Context, to_bytes, LE}};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Type, PartialEq, Debug)]
@@ -291,7 +291,7 @@ Enum encoding can be adjusted by using the [`serde_repr`] crate and by annotatin
 representation of the enum with `repr`:
 
 ```rust,noplayground
-use zbus::wire::{serialized::Context, to_bytes, Type, LE};
+use zbus::{Type, wire::{serialized::Context, to_bytes, LE}};
 use serde_repr::{Serialize_repr, Deserialize_repr};
 
 #[derive(Deserialize_repr, Serialize_repr, Type, PartialEq, Debug)]
@@ -311,7 +311,7 @@ assert_eq!(e, UnitEnum::Variant2);
 Unit enums can also be (de)serialized as strings:
 
 ```rust,noplayground
-use zbus::wire::{serialized::Context, to_bytes, Type, LE};
+use zbus::{Type, wire::{serialized::Context, to_bytes, LE}};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Type, PartialEq, Debug)]

--- a/book/src/upgrading-to-6.md
+++ b/book/src/upgrading-to-6.md
@@ -7,8 +7,8 @@ zbus 6.0 is one dependency where there used to be as many as four. The `zvariant
 
 | Was | Is now |
 | --- | --- |
-| the `zvariant` crate | the [`zbus::wire`] module |
-| the `zvariant_derive` crate | the derives, re-exported from `zbus::wire` |
+| the `zvariant` crate | common types at the `zbus` root; codecs in [`zbus::wire`] |
+| the `zvariant_derive` crate | the derives, re-exported from `zbus` |
 | the `zbus_names` crate | the [`zbus::names`] module |
 
 The D-Bus API — connections, messages, proxies, the object server, `fdo` — now sits behind a
@@ -22,10 +22,12 @@ GVariant support, deprecated in zvariant 5.15, is gone; it lives on in the [zgva
 
 * **You depend on `zbus`.** Bump the version. `zbus::zvariant` is still there as a deprecated
   alias module, so almost everything keeps compiling with a warning; the handful of things that
-  do break are listed [further down][breaks]. Rename to `zbus::wire` at your own pace — the
-  compatibility module goes away in 7.0.
+  do break are listed [further down][breaks]. Move common types and derives to the `zbus` root and
+  direct encoding and decoding calls to `zbus::wire` at your own pace. The compatibility module
+  goes away in 7.0.
 * **You depend on `zvariant` and not on `zbus`.** Replace the dependency (below) and rename
-  `zvariant::` to `zbus::wire::`.
+  common types and derives from `zvariant::` to `zbus::`; use `zbus::wire::` for direct encoding
+  and decoding APIs.
 * **You depend on `zbus_names`.** Replace the dependency and rename `zbus_names::` to
   `zbus::names::`.
 * **You use the `gvariant` feature.** Move to [zgvariant].
@@ -106,16 +108,20 @@ needed it. zbus's own dependency on the macro crate is such a defaults-off one, 
 
 | zbus 5 / zvariant 5 / zbus_names 4 | zbus 6 |
 | --- | --- |
-| `zvariant::X`, `zbus::zvariant::X` | `zbus::wire::X` |
+| Common `zvariant::X`, `zbus::zvariant::X` types and derives | `zbus::X` |
 | `zvariant::serialized::Context` | `zbus::wire::serialized::Context` |
-| `zvariant::as_value`, `zvariant::dbus` | `zbus::wire::as_value`, `zbus::wire::dbus` |
-| `zvariant::signature!` | `zbus::wire::signature!` |
+| `zvariant::as_value`, `zvariant::dbus` | `zbus::as_value`, `zbus::wire::dbus` |
+| `zvariant::signature!` | `zbus::signature!` |
 | `zbus_names::X`, `zbus::names::X` | `zbus::names::X` |
 | `zvariant::Error`, `zvariant::Result` | `zbus::Error`, `zbus::Result` |
 | `zbus_names::Error`, `zbus::names::Error` | `zbus::Error` |
 | `zvariant::MaxDepthExceeded` | `zbus::MaxDepthExceeded` |
 | `#[zvariant(...)]` on a derive | `#[zbus(...)]`; both spellings stay accepted |
 | `#[zvariant(crate = "zvariant")]` | `#[zbus(crate = "zbus::wire")]` |
+
+Encoding and decoding functions, `serialized`, `Endian` and its constants, `DynamicDeserialize`,
+`StructureBuilder`, the `*Seed` types, and `signature::{Child, Fields}` remain under `zbus::wire`.
+Use `zbus::Structure::builder()` to construct structures without importing `StructureBuilder`.
 
 On these derives the `crate` attribute names the module that holds the wire types, so
 point it at `zbus::wire`.
@@ -126,7 +132,7 @@ After the rename the wire API reads like this:
 
 ```rust,noplayground
 use serde::{Deserialize, Serialize};
-use zbus::wire::{serialized::Context, to_bytes, Type, LE};
+use zbus::{Type, wire::{serialized::Context, to_bytes, LE}};
 
 #[derive(Deserialize, Serialize, Type, PartialEq, Debug)]
 struct Struct<'s> {
@@ -299,8 +305,8 @@ And the module does not cover:
   let _ = zbus::zvariant::DynamicTuple((1u32, "a"));
   ```
 
-  Spell it `zbus::wire::DynamicTuple((1u32, "a"))`. `DynamicTuple` and `OwnedStructure` are the
-  two aliased types this bites; `zbus::wire::as_value::Serialize` also has a public tuple field
+  Spell it `zbus::DynamicTuple((1u32, "a"))`. `DynamicTuple` and `OwnedStructure` are the
+  two aliased types this bites; `zbus::as_value::Serialize` also has a public tuple field
   but is re-exported rather than aliased, so it constructs fine either way.
 * Anything that named the crates themselves: `extern crate zvariant;`, a `zvariant = "5"`
   dependency, `#[zbus(crate = "zvariant")]`.
@@ -389,7 +395,7 @@ The `org.freedesktop.DBus.Properties` proxy — `zbus::fdo::PropertiesProxy` and
 sibling — takes the new value by reference:
 
 ```rust,noplayground
-use zbus::{fdo::PropertiesProxy, names::InterfaceName, wire::Value};
+use zbus::{fdo::PropertiesProxy, names::InterfaceName, Value};
 
 async fn mute(proxy: &PropertiesProxy<'_>, iface: InterfaceName<'_>) -> zbus::fdo::Result<()> {
     // Was: proxy.set(iface, "Muted", Value::from(true)).await
@@ -417,7 +423,7 @@ the string as it came, so a malformed name off the wire became a typed name and 
 as a method call with an empty destination, say. `BusName` and `OwnedBusName` already validated.
 
 ```rust,noplayground
-use zbus::{names::UniqueName, wire::{Optional, Value}};
+use zbus::{names::UniqueName, Optional, Value};
 
 // Accepted in 5.x, an `Error::InvalidName` now.
 UniqueName::try_from(Value::from("not.unique")).unwrap_err();
@@ -468,7 +474,7 @@ not do before. Everything else in the D-Bus API (`Connection`, `Message`, `Messa
 ## A stale zvariant in the dependency graph
 
 If another crate in your tree still depends on zvariant 5, your build contains two unrelated
-`Type`, `Value` and `Signature` types, and the resulting errors ("expected `zbus::wire::Value`,
+`Type`, `Value` and `Signature` types, and the resulting errors ("expected `zbus::Value`,
 found `zvariant::Value`") are confusing. `Signature` is duplicated like the other two: zbus 6
 re-exports it from `zbus_utils`, which no zvariant 5 release uses. Find the culprit with:
 

--- a/test_fixtures/renamed_zbus/src/lib.rs
+++ b/test_fixtures/renamed_zbus/src/lib.rs
@@ -55,7 +55,7 @@ enum Error {
 }
 
 // The wire derives through the renamed crate.
-#[derive(my_zbus::wire::Type)]
+#[derive(my_zbus::Type)]
 #[zbus(crate = "my_zbus::wire")]
 struct Data {
     field: u32,

--- a/test_fixtures/zbus_only/Cargo.toml
+++ b/test_fixtures/zbus_only/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 description = "Compile-only fixture: downstream crate using the wire derives through zbus"
 
 [dependencies]
-# The derives are used through the `zbus::wire` re-export, like the book examples do.
+# The derives are used through the `zbus` re-export, like the book examples do.
 zbus = { path = "../../zbus" }
 serde = { workspace = true, features = ["derive"] }
 

--- a/test_fixtures/zbus_only/src/lib.rs
+++ b/test_fixtures/zbus_only/src/lib.rs
@@ -1,12 +1,12 @@
 //! Compile-only fixture: a downstream crate that depends only on `zbus` and uses the wire
 //! derives through it, as the book examples do.
 //!
-//! The derives default to `::zbus::wire` paths, so no `crate` attribute is needed.
+//! The derives default to `::zbus::wire` internally, so no `crate` attribute is needed.
 
 #![allow(dead_code)]
 
 use serde::{Deserialize, Serialize};
-use zbus::wire::{DeserializeDict, OwnedValue, SerializeDict, Type, Value};
+use zbus::{DeserializeDict, OwnedValue, SerializeDict, Type, Value};
 
 #[derive(DeserializeDict, SerializeDict, Type)]
 #[zbus(signature = "dict")]

--- a/zbus/benches/benchmarks.rs
+++ b/zbus/benches/benchmarks.rs
@@ -4,7 +4,7 @@ use zbus::Message;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 
-use zbus::wire::{Type, Value};
+use zbus::{Type, Value};
 
 fn msg_ser(c: &mut Criterion) {
     let mut g = c.benchmark_group("message-ser");

--- a/zbus/benches/wire.rs
+++ b/zbus/benches/wire.rs
@@ -5,7 +5,10 @@ use std::{collections::HashMap, hint::black_box, vec};
 
 use criterion::{Criterion, criterion_group, criterion_main};
 
-use zbus::wire::{LE, Type, Value, serialized::Context, to_bytes};
+use zbus::{
+    Type, Value,
+    wire::{LE, serialized::Context, to_bytes},
+};
 
 macro_rules! benchmark {
     ($c:ident, $data:ident, $data_type:ty, $func_prefix:literal) => {
@@ -119,7 +122,7 @@ fn signature_parse(c: &mut Criterion) {
 
     c.bench_function("signature_parse", |b| {
         b.iter(|| {
-            zbus::wire::Signature::try_from(black_box(signature_str.as_str())).unwrap();
+            zbus::Signature::try_from(black_box(signature_str.as_str())).unwrap();
         })
     });
 }
@@ -130,7 +133,7 @@ fn object_path_parse(c: &mut Criterion) {
 
     c.bench_function("object_path_parse", |b| {
         b.iter(|| {
-            zbus::wire::ObjectPath::try_from(black_box(PATH)).unwrap();
+            zbus::ObjectPath::try_from(black_box(PATH)).unwrap();
         })
     });
 }

--- a/zbus/examples/watch-systemd-jobs.rs
+++ b/zbus/examples/watch-systemd-jobs.rs
@@ -5,7 +5,7 @@
 //! Run with command: `cargo run --example watch-systemd-jobs`
 
 use futures_util::stream::StreamExt;
-use zbus::{Connection, wire::OwnedObjectPath};
+use zbus::{Connection, OwnedObjectPath};
 use zbus_macros::proxy;
 
 fn main() {

--- a/zbus/fuzz/fuzz_targets/utils.rs
+++ b/zbus/fuzz/fuzz_targets/utils.rs
@@ -1,6 +1,9 @@
-use zbus::wire::{
-    serialized::{Context, Data},
-    to_bytes, Value,
+use zbus::{
+    Value,
+    wire::{
+        serialized::{Context, Data},
+        to_bytes,
+    },
 };
 
 pub fn fuzz_for_context(bytes: &[u8], ctx: Context) {

--- a/zbus/src/blocking/connection/builder.rs
+++ b/zbus/src/blocking/connection/builder.rs
@@ -13,7 +13,7 @@ use crate::{
     connection::socket::BoxedSplit, names::WellKnownName, utils::block_on,
 };
 #[cfg(feature = "service")]
-use crate::{object_server::Interface, wire::ObjectPath};
+use crate::{ObjectPath, object_server::Interface};
 
 /// A builder for [`zbus::blocking::Connection`].
 #[derive(Debug)]

--- a/zbus/src/blocking/connection/mod.rs
+++ b/zbus/src/blocking/connection/mod.rs
@@ -9,12 +9,11 @@ use std::{io, sync::Arc};
 #[cfg(feature = "service")]
 use crate::blocking::ObjectServer;
 use crate::{
-    DBusError, Error, Result,
+    DBusError, Error, ObjectPath, Result,
     fdo::{ConnectionCredentials, RequestNameFlags, RequestNameReply},
     message::Message,
     names::{BusName, ErrorName, InterfaceName, MemberName, OwnedUniqueName, WellKnownName},
     utils::block_on,
-    wire::ObjectPath,
 };
 
 mod builder;
@@ -88,7 +87,7 @@ impl Connection {
         P::Error: Into<Error>,
         I::Error: Into<Error>,
         M::Error: Into<Error>,
-        B: serde::ser::Serialize + crate::wire::DynamicType,
+        B: serde::ser::Serialize + crate::DynamicType,
     {
         block_on(
             self.inner
@@ -116,7 +115,7 @@ impl Connection {
         P::Error: Into<Error>,
         I::Error: Into<Error>,
         M::Error: Into<Error>,
-        B: serde::ser::Serialize + crate::wire::DynamicType,
+        B: serde::ser::Serialize + crate::DynamicType,
     {
         block_on(
             self.inner
@@ -130,7 +129,7 @@ impl Connection {
     /// given `body`.
     pub fn reply<B>(&self, call: &zbus::message::Header<'_>, body: &B) -> Result<()>
     where
-        B: serde::ser::Serialize + crate::wire::DynamicType,
+        B: serde::ser::Serialize + crate::DynamicType,
     {
         block_on(self.inner.reply(call, body))
     }
@@ -148,7 +147,7 @@ impl Connection {
         body: &B,
     ) -> Result<()>
     where
-        B: serde::ser::Serialize + crate::wire::DynamicType,
+        B: serde::ser::Serialize + crate::DynamicType,
         E: TryInto<ErrorName<'e>>,
         E::Error: Into<Error>,
     {

--- a/zbus/src/blocking/object_server.rs
+++ b/zbus/src/blocking/object_server.rs
@@ -1,10 +1,9 @@
 //! The object server API.
 
 use crate::{
-    Error, Result,
+    Error, ObjectPath, Result,
     object_server::{Interface, InterfaceDeref, InterfaceDerefMut, SignalEmitter},
     utils::block_on,
-    wire::ObjectPath,
 };
 
 /// Wrapper over an interface, along with its corresponding `SignalEmitter`

--- a/zbus/src/blocking/proxy/builder.rs
+++ b/zbus/src/blocking/proxy/builder.rs
@@ -1,10 +1,9 @@
 use crate::{
-    Error, Result,
+    Error, ObjectPath, Result,
     blocking::Connection,
     names::{BusName, InterfaceName},
     proxy::CacheProperties,
     utils::block_on,
-    wire::ObjectPath,
 };
 
 pub use crate::proxy::Defaults;

--- a/zbus/src/blocking/proxy/mod.rs
+++ b/zbus/src/blocking/proxy/mod.rs
@@ -5,13 +5,12 @@ use futures_lite::StreamExt;
 use std::{fmt, ops::Deref};
 
 use crate::{
-    Error, Result,
+    Error, ObjectPath, Result, Value,
     blocking::Connection,
     message::Message,
     names::{BusName, InterfaceName, MemberName, UniqueName},
     proxy::{Defaults, MethodFlags},
     utils::block_on,
-    wire::{ObjectPath, Value},
 };
 
 use crate::fdo;
@@ -168,7 +167,7 @@ impl<'a> Proxy<'a> {
     /// the peer.
     pub fn cached_property<T>(&self, property_name: &str) -> Result<Option<T>>
     where
-        T: serde::de::DeserializeOwned + crate::wire::Type,
+        T: serde::de::DeserializeOwned + crate::Type,
     {
         self.inner().cached_property(property_name)
     }
@@ -190,7 +189,7 @@ impl<'a> Proxy<'a> {
     /// `org.freedesktop.DBus.Properties` interface.
     pub fn get_property<T>(&self, property_name: &str) -> Result<T>
     where
-        T: serde::de::DeserializeOwned + crate::wire::Type,
+        T: serde::de::DeserializeOwned + crate::Type,
     {
         block_on(self.inner().get_property(property_name))
     }
@@ -200,7 +199,7 @@ impl<'a> Proxy<'a> {
     /// Effectively, call the `Set` method of the `org.freedesktop.DBus.Properties` interface.
     pub fn set_property<T>(&self, property_name: &str, value: T) -> fdo::Result<()>
     where
-        T: serde::Serialize + crate::wire::Type,
+        T: serde::Serialize + crate::Type,
     {
         block_on(self.inner().set_property(property_name, value))
     }
@@ -216,7 +215,7 @@ impl<'a> Proxy<'a> {
     where
         M: TryInto<MemberName<'m>>,
         M::Error: Into<Error>,
-        B: serde::ser::Serialize + crate::wire::DynamicType,
+        B: serde::ser::Serialize + crate::DynamicType,
     {
         block_on(self.inner().call_method(method_name, body))
     }
@@ -230,7 +229,7 @@ impl<'a> Proxy<'a> {
     where
         M: TryInto<MemberName<'m>>,
         M::Error: Into<Error>,
-        B: serde::ser::Serialize + crate::wire::DynamicType,
+        B: serde::ser::Serialize + crate::DynamicType,
         R: for<'d> crate::wire::DynamicDeserialize<'d>,
     {
         block_on(self.inner().call(method_name, body))
@@ -254,7 +253,7 @@ impl<'a> Proxy<'a> {
     where
         M: TryInto<MemberName<'m>>,
         M::Error: Into<Error>,
-        B: serde::ser::Serialize + crate::wire::DynamicType,
+        B: serde::ser::Serialize + crate::DynamicType,
         R: for<'d> crate::wire::DynamicDeserialize<'d>,
     {
         block_on(self.inner().call_with_flags(method_name, flags, body))
@@ -267,7 +266,7 @@ impl<'a> Proxy<'a> {
     where
         M: TryInto<MemberName<'m>>,
         M::Error: Into<Error>,
-        B: serde::ser::Serialize + crate::wire::DynamicType,
+        B: serde::ser::Serialize + crate::DynamicType,
     {
         block_on(self.inner().call_noreply(method_name, body))
     }
@@ -459,7 +458,7 @@ impl<T> PropertyChanged<'_, T> {
 
 impl<T> PropertyChanged<'_, T>
 where
-    T: serde::de::DeserializeOwned + crate::wire::Type,
+    T: serde::de::DeserializeOwned + crate::Type,
 {
     /// Get the value of the property that changed.
     ///

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -28,9 +28,9 @@ use crate::{
 };
 #[cfg(feature = "service")]
 use crate::{
+    ObjectPath,
     names::InterfaceName,
     object_server::{ArcInterface, Interface},
-    wire::ObjectPath,
 };
 
 use super::{

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -22,14 +22,13 @@ use ordered_stream::OrderedFuture;
 #[cfg(feature = "service")]
 use crate::ObjectServer;
 use crate::{
-    DBusError, Error, Executor, MatchRule, OwnedGuid, OwnedMatchRule, Result, Task,
+    DBusError, Error, Executor, MatchRule, ObjectPath, OwnedGuid, OwnedMatchRule, Result, Task,
     async_lock::{Mutex, Semaphore, SemaphorePermit},
     fdo::{ConnectionCredentials, ReleaseNameReply, RequestNameFlags, RequestNameReply},
     is_flatpak,
     message::{Flags, Message, Type},
     names::{BusName, ErrorName, InterfaceName, MemberName, OwnedUniqueName, WellKnownName},
     timeout::timeout,
-    wire::ObjectPath,
 };
 
 mod builder;
@@ -283,7 +282,7 @@ impl Connection {
         P::Error: Into<Error>,
         I::Error: Into<Error>,
         M::Error: Into<Error>,
-        B: serde::ser::Serialize + crate::wire::DynamicType,
+        B: serde::ser::Serialize + crate::DynamicType,
     {
         let method = self
             .call_method_raw(
@@ -337,7 +336,7 @@ impl Connection {
         P::Error: Into<Error>,
         I::Error: Into<Error>,
         M::Error: Into<Error>,
-        B: serde::ser::Serialize + crate::wire::DynamicType,
+        B: serde::ser::Serialize + crate::DynamicType,
     {
         let _permit = acquire_serial_num_semaphore().await;
 
@@ -389,7 +388,7 @@ impl Connection {
         P::Error: Into<Error>,
         I::Error: Into<Error>,
         M::Error: Into<Error>,
-        B: serde::ser::Serialize + crate::wire::DynamicType,
+        B: serde::ser::Serialize + crate::DynamicType,
     {
         let _permit = acquire_serial_num_semaphore().await;
 
@@ -411,7 +410,7 @@ impl Connection {
     /// given `body`.
     pub async fn reply<B>(&self, call: &zbus::message::Header<'_>, body: &B) -> Result<()>
     where
-        B: serde::ser::Serialize + crate::wire::DynamicType,
+        B: serde::ser::Serialize + crate::DynamicType,
     {
         let _permit = acquire_serial_num_semaphore().await;
 
@@ -434,7 +433,7 @@ impl Connection {
         body: &B,
     ) -> Result<()>
     where
-        B: serde::ser::Serialize + crate::wire::DynamicType,
+        B: serde::ser::Serialize + crate::DynamicType,
         E: TryInto<ErrorName<'e>>,
         E::Error: Into<Error>,
     {

--- a/zbus/src/error.rs
+++ b/zbus/src/error.rs
@@ -8,10 +8,7 @@ use crate::{
     message::{Message, Type},
     names::OwnedErrorName,
 };
-use crate::{
-    names::InterfaceName,
-    wire::{self, ObjectPath, Signature},
-};
+use crate::{ObjectPath, Signature, names::InterfaceName, wire};
 
 /// The error type for `zbus`.
 ///

--- a/zbus/src/fdo/dbus.rs
+++ b/zbus/src/fdo/dbus.rs
@@ -4,7 +4,7 @@
 //! be useful across various D-Bus applications. This module provides their proxy.
 
 #[cfg(unix)]
-use crate::wire::OwnedFd;
+use crate::OwnedFd;
 #[cfg(feature = "proxy")]
 use enumflags2::BitFlags;
 use enumflags2::bitflags;
@@ -14,15 +14,14 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::collections::HashMap;
 
 use super::Result;
-use crate::wire::{DeserializeDict, SerializeDict, Type};
+use crate::{DeserializeDict, SerializeDict, Type};
 #[cfg(feature = "proxy")]
 use crate::{
-    OwnedGuid,
+    Optional, OwnedGuid,
     names::{
         BusName, OwnedBusName, OwnedInterfaceName, OwnedUniqueName, UniqueName, WellKnownName,
     },
     proxy,
-    wire::Optional,
 };
 
 #[cfg_attr(

--- a/zbus/src/fdo/mod.rs
+++ b/zbus/src/fdo/mod.rs
@@ -211,7 +211,7 @@ mod tests {
             signal.args().unwrap().interfaces_and_properties,
             vec![(
                 "org.zbus.TestObj".try_into().unwrap(),
-                vec![("Test", crate::wire::Value::new("test"))]
+                vec![("Test", crate::Value::new("test"))]
                     .into_iter()
                     .collect()
             )]

--- a/zbus/src/fdo/object_manager.rs
+++ b/zbus/src/fdo/object_manager.rs
@@ -14,14 +14,8 @@ use super::Result;
 #[cfg(feature = "service")]
 use crate::{Connection, ObjectServer, interface, message::Header, object_server::SignalEmitter};
 #[cfg(any(feature = "proxy", feature = "service"))]
-use crate::{
-    names::InterfaceName,
-    wire::{ObjectPath, Value},
-};
-use crate::{
-    names::OwnedInterfaceName,
-    wire::{OwnedObjectPath, OwnedValue},
-};
+use crate::{ObjectPath, Value, names::InterfaceName};
+use crate::{OwnedObjectPath, OwnedValue, names::OwnedInterfaceName};
 
 #[cfg_attr(
     feature = "proxy",

--- a/zbus/src/fdo/properties.rs
+++ b/zbus/src/fdo/properties.rs
@@ -10,10 +10,7 @@ use super::Error;
 use super::Result;
 #[cfg(feature = "service")]
 use crate::{Connection, ObjectServer, interface, message::Header, object_server::SignalEmitter};
-use crate::{
-    names::InterfaceName,
-    wire::{OwnedValue, Value},
-};
+use crate::{OwnedValue, Value, names::InterfaceName};
 
 /// Service-side implementation for the `org.freedesktop.DBus.Properties` interface.
 /// This interface is implemented automatically for any object registered to the

--- a/zbus/src/fdo/stats.rs
+++ b/zbus/src/fdo/stats.rs
@@ -8,9 +8,10 @@ use std::collections::HashMap;
 
 use super::Result;
 use crate::{
+    OwnedValue, Type,
+    as_value::optional,
     names::{BusName, OwnedUniqueName},
     proxy,
-    wire::{OwnedValue, Type, as_value::optional},
 };
 
 /// Proxy for the [`org.freedesktop.DBus.Debug.Stats`][link] interface.

--- a/zbus/src/guid.rs
+++ b/zbus/src/guid.rs
@@ -5,7 +5,7 @@ use std::{
     str::FromStr,
 };
 
-use crate::wire::{Str, Type};
+use crate::{Str, Type};
 use serde::{Deserialize, Serialize, de};
 
 /// A D-Bus server GUID.

--- a/zbus/src/lib.rs
+++ b/zbus/src/lib.rs
@@ -75,12 +75,23 @@ mod error;
 pub use error::*;
 
 pub mod wire;
+#[doc(inline)]
+pub use wire::{
+    Array, Basic, DeserializeDict, Dict, DynamicTuple, DynamicType, FilePath, NoneValue,
+    ObjectPath, Optional, OwnedObjectPath, OwnedStructure, OwnedValue, SerializeDict, Signature,
+    Str, Structure, Type, Value, as_value,
+};
+#[cfg(unix)]
+#[doc(inline)]
+pub use wire::{Fd, OwnedFd};
+#[doc(inline)]
+pub use zbus_macros::signature;
 
 pub mod names;
 
 #[deprecated(
     since = "6.0.0",
-    note = "zvariant was merged into zbus; use `zbus::wire`"
+    note = "zvariant was merged into zbus; use `zbus` for types, `zbus::wire` for codecs"
 )]
 pub mod zvariant;
 

--- a/zbus/src/match_rule/builder.rs
+++ b/zbus/src/match_rule/builder.rs
@@ -1,9 +1,8 @@
 use crate::{
-    Error, MatchRule, Result,
+    Error, MatchRule, ObjectPath, Result, Str,
     match_rule::PathSpec,
     message::Type,
     names::{BusName, InterfaceName, MemberName, UniqueName},
-    wire::{ObjectPath, Str},
 };
 
 const MAX_ARGS: u8 = 64;

--- a/zbus/src/match_rule/mod.rs
+++ b/zbus/src/match_rule/mod.rs
@@ -9,10 +9,9 @@ use std::{
 use serde::{Deserialize, Serialize, de};
 
 use crate::{
-    Error, Result,
+    Error, ObjectPath, Result, Str, Structure, Type as VariantType,
     message::Type,
     names::{BusName, InterfaceName, MemberName, UniqueName},
-    wire::{ObjectPath, Str, Structure, Type as VariantType},
 };
 
 mod builder;

--- a/zbus/src/message/body.rs
+++ b/zbus/src/message/body.rs
@@ -1,9 +1,6 @@
 use crate::{
-    Message, Result,
-    wire::{
-        Signature, Type,
-        serialized::{self, Data},
-    },
+    Message, Result, Signature, Type,
+    wire::serialized::{self, Data},
 };
 
 /// The body of a message.

--- a/zbus/src/message/builder.rs
+++ b/zbus/src/message/builder.rs
@@ -1,5 +1,5 @@
 #[cfg(unix)]
-use crate::wire::OwnedFd;
+use crate::OwnedFd;
 use std::{
     borrow::Cow,
     io::{Cursor, Write},
@@ -10,11 +10,11 @@ use std::{
 use enumflags2::BitFlags;
 
 use crate::{
-    Error, Result,
+    DynamicType, Error, ObjectPath, Result, Signature,
     message::{EndianSig, Fields, Flags, Header, Message, PrimaryHeader, Sequence, Type},
     names::{BusName, ErrorName, InterfaceName, MemberName, UniqueName},
     utils::padding_for_8_bytes,
-    wire::{DynamicType, Endian, ObjectPath, Signature, serialized, serialized::Context},
+    wire::{Endian, serialized, serialized::Context},
 };
 
 use crate::message::header::MAX_MESSAGE_SIZE;

--- a/zbus/src/message/field_code.rs
+++ b/zbus/src/message/field_code.rs
@@ -1,6 +1,6 @@
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::wire::Type;
+use crate::Type;
 
 /// The message field code.
 ///

--- a/zbus/src/message/fields.rs
+++ b/zbus/src/message/fields.rs
@@ -6,9 +6,9 @@ use serde::{
 use std::{borrow::Cow, num::NonZeroU32};
 
 use crate::{
+    ObjectPath, Signature, Type, Value,
     message::{FieldCode, Header, Message},
     names::{BusName, ErrorName, InterfaceName, MemberName, UniqueName},
-    wire::{ObjectPath, Signature, Type, Value},
 };
 
 /// A collection of [`Field`] instances.

--- a/zbus/src/message/header.rs
+++ b/zbus/src/message/header.rs
@@ -8,11 +8,11 @@ use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::{
-    Error,
+    Error, ObjectPath, Signature, Type as VariantType,
     message::Fields,
     names::{BusName, ErrorName, InterfaceName, MemberName, UniqueName},
     wire::{
-        Endian, ObjectPath, Signature, Type as VariantType,
+        Endian,
         serialized::{self, Context},
     },
 };
@@ -321,8 +321,9 @@ mod tests {
     use crate::message::{Fields, Header, PrimaryHeader, Type};
 
     use crate::{
+        ObjectPath, Signature,
         names::{InterfaceName, MemberName},
-        wire::{ObjectPath, Signature, signature},
+        signature,
     };
     use std::{borrow::Cow, error::Error};
     use test_log::test;

--- a/zbus/src/message/mod.rs
+++ b/zbus/src/message/mod.rs
@@ -2,10 +2,10 @@
 use std::{borrow::Cow, fmt, sync::Arc};
 
 use crate::{
-    Error, Result,
+    Error, ObjectPath, Result,
     names::{ErrorName, InterfaceName, MemberName},
     utils::padding_for_8_bytes,
-    wire::{Endian, ObjectPath, serialized},
+    wire::{Endian, serialized},
 };
 
 mod builder;
@@ -51,7 +51,7 @@ impl Sequence {
 /// using the low-level API.
 ///
 /// **Note**: The message owns the received FDs and will close them when dropped. You can
-/// deserialize the body (that you get using [`Message::body`]) to [`crate::wire::OwnedFd`] if
+/// deserialize the body (that you get using [`Message::body`]) to [`crate::OwnedFd`] if
 /// you want to keep the FDs around after the containing message is dropped.
 #[derive(Clone)]
 pub struct Message {
@@ -200,11 +200,11 @@ impl Message {
     ///     .build(&send_body)?;
     /// let header = message.header();
     /// let body = message.body();
-    /// let body: zbus::wire::Structure<'_> = body.deserialize()?;
+    /// let body: zbus::Structure<'_> = body.deserialize()?;
     /// let fields = body.fields();
-    /// assert!(matches!(fields[0], zbus::wire::Value::I32(7)));
-    /// assert!(matches!(fields[1], zbus::wire::Value::Structure(_)));
-    /// assert!(matches!(fields[2], zbus::wire::Value::Array(_)));
+    /// assert!(matches!(fields[0], zbus::Value::I32(7)));
+    /// assert!(matches!(fields[1], zbus::Value::Structure(_)));
+    /// assert!(matches!(fields[2], zbus::Value::Array(_)));
     ///
     /// let reply_body = Message::method_return(&header)?.build(&body)?.body();
     /// let reply_value : (i32, (i32, &str), Vec<String>) = reply_body.deserialize()?;
@@ -270,7 +270,7 @@ impl fmt::Debug for Message {
             msg.field("member", &member);
         }
         match self.body().signature() {
-            crate::wire::Signature::Unit => (),
+            crate::Signature::Unit => (),
             s => {
                 msg.field("body", &s);
             }
@@ -334,8 +334,8 @@ impl fmt::Display for Message {
 #[cfg(test)]
 mod tests {
     #[cfg(unix)]
-    use crate::wire::Fd;
-    use crate::wire::Signature;
+    use crate::Fd;
+    use crate::Signature;
     #[cfg(unix)]
     use std::os::fd::{AsFd, AsRawFd};
     use test_log::test;

--- a/zbus/src/names/bus_name.rs
+++ b/zbus/src/names/bus_name.rs
@@ -6,11 +6,10 @@ use core::{
 use std::{borrow::Cow, sync::Arc};
 
 use crate::{
-    Error, Result,
+    Error, NoneValue, OwnedValue, Result, Str, Type, Value,
     names::{
         OwnedUniqueName, OwnedWellKnownName, UniqueName, WellKnownName, utils::impl_str_basic,
     },
-    wire::{NoneValue, OwnedValue, Str, Type, Value},
 };
 use serde::{Deserialize, Serialize, de};
 use zbus_utils::names::BusNameKind;
@@ -195,7 +194,7 @@ impl<'de: 'name, 'name> Deserialize<'de> for BusName<'name> {
 }
 
 impl Type for BusName<'_> {
-    const SIGNATURE: &'static crate::wire::Signature = &crate::wire::Signature::Str;
+    const SIGNATURE: &'static crate::Signature = &crate::Signature::Str;
 }
 
 impl<'name> From<UniqueName<'name>> for BusName<'name> {

--- a/zbus/src/names/error_name.rs
+++ b/zbus/src/names/error_name.rs
@@ -1,7 +1,4 @@
-use crate::{
-    names::utils::define_name_type_impls,
-    wire::{Str, Type},
-};
+use crate::{Str, Type, names::utils::define_name_type_impls};
 use serde::Serialize;
 
 /// String that identifies an [error name][en] on the bus.

--- a/zbus/src/names/interface_name.rs
+++ b/zbus/src/names/interface_name.rs
@@ -1,7 +1,4 @@
-use crate::{
-    names::utils::define_name_type_impls,
-    wire::{Str, Type},
-};
+use crate::{Str, Type, names::utils::define_name_type_impls};
 use serde::Serialize;
 
 /// String that identifies an [interface name][in] on the bus.

--- a/zbus/src/names/member_name.rs
+++ b/zbus/src/names/member_name.rs
@@ -1,7 +1,4 @@
-use crate::{
-    names::utils::define_name_type_impls,
-    wire::{Str, Type},
-};
+use crate::{Str, Type, names::utils::define_name_type_impls};
 use serde::Serialize;
 
 /// String that identifies an [member (method or signal) name][in] on the bus.

--- a/zbus/src/names/mod.rs
+++ b/zbus/src/names/mod.rs
@@ -25,8 +25,8 @@
 //! ```
 //!
 //! [dbn]: https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names
-//! [`Type`]: trait@crate::wire::Type
-//! [`Value`]: enum@crate::wire::Value
+//! [`Type`]: trait@crate::Type
+//! [`Value`]: enum@crate::Value
 
 mod bus_name;
 pub use bus_name::*;

--- a/zbus/src/names/property_name.rs
+++ b/zbus/src/names/property_name.rs
@@ -1,7 +1,4 @@
-use crate::{
-    names::utils::define_name_type_impls,
-    wire::{Str, Type},
-};
+use crate::{Str, Type, names::utils::define_name_type_impls};
 use serde::Serialize;
 
 /// String that identifies a [property][pn] name on the bus.

--- a/zbus/src/names/unique_name.rs
+++ b/zbus/src/names/unique_name.rs
@@ -1,7 +1,4 @@
-use crate::{
-    names::utils::define_name_type_impls,
-    wire::{Str, Type},
-};
+use crate::{Str, Type, names::utils::define_name_type_impls};
 use serde::Serialize;
 
 /// String that identifies a [unique bus name][ubn].
@@ -43,19 +40,19 @@ define_name_type_impls! {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::wire::{OwnedValue, Value};
+    use crate::{OwnedValue, Value};
 
     #[test]
     fn value_conversion_rejects_empty_name() {
         let value = Value::from("");
         UniqueName::try_from(value).unwrap_err();
         OwnedUniqueName::try_from(Value::from("")).unwrap_err();
-        OwnedUniqueName::try_from(OwnedValue::from(crate::wire::Str::from(""))).unwrap_err();
+        OwnedUniqueName::try_from(OwnedValue::from(crate::Str::from(""))).unwrap_err();
     }
 
     #[test]
     fn optional_value_conversion_maps_empty_name_to_none() {
-        use crate::wire::Optional;
+        use crate::Optional;
 
         // An empty string is the D-Bus sentinel for "no name" and must map to `None`
         // rather than fail validation.
@@ -71,14 +68,14 @@ mod tests {
 
     #[test]
     fn optional_owned_value_conversion_maps_empty_name_to_none() {
-        use crate::wire::Optional;
+        use crate::Optional;
 
         // The sentinel must be recognized before the empty name is validated.
-        let owned = OwnedValue::from(crate::wire::Str::from(""));
+        let owned = OwnedValue::from(crate::Str::from(""));
         let opt = Optional::<OwnedUniqueName>::try_from(owned).unwrap();
         assert!(Option::<OwnedUniqueName>::from(opt).is_none());
 
-        let owned = OwnedValue::from(crate::wire::Str::from(":1.23"));
+        let owned = OwnedValue::from(crate::Str::from(":1.23"));
         let opt = Optional::<OwnedUniqueName>::try_from(owned).unwrap();
         assert_eq!(
             Option::<OwnedUniqueName>::from(opt).unwrap().as_str(),
@@ -88,7 +85,10 @@ mod tests {
 
     #[test]
     fn optional_name_wire_round_trip() {
-        use crate::wire::{LE, Optional, serialized::Context, to_bytes};
+        use crate::{
+            Optional,
+            wire::{LE, serialized::Context, to_bytes},
+        };
 
         let ctxt = Context::new(LE, 0);
 
@@ -112,8 +112,9 @@ mod tests {
     #[test]
     fn optional_owned_name_is_deserialize_owned() {
         use crate::{
+            Optional,
             names::OwnedBusName,
-            wire::{LE, Optional, serialized::Context, to_bytes},
+            wire::{LE, serialized::Context, to_bytes},
         };
         use serde::de::DeserializeOwned;
 

--- a/zbus/src/names/utils.rs
+++ b/zbus/src/names/utils.rs
@@ -1,8 +1,8 @@
 macro_rules! impl_str_basic {
     ($type:ty) => {
-        impl crate::wire::Basic for $type {
-            const SIGNATURE_CHAR: char = <crate::wire::Str<'_>>::SIGNATURE_CHAR;
-            const SIGNATURE_STR: &'static str = <crate::wire::Str<'_>>::SIGNATURE_STR;
+        impl crate::Basic for $type {
+            const SIGNATURE_CHAR: char = <crate::Str<'_>>::SIGNATURE_CHAR;
+            const SIGNATURE_STR: &'static str = <crate::Str<'_>>::SIGNATURE_STR;
         }
     };
 }
@@ -22,9 +22,9 @@ macro_rules! define_name_type_impls {
         validate: $validate_fn:ident $(,)?
     ) => {
         // === impl_str_basic for borrowed type ===
-        impl crate::wire::Basic for $name<'_> {
-            const SIGNATURE_CHAR: char = <crate::wire::Str<'_>>::SIGNATURE_CHAR;
-            const SIGNATURE_STR: &'static str = <crate::wire::Str<'_>>::SIGNATURE_STR;
+        impl crate::Basic for $name<'_> {
+            const SIGNATURE_CHAR: char = <crate::Str<'_>>::SIGNATURE_CHAR;
+            const SIGNATURE_STR: &'static str = <crate::Str<'_>>::SIGNATURE_STR;
         }
 
         impl<'name> $name<'name> {
@@ -43,19 +43,19 @@ macro_rules! define_name_type_impls {
             /// Since the passed string is not checked for correctness, prefer using the
             /// `TryFrom<&str>` implementation.
             pub fn from_str_unchecked(name: &'name str) -> Self {
-                Self(crate::wire::Str::from(name))
+                Self(crate::Str::from(name))
             }
 
             /// Same as `try_from`, except it takes a `&'static str`.
             pub fn from_static_str(name: &'static str) -> crate::Result<Self> {
                 zbus_utils::names::$validate_fn(name.as_bytes())
                     .map_err(crate::Error::InvalidName)?;
-                Ok(Self(crate::wire::Str::from_static(name)))
+                Ok(Self(crate::Str::from_static(name)))
             }
 
             /// Same as `from_str_unchecked`, except it takes a `&'static str`.
             pub const fn from_static_str_unchecked(name: &'static str) -> Self {
-                Self(crate::wire::Str::from_static(name))
+                Self(crate::Str::from_static(name))
             }
 
             /// Same as `from_str_unchecked`, except it takes an owned `String`.
@@ -63,7 +63,7 @@ macro_rules! define_name_type_impls {
             /// Since the passed string is not checked for correctness, prefer using the
             /// `TryFrom<String>` implementation.
             pub fn from_string_unchecked(name: String) -> Self {
-                Self(crate::wire::Str::from(name))
+                Self(crate::Str::from(name))
             }
 
             /// Creates an owned clone of `self`.
@@ -142,13 +142,13 @@ macro_rules! define_name_type_impls {
             }
         }
 
-        impl<'name> From<$name<'name>> for crate::wire::Str<'name> {
+        impl<'name> From<$name<'name>> for crate::Str<'name> {
             fn from(value: $name<'name>) -> Self {
                 value.0
             }
         }
 
-        impl<'name> crate::wire::NoneValue for $name<'name> {
+        impl<'name> crate::NoneValue for $name<'name> {
             type NoneType = &'name str;
 
             fn null_value() -> Self::NoneType {
@@ -161,7 +161,7 @@ macro_rules! define_name_type_impls {
             type Error = crate::Error;
 
             fn try_from(value: &'s str) -> crate::Result<Self> {
-                let value = crate::wire::Str::from(value);
+                let value = crate::Str::from(value);
                 zbus_utils::names::$validate_fn(value.as_str().as_bytes())
                     .map_err(crate::Error::InvalidName)?;
                 Ok(Self(value))
@@ -180,7 +180,7 @@ macro_rules! define_name_type_impls {
             type Error = crate::Error;
 
             fn try_from(value: String) -> crate::Result<Self> {
-                let value = crate::wire::Str::from(value);
+                let value = crate::Str::from(value);
                 zbus_utils::names::$validate_fn(value.as_str().as_bytes())
                     .map_err(crate::Error::InvalidName)?;
                 Ok(Self(value))
@@ -199,7 +199,7 @@ macro_rules! define_name_type_impls {
             type Error = crate::Error;
 
             fn try_from(value: std::sync::Arc<str>) -> crate::Result<Self> {
-                let value = crate::wire::Str::from(value);
+                let value = crate::Str::from(value);
                 zbus_utils::names::$validate_fn(value.as_str().as_bytes())
                     .map_err(crate::Error::InvalidName)?;
                 Ok(Self(value))
@@ -218,7 +218,7 @@ macro_rules! define_name_type_impls {
             type Error = crate::Error;
 
             fn try_from(value: std::borrow::Cow<'s, str>) -> crate::Result<Self> {
-                let value = crate::wire::Str::from(value);
+                let value = crate::Str::from(value);
                 zbus_utils::names::$validate_fn(value.as_str().as_bytes())
                     .map_err(crate::Error::InvalidName)?;
                 Ok(Self(value))
@@ -233,49 +233,49 @@ macro_rules! define_name_type_impls {
             }
         }
 
-        impl<'s> TryFrom<crate::wire::Str<'s>> for $name<'s> {
+        impl<'s> TryFrom<crate::Str<'s>> for $name<'s> {
             type Error = crate::Error;
 
-            fn try_from(value: crate::wire::Str<'s>) -> crate::Result<Self> {
+            fn try_from(value: crate::Str<'s>) -> crate::Result<Self> {
                 zbus_utils::names::$validate_fn(value.as_str().as_bytes())
                     .map_err(crate::Error::InvalidName)?;
                 Ok(Self(value))
             }
         }
 
-        impl<'s> TryFrom<crate::wire::Str<'s>> for $owned_name {
+        impl<'s> TryFrom<crate::Str<'s>> for $owned_name {
             type Error = crate::Error;
 
-            fn try_from(value: crate::wire::Str<'s>) -> crate::Result<Self> {
+            fn try_from(value: crate::Str<'s>) -> crate::Result<Self> {
                 Ok(Self::from(<$name<'s>>::try_from(value)?))
             }
         }
 
-        impl<'s> TryFrom<crate::wire::Value<'s>> for $name<'s> {
+        impl<'s> TryFrom<crate::Value<'s>> for $name<'s> {
             type Error = crate::Error;
 
-            fn try_from(value: crate::wire::Value<'s>) -> crate::Result<Self> {
-                let s = crate::wire::Str::try_from(value)?;
+            fn try_from(value: crate::Value<'s>) -> crate::Result<Self> {
+                let s = crate::Str::try_from(value)?;
                 Self::try_from(s)
             }
         }
 
-        impl<'s> From<$name<'s>> for crate::wire::Value<'s> {
+        impl<'s> From<$name<'s>> for crate::Value<'s> {
             fn from(name: $name<'s>) -> Self {
                 name.0.into()
             }
         }
 
-        impl TryFrom<crate::wire::OwnedValue> for $name<'_> {
+        impl TryFrom<crate::OwnedValue> for $name<'_> {
             type Error = crate::Error;
 
-            fn try_from(value: crate::wire::OwnedValue) -> crate::Result<Self> {
-                let s = crate::wire::Str::try_from(value)?;
+            fn try_from(value: crate::OwnedValue) -> crate::Result<Self> {
+                let s = crate::Str::try_from(value)?;
                 Self::try_from(s)
             }
         }
 
-        impl TryFrom<$name<'_>> for crate::wire::OwnedValue {
+        impl TryFrom<$name<'_>> for crate::OwnedValue {
             type Error = crate::Error;
 
             fn try_from(name: $name<'_>) -> crate::Result<Self> {
@@ -286,9 +286,9 @@ macro_rules! define_name_type_impls {
         // === Owned type impls ===
 
         // impl_str_basic for owned type
-        impl crate::wire::Basic for $owned_name {
-            const SIGNATURE_CHAR: char = <crate::wire::Str<'_>>::SIGNATURE_CHAR;
-            const SIGNATURE_STR: &'static str = <crate::wire::Str<'_>>::SIGNATURE_STR;
+        impl crate::Basic for $owned_name {
+            const SIGNATURE_CHAR: char = <crate::Str<'_>>::SIGNATURE_CHAR;
+            const SIGNATURE_STR: &'static str = <crate::Str<'_>>::SIGNATURE_STR;
         }
 
         impl $owned_name {
@@ -366,7 +366,7 @@ macro_rules! define_name_type_impls {
             }
         }
 
-        impl From<$owned_name> for crate::wire::Str<'_> {
+        impl From<$owned_name> for crate::Str<'_> {
             fn from(value: $owned_name) -> Self {
                 value.into_inner().0
             }
@@ -397,7 +397,7 @@ macro_rules! define_name_type_impls {
             }
         }
 
-        impl crate::wire::NoneValue for $owned_name {
+        impl crate::NoneValue for $owned_name {
             type NoneType = String;
 
             fn null_value() -> Self::NoneType {
@@ -405,29 +405,29 @@ macro_rules! define_name_type_impls {
             }
         }
 
-        impl TryFrom<crate::wire::Value<'static>> for $owned_name {
+        impl TryFrom<crate::Value<'static>> for $owned_name {
             type Error = crate::Error;
 
-            fn try_from(value: crate::wire::Value<'static>) -> crate::Result<Self> {
+            fn try_from(value: crate::Value<'static>) -> crate::Result<Self> {
                 <$name<'static>>::try_from(value).map(Self::from)
             }
         }
 
-        impl From<$owned_name> for crate::wire::Value<'_> {
+        impl From<$owned_name> for crate::Value<'_> {
             fn from(name: $owned_name) -> Self {
                 name.0.into()
             }
         }
 
-        impl TryFrom<crate::wire::OwnedValue> for $owned_name {
+        impl TryFrom<crate::OwnedValue> for $owned_name {
             type Error = crate::Error;
 
-            fn try_from(value: crate::wire::OwnedValue) -> crate::Result<Self> {
+            fn try_from(value: crate::OwnedValue) -> crate::Result<Self> {
                 <$name<'static>>::try_from(value).map(Self::from)
             }
         }
 
-        impl TryFrom<$owned_name> for crate::wire::OwnedValue {
+        impl TryFrom<$owned_name> for crate::OwnedValue {
             type Error = crate::Error;
 
             fn try_from(name: $owned_name) -> crate::Result<Self> {

--- a/zbus/src/names/well_known_name.rs
+++ b/zbus/src/names/well_known_name.rs
@@ -1,7 +1,4 @@
-use crate::{
-    names::utils::define_name_type_impls,
-    wire::{Str, Type},
-};
+use crate::{Str, Type, names::utils::define_name_type_impls};
 use serde::Serialize;
 
 /// String that identifies a [well-known bus name][wbn].

--- a/zbus/src/object_server/dispatch_notifier.rs
+++ b/zbus/src/object_server/dispatch_notifier.rs
@@ -3,7 +3,7 @@
 use event_listener::{Event, EventListener};
 use serde::{Deserialize, Serialize};
 
-use crate::wire::{Signature, Type};
+use crate::{Signature, Type};
 
 /// A response wrapper that notifies after the response has been sent.
 ///

--- a/zbus/src/object_server/interface/dispatch_result.rs
+++ b/zbus/src/object_server/interface/dispatch_result.rs
@@ -2,7 +2,7 @@ use std::{future::Future, pin::Pin};
 
 use zbus::message::Flags;
 
-use crate::{Connection, fdo, message::Message, wire::DynamicType};
+use crate::{Connection, DynamicType, fdo, message::Message};
 use tracing::trace;
 
 /// A helper type returned by [`Interface`](`crate::object_server::Interface`) callbacks.

--- a/zbus/src/object_server/interface/mod.rs
+++ b/zbus/src/object_server/interface/mod.rs
@@ -15,13 +15,12 @@ use std::{
 use async_trait::async_trait;
 
 use crate::{
-    Connection, ObjectServer,
+    Connection, ObjectServer, OwnedValue, Value,
     async_lock::RwLock,
     fdo,
     message::{self, Header, Message},
     names::{InterfaceName, MemberName},
     object_server::SignalEmitter,
-    wire::{OwnedValue, Value},
 };
 
 /// This trait is used to dispatch messages to an interface instance.

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -4,14 +4,13 @@ use std::{collections::HashMap, marker::PhantomData, sync::Arc};
 use tracing::{Instrument, debug, instrument, trace, trace_span};
 
 use crate::{
-    Connection, Error, Result,
+    Connection, Error, ObjectPath, Result, Value,
     async_lock::RwLock,
     connection::WeakConnection,
     fdo,
     fdo::ObjectManager,
     message::{Header, Message},
     names::InterfaceName,
-    wire::{ObjectPath, Value},
 };
 
 mod interface;

--- a/zbus/src/object_server/node.rs
+++ b/zbus/src/object_server/node.rs
@@ -6,11 +6,10 @@ use std::{
 };
 
 use crate::{
-    Connection, ObjectServer,
+    Connection, ObjectPath, ObjectServer, OwnedObjectPath, OwnedValue,
     fdo::{self, Introspectable, ManagedObjects, ObjectManager, Peer, Properties},
     names::InterfaceName,
     object_server::SignalEmitter,
-    wire::{ObjectPath, OwnedObjectPath, OwnedValue},
 };
 
 use super::{ArcInterface, Interface};

--- a/zbus/src/object_server/signal_emitter.rs
+++ b/zbus/src/object_server/signal_emitter.rs
@@ -1,7 +1,6 @@
 use crate::{
-    Connection, Error, Result,
+    Connection, Error, ObjectPath, Result,
     names::{BusName, InterfaceName, MemberName},
-    wire::ObjectPath,
 };
 
 /// A signal emitter.
@@ -49,7 +48,7 @@ impl<'s> SignalEmitter<'s> {
         I::Error: Into<Error>,
         M: TryInto<MemberName<'m>>,
         M::Error: Into<Error>,
-        B: serde::ser::Serialize + crate::wire::DynamicType,
+        B: serde::ser::Serialize + crate::DynamicType,
     {
         self.conn
             .emit_signal(

--- a/zbus/src/proxy/builder.rs
+++ b/zbus/src/proxy/builder.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashSet, marker::PhantomData, sync::Arc};
 
 use crate::{
+    ObjectPath, Str,
     names::{BusName, InterfaceName},
-    wire::{ObjectPath, Str},
 };
 
 use crate::{Connection, Error, Proxy, Result, proxy::ProxyInner};

--- a/zbus/src/proxy/defaults.rs
+++ b/zbus/src/proxy/defaults.rs
@@ -1,6 +1,6 @@
 use crate::{
+    ObjectPath,
     names::{BusName, InterfaceName},
-    wire::ObjectPath,
 };
 
 /// Trait for the default associated values of a proxy.

--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -16,11 +16,11 @@ use std::{
 use tracing::{Instrument, debug, info_span, instrument, trace, warn};
 
 use crate::{
-    AsyncDrop, Connection, Error, Executor, MatchRule, MessageStream, OwnedMatchRule, Result, Task,
+    AsyncDrop, Connection, Error, Executor, MatchRule, MessageStream, ObjectPath, OwnedMatchRule,
+    OwnedValue, Result, Str, Task, Value, as_value,
     fdo::{self, IntrospectableProxy, NameOwnerChanged, PropertiesChangedStream, PropertiesProxy},
     message::{Flags, Message, Sequence, Type},
     names::{BusName, InterfaceName, MemberName, UniqueName},
-    wire::{ObjectPath, OwnedValue, Str, Value, as_value},
 };
 
 mod builder;
@@ -189,7 +189,7 @@ impl<T> PropertyChanged<'_, T> {
 
 impl<T> PropertyChanged<'_, T>
 where
-    T: serde::de::DeserializeOwned + crate::wire::Type,
+    T: serde::de::DeserializeOwned + crate::Type,
 {
     /// Get the value of the property that changed.
     ///
@@ -265,7 +265,7 @@ impl PropertiesCache {
         proxy: PropertiesProxy<'static>,
         interface: InterfaceName<'static>,
         executor: &Executor<'_>,
-        uncached_properties: HashSet<crate::wire::Str<'static>>,
+        uncached_properties: HashSet<crate::Str<'static>>,
     ) -> (Arc<Self>, Task<()>) {
         let cache = Arc::new(PropertiesCache {
             values: Default::default(),
@@ -326,11 +326,11 @@ impl PropertiesCache {
         &self,
         proxy: PropertiesProxy<'static>,
         interface: InterfaceName<'static>,
-        uncached_properties: HashSet<crate::wire::Str<'static>>,
+        uncached_properties: HashSet<crate::Str<'static>>,
     ) -> Result<(
         PropertiesChangedStream,
         InterfaceName<'static>,
-        HashSet<crate::wire::Str<'static>>,
+        HashSet<crate::Str<'static>>,
     )> {
         use ordered_stream::OrderedStreamExt;
 
@@ -394,7 +394,7 @@ impl PropertiesCache {
         &self,
         mut prop_changes: PropertiesChangedStream,
         interface: InterfaceName<'static>,
-        uncached_properties: HashSet<crate::wire::Str<'static>>,
+        uncached_properties: HashSet<crate::Str<'static>>,
     ) -> Result<()> {
         use futures_lite::StreamExt;
 
@@ -689,7 +689,7 @@ impl<'a> Proxy<'a> {
         let (cache, _) = &cache.get_or_init(|| {
             let proxy = self.owned_properties_proxy();
             let interface = self.interface().to_owned();
-            let uncached_properties: HashSet<crate::wire::Str<'static>> = self
+            let uncached_properties: HashSet<crate::Str<'static>> = self
                 .inner
                 .uncached_properties
                 .iter()
@@ -711,7 +711,7 @@ impl<'a> Proxy<'a> {
     /// the peer.
     pub fn cached_property<T>(&self, property_name: &str) -> Result<Option<T>>
     where
-        T: serde::de::DeserializeOwned + crate::wire::Type,
+        T: serde::de::DeserializeOwned + crate::Type,
     {
         self.cached_property_raw(property_name)
             .as_deref()
@@ -779,7 +779,7 @@ impl<'a> Proxy<'a> {
     /// `Get` method of the `org.freedesktop.DBus.Properties` interface.
     pub async fn get_property<T>(&self, property_name: &str) -> Result<T>
     where
-        T: serde::de::DeserializeOwned + crate::wire::Type,
+        T: serde::de::DeserializeOwned + crate::Type,
     {
         if let Some(cache) = self.get_property_cache() {
             cache.ready().await?;
@@ -797,13 +797,13 @@ impl<'a> Proxy<'a> {
     /// Effectively, call the `Set` method of the `org.freedesktop.DBus.Properties` interface.
     pub async fn set_property<T>(&self, property_name: &str, value: T) -> fdo::Result<()>
     where
-        T: serde::Serialize + crate::wire::Type,
+        T: serde::Serialize + crate::Type,
     {
         self.properties_proxy()
             .inner()
             .call::<_, _, ()>(
                 "Set",
-                &crate::wire::DynamicTuple((
+                &crate::DynamicTuple((
                     self.inner.interface.as_ref(),
                     property_name,
                     as_value::Serialize(&value),
@@ -825,7 +825,7 @@ impl<'a> Proxy<'a> {
     where
         M: TryInto<MemberName<'m>>,
         M::Error: Into<Error>,
-        B: serde::ser::Serialize + crate::wire::DynamicType,
+        B: serde::ser::Serialize + crate::DynamicType,
     {
         self.inner
             .inner_without_borrows
@@ -849,7 +849,7 @@ impl<'a> Proxy<'a> {
     where
         M: TryInto<MemberName<'m>>,
         M::Error: Into<Error>,
-        B: serde::ser::Serialize + crate::wire::DynamicType,
+        B: serde::ser::Serialize + crate::DynamicType,
         R: for<'d> crate::wire::DynamicDeserialize<'d>,
     {
         let reply = self.call_method(method_name, body).await?;
@@ -875,7 +875,7 @@ impl<'a> Proxy<'a> {
     where
         M: TryInto<MemberName<'m>>,
         M::Error: Into<Error>,
-        B: serde::ser::Serialize + crate::wire::DynamicType,
+        B: serde::ser::Serialize + crate::DynamicType,
         R: for<'d> crate::wire::DynamicDeserialize<'d>,
     {
         let flags = flags.iter().map(Flags::from).collect::<BitFlags<_>>();
@@ -905,7 +905,7 @@ impl<'a> Proxy<'a> {
     where
         M: TryInto<MemberName<'m>>,
         M::Error: Into<Error>,
-        B: serde::ser::Serialize + crate::wire::DynamicType,
+        B: serde::ser::Serialize + crate::DynamicType,
     {
         self.call_with_flags::<_, _, ()>(method_name, MethodFlags::NoReplyExpected.into(), body)
             .await?;
@@ -1371,7 +1371,7 @@ where
 
 fn convert_property_value<T>(value: &Value<'_>) -> Result<T>
 where
-    T: serde::de::DeserializeOwned + crate::wire::Type,
+    T: serde::de::DeserializeOwned + crate::Type,
 {
     as_value::deserialize_for_property(value)
 }

--- a/zbus/src/wire/as_value/deserialize.rs
+++ b/zbus/src/wire/as_value/deserialize.rs
@@ -8,10 +8,10 @@ use crate::wire::{Signature, Type};
 /// A wrapper to deserialize a value to `T: Type + serde::Deserialize`.
 ///
 /// When the type of a value is well-known, you may avoid the cost and complexity of wrapping to a
-/// generic [`enum@crate::wire::Value`] and instead use this wrapper.
+/// generic [`enum@crate::Value`] and instead use this wrapper.
 ///
 /// ```
-/// # use zbus::wire::{to_bytes, serialized::Context, as_value::{Deserialize, Serialize}, LE};
+/// # use zbus::{as_value::{Deserialize, Serialize}, wire::{LE, serialized::Context, to_bytes}};
 /// #
 /// # let ctxt = Context::new(LE, 0);
 /// # let array = [0, 1, 2];
@@ -82,7 +82,7 @@ impl<'de, T: Type + serde::Deserialize<'de>> Type for Deserialize<'de, T> {
     const SIGNATURE: &'static Signature = &Signature::Variant;
 }
 
-/// Deserialize a value as a [`enum@zbus::wire::Value`].
+/// Deserialize a value as a [`enum@zbus::Value`].
 pub fn deserialize<'de, T, D>(deserializer: D) -> std::result::Result<T, D::Error>
 where
     D: Deserializer<'de>,
@@ -93,7 +93,7 @@ where
     Deserialize::deserialize(deserializer).map(|v| v.0)
 }
 
-/// Deserialize an optional value as a [`enum@zbus::wire::Value`].
+/// Deserialize an optional value as a [`enum@zbus::Value`].
 pub fn deserialize_optional<'de, T, D>(deserializer: D) -> std::result::Result<Option<T>, D::Error>
 where
     D: Deserializer<'de>,

--- a/zbus/src/wire/as_value/mod.rs
+++ b/zbus/src/wire/as_value/mod.rs
@@ -1,4 +1,4 @@
-//! Utilities to (de)serialize a value as a [`enum@zbus::wire::Value`].
+//! Utilities to (de)serialize a value as a [`enum@zbus::Value`].
 //!
 //! This is mainly useful for constructing a strongly-typed API for dealing with dictionaries
 //! containing string keys and variant values (`a{sv}` in D-Bus language) See the relevant
@@ -15,7 +15,7 @@ pub use property::deserialize_for_property;
 mod value_serializer;
 pub use value_serializer::to_owned_value;
 
-/// Utilities to (de)serialize an optional value as a [`enum@zbus::wire::Value`].
+/// Utilities to (de)serialize an optional value as a [`enum@zbus::Value`].
 pub mod optional {
     use super::*;
 

--- a/zbus/src/wire/as_value/property.rs
+++ b/zbus/src/wire/as_value/property.rs
@@ -864,7 +864,7 @@ mod tests {
     use serde::Deserialize;
 
     use super::*;
-    use crate::wire::{Array, OwnedValue, StructureBuilder, Type};
+    use crate::wire::{Array, OwnedValue, Structure, Type};
 
     fn convert_property_value<T>(value: &Value<'_>) -> T
     where
@@ -897,7 +897,7 @@ mod tests {
             .unwrap();
         let mut outer = Array::new(inner.signature());
         outer.append(Value::Array(inner)).unwrap();
-        let structure = StructureBuilder::new()
+        let structure = Structure::builder()
             .append_field(Value::Array(outer))
             .build()
             .unwrap();
@@ -965,16 +965,16 @@ mod tests {
 
     #[test]
     fn unwraps_variant_structure_and_enum_fields() {
-        #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize, crate::wire::Type)]
+        #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize, crate::Type)]
         struct WithValue(u32, OwnedValue);
 
-        #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize, crate::wire::Type)]
+        #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize, crate::Type)]
         enum NewType {
             First(OwnedValue),
             Second(OwnedValue),
         }
 
-        #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize, crate::wire::Type)]
+        #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize, crate::Type)]
         enum Fields {
             First(u8, OwnedValue),
             Second { y: u8, value: OwnedValue },
@@ -1015,7 +1015,7 @@ mod tests {
     #[test]
     fn deserializes_repr_enums() {
         #[repr(u32)]
-        #[derive(Debug, PartialEq, crate::wire::Type, serde_repr::Deserialize_repr)]
+        #[derive(Debug, PartialEq, crate::Type, serde_repr::Deserialize_repr)]
         enum Kind {
             First = 1,
             Second = 2,
@@ -1030,7 +1030,7 @@ mod tests {
 
     #[test]
     fn deserializes_wire_enum_representations() {
-        #[derive(Debug, PartialEq, crate::wire::Type, serde::Deserialize)]
+        #[derive(Debug, PartialEq, crate::Type, serde::Deserialize)]
         enum Unit {
             First,
             Second,
@@ -1042,7 +1042,7 @@ mod tests {
             Unit::Second
         );
 
-        #[derive(Debug, PartialEq, crate::wire::Type, serde::Deserialize)]
+        #[derive(Debug, PartialEq, crate::Type, serde::Deserialize)]
         #[zvariant(signature = "s")]
         #[serde(rename_all = "snake_case")]
         enum StringUnit {
@@ -1056,13 +1056,13 @@ mod tests {
             StringUnit::Second
         );
 
-        #[derive(Debug, PartialEq, crate::wire::Type, serde::Deserialize)]
+        #[derive(Debug, PartialEq, crate::Type, serde::Deserialize)]
         enum NewType {
             First(f64),
             Second(f64),
         }
 
-        let value = StructureBuilder::new()
+        let value = Structure::builder()
             .append_field(Value::U32(1))
             .append_field(Value::F64(2.5))
             .build()
@@ -1072,18 +1072,18 @@ mod tests {
             NewType::Second(2.5)
         );
 
-        #[derive(Debug, PartialEq, crate::wire::Type, serde::Deserialize)]
+        #[derive(Debug, PartialEq, crate::Type, serde::Deserialize)]
         enum Fields {
             First(u8, u32),
             Second { y: u8, t: u32 },
         }
 
-        let payload = StructureBuilder::new()
+        let payload = Structure::builder()
             .append_field(Value::U8(3))
             .append_field(Value::U32(4))
             .build()
             .unwrap();
-        let value = StructureBuilder::new()
+        let value = Structure::builder()
             .append_field(Value::U32(1))
             .append_field(Value::Structure(payload))
             .build()
@@ -1096,7 +1096,7 @@ mod tests {
 
     #[test]
     fn deserializes_value_containers_and_dict_structs() {
-        #[derive(Debug, PartialEq, crate::wire::DeserializeDict, crate::wire::Type)]
+        #[derive(Debug, PartialEq, crate::DeserializeDict, crate::Type)]
         #[zvariant(signature = "dict")]
         struct DictStruct {
             count: u32,
@@ -1127,7 +1127,7 @@ mod tests {
 
     #[test]
     fn deserializes_empty_structs() {
-        #[derive(serde::Deserialize, crate::wire::Type)]
+        #[derive(serde::Deserialize, crate::Type)]
         struct Empty {}
 
         deserialize_for_property::<Empty>(&Value::U8(0)).unwrap();

--- a/zbus/src/wire/as_value/serialize.rs
+++ b/zbus/src/wire/as_value/serialize.rs
@@ -5,10 +5,10 @@ use crate::wire::{Signature, Type};
 /// A wrapper to serialize `T: Type + serde::Serialize` as a value.
 ///
 /// When the type of a value is well-known, you may avoid the cost and complexity of wrapping to a
-/// generic [`enum@crate::wire::Value`] and instead use this wrapper.
+/// generic [`enum@crate::Value`] and instead use this wrapper.
 ///
 /// ```
-/// # use zbus::wire::{to_bytes, serialized::Context, as_value::Serialize, LE};
+/// # use zbus::{as_value::Serialize, wire::{LE, serialized::Context, to_bytes}};
 /// #
 /// # let ctxt = Context::new(LE, 0);
 /// let _ = to_bytes(ctxt, &Serialize(&[0, 1, 2])).unwrap();
@@ -38,10 +38,10 @@ impl<T: Type + serde::Serialize> serde::Serialize for Serialize<'_, T> {
 }
 
 impl<T: Type + serde::Serialize> Type for Serialize<'_, T> {
-    const SIGNATURE: &'static crate::wire::Signature = &crate::wire::Signature::Variant;
+    const SIGNATURE: &'static crate::Signature = &crate::Signature::Variant;
 }
 
-/// Serialize a value as a [`enum@zbus::wire::Value`].
+/// Serialize a value as a [`enum@zbus::Value`].
 pub fn serialize<T, S>(value: &T, ser: S) -> std::result::Result<S::Ok, S::Error>
 where
     S: Serializer,
@@ -52,7 +52,7 @@ where
     Serialize(value).serialize(ser)
 }
 
-/// Serialize an optional value as a [`enum@zbus::wire::Value`].
+/// Serialize an optional value as a [`enum@zbus::Value`].
 pub fn serialize_optional<T, S>(value: &Option<T>, ser: S) -> std::result::Result<S::Ok, S::Error>
 where
     S: Serializer,

--- a/zbus/src/wire/as_value/value_serializer.rs
+++ b/zbus/src/wire/as_value/value_serializer.rs
@@ -10,8 +10,7 @@ use serde::{
 };
 
 use crate::wire::{
-    Array, Dict, OwnedValue, Signature, StructureBuilder, Type, Value,
-    container_depths::ContainerDepths,
+    Array, Dict, OwnedValue, Signature, Structure, Type, Value, container_depths::ContainerDepths,
 };
 
 #[cfg(unix)]
@@ -94,7 +93,7 @@ impl ser::Serializer for &mut ValueSerializer {
             // SAFETY: `value` is the raw descriptor supplied by the Serialize implementation.
             // It is borrowed only for the duration of the immediate clone operation.
             let fd = unsafe { BorrowedFd::borrow_raw(value) }.try_clone_to_owned()?;
-            return Ok(Value::Fd(crate::wire::Fd::Owned(fd)));
+            return Ok(Value::Fd(crate::Fd::Owned(fd)));
         }
 
         self.expect(Signature::I32).map(|()| Value::I32(value))
@@ -136,7 +135,7 @@ impl ser::Serializer for &mut ValueSerializer {
     fn serialize_str(self, value: &str) -> crate::Result<Self::Ok> {
         match self.signature {
             Signature::Str => Ok(Value::Str(value.to_owned().into())),
-            Signature::ObjectPath => Ok(Value::ObjectPath(crate::wire::ObjectPath::try_from(
+            Signature::ObjectPath => Ok(Value::ObjectPath(crate::ObjectPath::try_from(
                 value.to_owned(),
             )?)),
             Signature::Signature => Ok(Value::Signature(value.parse()?)),
@@ -494,12 +493,12 @@ impl StructSerializer {
                     "an enum variant with the expected number of fields".to_owned(),
                 ));
             }
-            let mut builder = StructureBuilder::new();
+            let mut builder = Structure::builder();
             builder.push_value(Value::U32(match self.fields.first() {
                 Some(Value::U32(index)) => *index,
                 _ => unreachable!(),
             }));
-            let mut inner_builder = StructureBuilder::new();
+            let mut inner_builder = Structure::builder();
             for field in inner_fields {
                 inner_builder.push_value(field);
             }
@@ -522,7 +521,7 @@ impl StructSerializer {
         if self.expected == Signature::U8 && self.fields.len() == 1 {
             return Ok(self.fields.pop().expect("unit field is present"));
         }
-        let mut builder = StructureBuilder::new();
+        let mut builder = Structure::builder();
         for field in self.fields {
             builder.push_value(field);
         }
@@ -710,32 +709,32 @@ mod tests {
     use super::*;
     use crate::wire::{LE, serialized::Context, to_bytes};
 
-    #[derive(Debug, PartialEq, serde::Serialize, crate::wire::Type)]
+    #[derive(Debug, PartialEq, serde::Serialize, crate::Type)]
     struct Pair(u32, String);
 
-    #[derive(serde::Serialize, crate::wire::Type)]
+    #[derive(serde::Serialize, crate::Type)]
     struct Empty {}
 
-    #[derive(crate::wire::SerializeDict, crate::wire::Type)]
+    #[derive(crate::SerializeDict, crate::Type)]
     #[zvariant(signature = "dict")]
     struct DictStruct {
         count: u32,
         name: String,
     }
 
-    #[derive(Debug, PartialEq, serde::Serialize, crate::wire::Type)]
+    #[derive(Debug, PartialEq, serde::Serialize, crate::Type)]
     enum Enum {
         First(u32, String),
         Second(u32, String),
     }
 
-    #[derive(serde::Serialize, crate::wire::Type)]
+    #[derive(serde::Serialize, crate::Type)]
     enum UnitEnum {
         First,
         Second,
     }
 
-    #[derive(serde::Serialize, crate::wire::Type)]
+    #[derive(serde::Serialize, crate::Type)]
     #[zvariant(signature = "s")]
     #[serde(rename_all = "snake_case")]
     enum StringEnum {
@@ -744,7 +743,7 @@ mod tests {
     }
 
     #[repr(u32)]
-    #[derive(serde_repr::Serialize_repr, crate::wire::Type)]
+    #[derive(serde_repr::Serialize_repr, crate::Type)]
     enum ReprEnum {
         First = 1,
         Second = 2,

--- a/zbus/src/wire/basic.rs
+++ b/zbus/src/wire/basic.rs
@@ -395,7 +395,7 @@ mod tests {
     assert_impl_all!([u8; 0]: Basic);
     assert_impl_all!(std::path::Path: Basic);
     assert_impl_all!(std::path::PathBuf: Basic);
-    assert_impl_all!(crate::wire::Optional<u8>: Basic);
+    assert_impl_all!(crate::Optional<u8>: Basic);
 
     #[cfg(feature = "arrayvec")]
     assert_impl_all!(arrayvec::ArrayString<8>: Basic);

--- a/zbus/src/wire/fd.rs
+++ b/zbus/src/wire/fd.rs
@@ -114,7 +114,7 @@ macro_rules! fd_impl {
         }
 
         impl Type for $i {
-            const SIGNATURE: &'static crate::wire::Signature = &crate::wire::Signature::Fd;
+            const SIGNATURE: &'static crate::Signature = &crate::Signature::Fd;
         }
     };
 }

--- a/zbus/src/wire/file_path.rs
+++ b/zbus/src/wire/file_path.rs
@@ -5,11 +5,11 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::wire::Type;
+use crate::Type;
 
 /// File name represented as a nul-terminated byte array.
 ///
-/// While `zbus::wire::Type` and `serde::{Serialize, Deserialize}`, are implemented for [`Path`] and
+/// While `zbus::Type` and `serde::{Serialize, Deserialize}`, are implemented for [`Path`] and
 /// [`PathBuf`], unfortunately `serde` serializes them as UTF-8 strings and that limits the number
 /// of possible characters to use on a file path. This is not the desired behavior since file paths
 /// are not guaranteed to contain only UTF-8 characters.
@@ -20,7 +20,7 @@ use crate::wire::Type;
 /// # Examples:
 ///
 /// ```
-/// use zbus::wire::FilePath;
+/// use zbus::FilePath;
 /// use std::path::{Path, PathBuf};
 ///
 /// let path = Path::new("/hello/world\0");
@@ -177,7 +177,7 @@ fn bytes_with_null(bytes: &[u8]) -> Cow<'_, CStr> {
 #[cfg(test)]
 mod file_path_test {
     use super::*;
-    use crate::wire::Signature;
+    use crate::Signature;
     use std::path::{Path, PathBuf};
 
     #[test]

--- a/zbus/src/wire/from_value.rs
+++ b/zbus/src/wire/from_value.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 #[cfg(unix)]
-use crate::wire::Fd;
+use crate::Fd;
 
 use std::{
     collections::{BTreeMap, HashMap},
@@ -171,7 +171,7 @@ where
 
 impl<'a, K, V> TryFrom<Value<'a>> for BTreeMap<K, V>
 where
-    K: crate::wire::Basic + TryFrom<Value<'a>> + std::cmp::Ord,
+    K: crate::Basic + TryFrom<Value<'a>> + std::cmp::Ord,
     V: TryFrom<Value<'a>>,
     K::Error: Into<crate::wire::Error>,
     V::Error: Into<crate::wire::Error>,
@@ -189,7 +189,7 @@ where
 
 impl<'a, K, V, H> TryFrom<Value<'a>> for HashMap<K, V, H>
 where
-    K: crate::wire::Basic + TryFrom<Value<'a>> + std::hash::Hash + std::cmp::Eq,
+    K: crate::Basic + TryFrom<Value<'a>> + std::hash::Hash + std::cmp::Eq,
     V: TryFrom<Value<'a>>,
     H: BuildHasher + Default,
     K::Error: Into<crate::Error>,

--- a/zbus/src/wire/into_value.rs
+++ b/zbus/src/wire/into_value.rs
@@ -10,7 +10,7 @@ use crate::wire::{
 };
 
 #[cfg(unix)]
-use crate::wire::Fd;
+use crate::Fd;
 
 //
 // Conversions from encodable types to `Value`

--- a/zbus/src/wire/mod.rs
+++ b/zbus/src/wire/mod.rs
@@ -3,6 +3,9 @@
 //! This module encodes and decodes data to and from the [D-Bus wire format][dwf]. The format is
 //! simple and very efficient, which makes it useful outside of a D-Bus context as well.
 //!
+//! Commonly used types and traits are re-exported at the [`crate`] root. This module contains the
+//! lower-level encoding and decoding API.
+//!
 //! The API is [serde]-based, so you will find it intuitive if you are already familiar with
 //! serde. If you are not, you may want to read serde's [tutorial] first.
 //!
@@ -28,7 +31,7 @@
 //!
 //! ```
 //! use std::collections::HashMap;
-//! use zbus::wire::{serialized::Context, to_bytes, Type, LE};
+//! use zbus::{Type, wire::{LE, serialized::Context, to_bytes}};
 //! use serde::{Deserialize, Serialize};
 //!
 //! // All serialization and deserialization API, needs a context.

--- a/zbus/src/wire/mod.rs
+++ b/zbus/src/wire/mod.rs
@@ -22,8 +22,9 @@
 //! ```
 //!
 //! That build contains no connection, proxy or object server, and pulls in nothing beyond what
-//! the encoding itself needs. Enabling any D-Bus feature (`comms`, `async-io`, `tokio`,
-//! `blocking-api`, `p2p`, `bus-impl`, `vsock`, `tokio-vsock`) brings the whole API back.
+//! the encoding itself needs. Runtime features such as `async-io` and `tokio` enable `comms`
+//! for connections and messages. Enable `proxy` for clients and `service` for the object server;
+//! both features are enabled by default.
 //!
 //! # Example
 //!

--- a/zbus/src/wire/object_path.rs
+++ b/zbus/src/wire/object_path.rs
@@ -18,7 +18,7 @@ use zbus_utils::object_path;
 /// # Examples
 ///
 /// ```
-/// use zbus::wire::ObjectPath;
+/// use zbus::ObjectPath;
 ///
 /// // Valid object paths
 /// let o = ObjectPath::try_from("/").unwrap();
@@ -129,7 +129,7 @@ impl Basic for ObjectPath<'_> {
 }
 
 impl Type for ObjectPath<'_> {
-    const SIGNATURE: &'static crate::wire::Signature = &crate::wire::Signature::ObjectPath;
+    const SIGNATURE: &'static crate::Signature = &crate::Signature::ObjectPath;
 }
 
 impl<'a> TryFrom<&'a [u8]> for ObjectPath<'a> {
@@ -288,7 +288,7 @@ impl std::convert::From<OwnedObjectPath> for ObjectPath<'static> {
     }
 }
 
-impl std::convert::From<OwnedObjectPath> for crate::wire::Value<'_> {
+impl std::convert::From<OwnedObjectPath> for crate::Value<'_> {
     fn from(o: OwnedObjectPath) -> Self {
         o.into_inner().into()
     }

--- a/zbus/src/wire/optional.rs
+++ b/zbus/src/wire/optional.rs
@@ -52,7 +52,7 @@ where
 /// # Examples
 ///
 /// ```
-/// use zbus::wire::{serialized::Context, Optional, to_bytes, LE};
+/// use zbus::{Optional, wire::{LE, serialized::Context, to_bytes}};
 ///
 /// // `Null` case.
 /// let ctxt = Context::new(LE, 0);
@@ -88,7 +88,7 @@ impl<T> Type for Optional<T>
 where
     T: Type,
 {
-    const SIGNATURE: &'static crate::wire::Signature = T::SIGNATURE;
+    const SIGNATURE: &'static crate::Signature = T::SIGNATURE;
 }
 
 impl<T> Serialize for Optional<T>

--- a/zbus/src/wire/owned_value.rs
+++ b/zbus/src/wire/owned_value.rs
@@ -11,7 +11,7 @@ use crate::wire::{
 };
 
 #[cfg(unix)]
-use crate::wire::Fd;
+use crate::Fd;
 
 // FIXME: Replace with a generic impl<T: TryFrom<Value>> TryFrom<OwnedValue> for T?
 // https://github.com/z-galaxy/zbus/issues/138
@@ -129,7 +129,7 @@ where
 
 impl<'k, 'v, K, V> TryFrom<OwnedValue> for BTreeMap<K, V>
 where
-    K: crate::wire::Basic + TryFrom<Value<'k>> + std::cmp::Ord,
+    K: crate::Basic + TryFrom<Value<'k>> + std::cmp::Ord,
     V: TryFrom<Value<'v>>,
     K::Error: Into<crate::wire::Error>,
     V::Error: Into<crate::wire::Error>,
@@ -157,7 +157,7 @@ where
 
 impl<'k, 'v, K, V, H> TryFrom<OwnedValue> for HashMap<K, V, H>
 where
-    K: crate::wire::Basic + TryFrom<Value<'k>> + std::hash::Hash + std::cmp::Eq,
+    K: crate::Basic + TryFrom<Value<'k>> + std::hash::Hash + std::cmp::Eq,
     V: TryFrom<Value<'v>>,
     H: BuildHasher + Default,
     K::Error: Into<crate::Error>,

--- a/zbus/src/wire/serialized/written.rs
+++ b/zbus/src/wire/serialized/written.rs
@@ -1,5 +1,5 @@
 #[cfg(unix)]
-use crate::wire::OwnedFd;
+use crate::OwnedFd;
 use std::ops::Deref;
 
 use crate::wire::serialized::Context;

--- a/zbus/src/wire/signature.rs
+++ b/zbus/src/wire/signature.rs
@@ -11,8 +11,8 @@ impl Basic for Signature {
     const SIGNATURE_STR: &'static str = "g";
 }
 
-impl From<Signature> for crate::wire::Value<'static> {
+impl From<Signature> for crate::Value<'static> {
     fn from(value: Signature) -> Self {
-        crate::wire::Value::Signature(value)
+        crate::Value::Signature(value)
     }
 }

--- a/zbus/src/wire/str.rs
+++ b/zbus/src/wire/str.rs
@@ -1,6 +1,6 @@
 /// This type is used for keeping strings in a [`Value`], among other things.
 ///
-/// [`Value`]: crate::wire::Value::Str
+/// [`Value`]: crate::Value::Str
 pub use zcheapstr::CheapStr as Str;
 
 use crate::wire::{Basic, Type};
@@ -11,5 +11,5 @@ impl Basic for Str<'_> {
 }
 
 impl Type for Str<'_> {
-    const SIGNATURE: &'static crate::wire::Signature = &crate::wire::Signature::Str;
+    const SIGNATURE: &'static crate::Signature = &crate::Signature::Str;
 }

--- a/zbus/src/wire/structure.rs
+++ b/zbus/src/wire/structure.rs
@@ -12,6 +12,8 @@ use crate::wire::{
 
 /// Use this to efficiently build a [`Structure`].
 ///
+/// Create one with [`Structure::builder`].
+///
 /// [`Structure`]: struct.Structure.html
 #[derive(Debug, Default, PartialEq)]
 pub struct StructureBuilder<'a>(Vec<Value<'a>>);
@@ -175,6 +177,24 @@ pub struct Structure<'a> {
 }
 
 impl<'a> Structure<'a> {
+    /// A builder for a new structure.
+    ///
+    /// ```
+    /// use zbus::Structure;
+    ///
+    /// let name = String::from("hello");
+    /// let structure = Structure::builder()
+    ///     .add_field(name.as_str())
+    ///     .add_field(42u32)
+    ///     .build()?;
+    /// assert_eq!(structure.signature(), "(su)");
+    /// # Ok::<(), zbus::Error>(())
+    /// ```
+    #[must_use]
+    pub fn builder() -> StructureBuilder<'a> {
+        StructureBuilder::new()
+    }
+
     /// Get a reference to all the fields of `self`.
     pub fn fields(&self) -> &[Value<'a>] {
         &self.fields
@@ -312,7 +332,7 @@ macro_rules! tuple_impls {
             {
                 #[inline]
                 fn from(value: ($($name),+,)) -> Self {
-                    StructureBuilder::new()
+                    Self::builder()
                     $(
                         .add_field(value. $n)
                     )+

--- a/zbus/src/wire/tuple.rs
+++ b/zbus/src/wire/tuple.rs
@@ -116,7 +116,7 @@ macro_rules! tuple_impls {
                     signature: &Signature,
                 ) -> crate::Result<Self::Deserializer> {
                     let mut fields_iter = match &signature {
-                        crate::wire::Signature::Structure(fields) => fields.iter(),
+                        crate::Signature::Structure(fields) => fields.iter(),
                         _ => return Err(crate::Error::IncorrectType),
                     };
 

--- a/zbus/src/wire/type/bytes.rs
+++ b/zbus/src/wire/type/bytes.rs
@@ -1,9 +1,9 @@
-use crate::wire::Signature;
+use crate::Signature;
 
-impl crate::wire::Type for serde_bytes::Bytes {
+impl crate::Type for serde_bytes::Bytes {
     const SIGNATURE: &'static Signature = &Signature::static_array(&Signature::U8);
 }
 
-impl crate::wire::Type for serde_bytes::ByteBuf {
+impl crate::Type for serde_bytes::ByteBuf {
     const SIGNATURE: &'static Signature = &Signature::static_array(&Signature::U8);
 }

--- a/zbus/src/wire/type/libstd.rs
+++ b/zbus/src/wire/type/libstd.rs
@@ -281,7 +281,7 @@ mod tests {
     type NonBasicBTreeMap = BTreeMap<Vec<u8>, u8>;
     type PathHashMap = HashMap<std::path::PathBuf, u8>;
     type EmptyArrayHashMap = HashMap<[u8; 0], u8>;
-    type OptionalHashMap = HashMap<crate::wire::Optional<u8>, u8>;
+    type OptionalHashMap = HashMap<crate::Optional<u8>, u8>;
 
     assert_impl_all!(
         BasicHashMap: Type,

--- a/zbus/src/wire/type/mod.rs
+++ b/zbus/src/wire/type/mod.rs
@@ -11,7 +11,7 @@ mod time;
 #[cfg(feature = "uuid")]
 mod uuid;
 
-use crate::wire::Signature;
+use crate::Signature;
 
 /// Trait implemented by all serializable types.
 ///
@@ -19,7 +19,7 @@ use crate::wire::Signature;
 /// system] relies on these signatures, our [serialization] and [deserialization] API requires this
 /// trait in addition to [`trait@serde::Serialize`] and [`serde::de::Deserialize`], respectively.
 ///
-/// Implementation is provided for all the [basic types](crate::wire::Basic) and blanket
+/// Implementation is provided for all the [basic types](crate::Basic) and blanket
 /// implementations for common container types, such as, arrays, slices, tuples, [`Vec`] and
 /// [`std::collections::HashMap`]. For easy implementation for custom types, use `Type` derive
 /// macro re-exported by this module.
@@ -38,7 +38,7 @@ pub trait Type {
     ///
     /// ```
     /// use std::collections::HashMap;
-    /// use zbus::wire::{Type, signature::{Child, Signature}};
+    /// use zbus::{Type, Signature, wire::signature::Child};
     ///
     /// assert_eq!(u32::SIGNATURE, &Signature::U32);
     /// assert_eq!(String::SIGNATURE, &Signature::Str);
@@ -91,8 +91,8 @@ macro_rules! impl_type_with_repr {
             repr($sample_ident:ident) = $into_repr:expr,
         }
     }) => {
-        impl $(<$typaram $(: $($tbound)::+)?>)? $crate::wire::Type for $($ty)::+ $(<$typaram>)? {
-            const SIGNATURE: &'static $crate::wire::Signature = <$repr>::SIGNATURE;
+        impl $(<$typaram $(: $($tbound)::+)?>)? $crate::Type for $($ty)::+ $(<$typaram>)? {
+            const SIGNATURE: &'static $crate::Signature = <$repr>::SIGNATURE;
         }
 
         #[cfg(test)]
@@ -167,7 +167,7 @@ macro_rules! impl_type_with_repr {
             $(
                 #[test]
                 fn signature_equals() {
-                    assert_eq!(<Ty as $crate::wire::Type>::SIGNATURE, $signature);
+                    assert_eq!(<Ty as $crate::Type>::SIGNATURE, $signature);
                 }
             )?
         }

--- a/zbus/src/wire/value.rs
+++ b/zbus/src/wire/value.rs
@@ -18,12 +18,12 @@ use serde::{
 };
 
 use crate::wire::{
-    Array, Basic, Dict, DynamicType, ObjectPath, OwnedValue, Signature, Str, Structure,
-    StructureBuilder, Type, array_display_fmt, dict_display_fmt, structure_display_fmt, utils::*,
+    Array, Basic, Dict, DynamicType, ObjectPath, OwnedValue, Signature, Str, Structure, Type,
+    array_display_fmt, dict_display_fmt, structure_display_fmt, utils::*,
 };
 
 #[cfg(unix)]
-use crate::wire::Fd;
+use crate::Fd;
 
 /// A generic container, in the form of an enum that holds exactly one value of any of the other
 /// types.
@@ -34,7 +34,7 @@ use crate::wire::Fd;
 /// # Examples
 ///
 /// ```
-/// use zbus::wire::{to_bytes, serialized::Context, Value, LE};
+/// use zbus::{Value, wire::{LE, serialized::Context, to_bytes}};
 ///
 /// // Create a Value from an i16
 /// let v = Value::new(i16::max_value());
@@ -54,7 +54,7 @@ use crate::wire::Fd;
 ///
 /// ```
 /// use zbus::wire::{to_bytes, serialized::Context, LE};
-/// use zbus::wire::{Structure, Value, Str};
+/// use zbus::{Str, Structure, Value};
 ///
 /// // Create a Value from a tuple this time
 /// let v = Value::new((i16::max_value(), "hello", true));
@@ -182,7 +182,7 @@ impl<'a> Value<'a> {
     /// # Examples
     ///
     /// ```
-    /// use zbus::wire::Value;
+    /// use zbus::Value;
     ///
     /// let s = Value::new("hello");
     /// let u: Value = 51.into();
@@ -382,7 +382,7 @@ impl<'a> Value<'a> {
     /// # Examples
     ///
     /// ```
-    /// use zbus::{Error, Result, wire::Value};
+    /// use zbus::{Error, Result, Value};
     ///
     /// fn value_vec_to_type_vec<'a, T>(values: Vec<Value<'a>>) -> Result<Vec<T>>
     /// where
@@ -434,7 +434,7 @@ impl<'a> Value<'a> {
     /// # Examples
     ///
     /// ```
-    /// use zbus::{Error, Result, wire::Value};
+    /// use zbus::{Error, Result, Value};
     ///
     /// fn value_vec_to_type_vec<'a, T>(values: &'a Vec<Value<'a>>) -> Result<Vec<&'a T>>
     /// where
@@ -695,7 +695,7 @@ impl SignatureSeed<'_> {
             }
         };
 
-        let mut builder = StructureBuilder::new();
+        let mut builder = Structure::builder();
         for field_signature in fields_signatures {
             if let Some(field) = visitor.next_element_seed(ValueSeed::<Value<'_>> {
                 signature: field_signature,
@@ -997,10 +997,7 @@ mod tests {
 
         assert_eq!(
             Value::new((
-                vec![
-                    crate::wire::signature!(""),
-                    crate::wire::signature!("(ysa{sd})"),
-                ],
+                vec![crate::signature!(""), crate::signature!("(ysa{sd})")],
                 vec![
                     ObjectPath::from_static_str("/").unwrap(),
                     ObjectPath::from_static_str("/a/very/looooooooooooooooooooooooo0000o0ng/path")

--- a/zbus/src/zvariant.rs
+++ b/zbus/src/zvariant.rs
@@ -6,8 +6,9 @@
 //! alias, such as `DynamicTuple(…)`, the removed `Error` variants and the removed GVariant
 //! APIs, such as `Value::Maybe` and `Context::new_gvariant` — are covered by the "Upgrading to
 //! zbus 6.0" chapter of the zbus book. Code written against the `zvariant` crate itself needs
-//! more than this: it switches its dependency to `zbus` and renames `zvariant::` to
-//! `zbus::wire::`, as the same chapter describes. This module is removed in zbus 7.0.
+//! more than this: it switches its dependency to `zbus` and uses the corresponding items from
+//! the `zbus` crate root (or [`crate::wire`] for the low-level encoding and decoding API), as the
+//! same chapter describes. This module is removed in zbus 7.0.
 //!
 //! Importing the module, or naming any of the aliases, produces a deprecation warning:
 //!
@@ -48,20 +49,20 @@ pub use crate::wire::{
     dbus, export, impl_type_with_repr, static_str_type, to_writer, to_writer_for_signature,
 };
 
-/// Deprecated alias of [`crate::wire::Array`].
-#[deprecated(since = "6.0.0", note = "use `zbus::wire::Array` instead")]
+/// Deprecated alias of [`crate::Array`].
+#[deprecated(since = "6.0.0", note = "use `zbus::Array` instead")]
 pub type Array<'a> = wire::Array<'a>;
 
 /// Deprecated alias of [`crate::wire::ArraySeed`].
 #[deprecated(since = "6.0.0", note = "use `zbus::wire::ArraySeed` instead")]
 pub type ArraySeed = wire::ArraySeed;
 
-/// Deprecated alias of [`crate::wire::Dict`].
-#[deprecated(since = "6.0.0", note = "use `zbus::wire::Dict` instead")]
+/// Deprecated alias of [`crate::Dict`].
+#[deprecated(since = "6.0.0", note = "use `zbus::Dict` instead")]
 pub type Dict<'k, 'v> = wire::Dict<'k, 'v>;
 
-/// Deprecated alias of [`crate::wire::DynamicTuple`].
-#[deprecated(since = "6.0.0", note = "use `zbus::wire::DynamicTuple` instead")]
+/// Deprecated alias of [`crate::DynamicTuple`].
+#[deprecated(since = "6.0.0", note = "use `zbus::DynamicTuple` instead")]
 pub type DynamicTuple<T> = wire::DynamicTuple<T>;
 
 /// Deprecated alias of [`crate::wire::TupleSeed`].
@@ -72,66 +73,66 @@ pub type TupleSeed<'a, T, S> = wire::TupleSeed<'a, T, S>;
 #[deprecated(since = "6.0.0", note = "use `zbus::wire::Endian` instead")]
 pub type Endian = wire::Endian;
 
-/// Deprecated alias of [`crate::wire::Fd`].
+/// Deprecated alias of [`crate::Fd`].
 #[cfg(unix)]
-#[deprecated(since = "6.0.0", note = "use `zbus::wire::Fd` instead")]
+#[deprecated(since = "6.0.0", note = "use `zbus::Fd` instead")]
 pub type Fd<'f> = wire::Fd<'f>;
 
-/// Deprecated alias of [`crate::wire::OwnedFd`].
+/// Deprecated alias of [`crate::OwnedFd`].
 #[cfg(unix)]
-#[deprecated(since = "6.0.0", note = "use `zbus::wire::OwnedFd` instead")]
+#[deprecated(since = "6.0.0", note = "use `zbus::OwnedFd` instead")]
 pub type OwnedFd = wire::OwnedFd;
 
-/// Deprecated alias of [`crate::wire::FilePath`].
-#[deprecated(since = "6.0.0", note = "use `zbus::wire::FilePath` instead")]
+/// Deprecated alias of [`crate::FilePath`].
+#[deprecated(since = "6.0.0", note = "use `zbus::FilePath` instead")]
 pub type FilePath<'f> = wire::FilePath<'f>;
 
-/// Deprecated alias of [`crate::wire::ObjectPath`].
-#[deprecated(since = "6.0.0", note = "use `zbus::wire::ObjectPath` instead")]
+/// Deprecated alias of [`crate::ObjectPath`].
+#[deprecated(since = "6.0.0", note = "use `zbus::ObjectPath` instead")]
 pub type ObjectPath<'a> = wire::ObjectPath<'a>;
 
-/// Deprecated alias of [`crate::wire::OwnedObjectPath`].
-#[deprecated(since = "6.0.0", note = "use `zbus::wire::OwnedObjectPath` instead")]
+/// Deprecated alias of [`crate::OwnedObjectPath`].
+#[deprecated(since = "6.0.0", note = "use `zbus::OwnedObjectPath` instead")]
 pub type OwnedObjectPath = wire::OwnedObjectPath;
 
-/// Deprecated alias of [`crate::wire::Optional`].
-#[deprecated(since = "6.0.0", note = "use `zbus::wire::Optional` instead")]
+/// Deprecated alias of [`crate::Optional`].
+#[deprecated(since = "6.0.0", note = "use `zbus::Optional` instead")]
 pub type Optional<T> = wire::Optional<T>;
 
-/// Deprecated alias of [`crate::wire::Signature`].
-#[deprecated(since = "6.0.0", note = "use `zbus::wire::Signature` instead")]
+/// Deprecated alias of [`crate::Signature`].
+#[deprecated(since = "6.0.0", note = "use `zbus::Signature` instead")]
 pub type Signature = wire::Signature;
 
-/// Deprecated alias of [`crate::wire::Str`].
-#[deprecated(since = "6.0.0", note = "use `zbus::wire::Str` instead")]
+/// Deprecated alias of [`crate::Str`].
+#[deprecated(since = "6.0.0", note = "use `zbus::Str` instead")]
 pub type Str<'a> = wire::Str<'a>;
 
-/// Deprecated alias of [`crate::wire::Structure`].
-#[deprecated(since = "6.0.0", note = "use `zbus::wire::Structure` instead")]
+/// Deprecated alias of [`crate::Structure`].
+#[deprecated(since = "6.0.0", note = "use `zbus::Structure` instead")]
 pub type Structure<'a> = wire::Structure<'a>;
 
 /// Deprecated alias of [`crate::wire::StructureBuilder`].
-#[deprecated(since = "6.0.0", note = "use `zbus::wire::StructureBuilder` instead")]
+#[deprecated(since = "6.0.0", note = "use `zbus::Structure::builder()` instead")]
 pub type StructureBuilder<'a> = wire::StructureBuilder<'a>;
 
 /// Deprecated alias of [`crate::wire::StructureSeed`].
 #[deprecated(since = "6.0.0", note = "use `zbus::wire::StructureSeed` instead")]
 pub type StructureSeed<'a> = wire::StructureSeed<'a>;
 
-/// Deprecated alias of [`crate::wire::OwnedStructure`].
-#[deprecated(since = "6.0.0", note = "use `zbus::wire::OwnedStructure` instead")]
+/// Deprecated alias of [`crate::OwnedStructure`].
+#[deprecated(since = "6.0.0", note = "use `zbus::OwnedStructure` instead")]
 pub type OwnedStructure = wire::OwnedStructure;
 
 /// Deprecated alias of [`crate::wire::OwnedStructureSeed`].
 #[deprecated(since = "6.0.0", note = "use `zbus::wire::OwnedStructureSeed` instead")]
 pub type OwnedStructureSeed = wire::OwnedStructureSeed;
 
-/// Deprecated alias of [`enum@crate::wire::Value`].
-#[deprecated(since = "6.0.0", note = "use `zbus::wire::Value` instead")]
+/// Deprecated alias of [`enum@crate::Value`].
+#[deprecated(since = "6.0.0", note = "use `zbus::Value` instead")]
 pub type Value<'a> = wire::Value<'a>;
 
-/// Deprecated alias of [`struct@crate::wire::OwnedValue`].
-#[deprecated(since = "6.0.0", note = "use `zbus::wire::OwnedValue` instead")]
+/// Deprecated alias of [`struct@crate::OwnedValue`].
+#[deprecated(since = "6.0.0", note = "use `zbus::OwnedValue` instead")]
 pub type OwnedValue = wire::OwnedValue;
 
 /// Deprecated alias of [`crate::Error`].

--- a/zbus/tests/basic.rs
+++ b/zbus/tests/basic.rs
@@ -8,10 +8,7 @@ use test_log::test;
 use tracing::{debug, instrument};
 use zbus::block_on;
 
-use zbus::{
-    names::UniqueName,
-    wire::{OwnedValue, Type},
-};
+use zbus::{OwnedValue, Type, names::UniqueName};
 
 use zbus::{
     Connection, Result,
@@ -101,7 +98,7 @@ fn fdpass_systemd() {
 #[cfg(all(unix, not(target_os = "macos")))]
 async fn fdpass_systemd_async() {
     use std::{fs::File, os::unix::io::AsRawFd};
-    use zbus::wire::OwnedFd;
+    use zbus::OwnedFd;
 
     let connection = Connection::system().await.unwrap();
 

--- a/zbus/tests/iface_and_proxy/client.rs
+++ b/zbus/tests/iface_and_proxy/client.rs
@@ -3,11 +3,10 @@ use futures_util::{StreamExt, TryStreamExt};
 use std::convert::TryInto;
 use tracing::{debug, instrument};
 use zbus::{
-    Connection, DBusError, Error, Message, MessageStream,
+    Connection, DBusError, Error, Message, MessageStream, Value,
     fdo::{ObjectManagerProxy, PropertiesProxy},
     message,
     proxy::CacheProperties,
-    wire::Value,
 };
 
 use super::{

--- a/zbus/tests/iface_and_proxy/helpers.rs
+++ b/zbus/tests/iface_and_proxy/helpers.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use zbus::wire::{OwnedValue, Value};
+use zbus::{OwnedValue, Value};
 
 use super::types::IP4Adress;
 

--- a/zbus/tests/iface_and_proxy/iface.rs
+++ b/zbus/tests/iface_and_proxy/iface.rs
@@ -2,11 +2,11 @@ use std::collections::HashMap;
 use tokio::sync::mpsc::Sender;
 use tracing::{debug, instrument};
 use zbus::{
+    Optional, OwnedValue, Value,
     connection::Connection,
     interface,
     message::{self, Header},
     object_server::{ObjectServer, ResponseDispatchNotifier, SignalEmitter},
-    wire::{Optional, OwnedValue, Value},
 };
 
 use super::types::{ArgStructTest, IP4Adress, MyIfaceError, NextAction, RefType};

--- a/zbus/tests/iface_and_proxy/types.rs
+++ b/zbus/tests/iface_and_proxy/types.rs
@@ -1,8 +1,5 @@
 use serde::{Deserialize, Serialize};
-use zbus::{
-    DBusError,
-    wire::{DeserializeDict, SerializeDict, Str, Type},
-};
+use zbus::{DBusError, DeserializeDict, SerializeDict, Str, Type};
 
 // Tests the `crate` attribute with a path to the wire module.
 #[derive(Debug, Deserialize, Serialize, Type)]

--- a/zbus/tests/issue/issue_1015.rs
+++ b/zbus/tests/issue/issue_1015.rs
@@ -1,7 +1,7 @@
 use ntest::timeout;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
-use zbus::{connection::Builder, proxy::Defaults, wire::Type};
+use zbus::{Type, connection::Builder, proxy::Defaults};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type)]
 struct SingleFieldStruct {

--- a/zbus/tests/issue/issue_104.rs
+++ b/zbus/tests/issue/issue_104.rs
@@ -2,7 +2,7 @@ use ntest::timeout;
 use test_log::test;
 use tracing::trace;
 
-use zbus::wire::{OwnedObjectPath, OwnedValue};
+use zbus::{OwnedObjectPath, OwnedValue};
 
 use zbus::{
     conn::{self, Connection},
@@ -22,7 +22,7 @@ fn issue104() {
 }
 
 async fn issue104_async() {
-    use zbus::wire::{ObjectPath, Value};
+    use zbus::{ObjectPath, Value};
 
     struct Secret;
     #[zbus::interface(name = "org.freedesktop.Secret.Service")]
@@ -58,7 +58,7 @@ async fn issue104_async() {
             fn open_session(
                 &self,
                 algorithm: &str,
-                input: &zbus::wire::Value<'_>,
+                input: &zbus::Value<'_>,
             ) -> zbus::Result<(OwnedValue, OwnedObjectPath)>;
         }
 

--- a/zbus/tests/issue/issue_121.rs
+++ b/zbus/tests/issue/issue_121.rs
@@ -1,6 +1,6 @@
 use test_log::test;
 
-use zbus::wire::OwnedObjectPath;
+use zbus::OwnedObjectPath;
 
 // This one we just want to see if it builds, no need to run it. For details see:
 //
@@ -18,6 +18,6 @@ fn issue_121() {
 
         /// Engines property
         #[zbus(property)]
-        fn engines(&self) -> zbus::Result<Vec<zbus::wire::OwnedValue>>;
+        fn engines(&self) -> zbus::Result<Vec<zbus::OwnedValue>>;
     }
 }

--- a/zbus/tests/issue/issue_310.rs
+++ b/zbus/tests/issue/issue_310.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use test_log::test;
 use tracing::instrument;
 
-use zbus::wire::OwnedObjectPath;
+use zbus::OwnedObjectPath;
 
 #[test(tokio::test(flavor = "multi_thread"))]
 #[instrument]

--- a/zbus/tests/issue/issue_356.rs
+++ b/zbus/tests/issue/issue_356.rs
@@ -1,6 +1,6 @@
 use test_log::test;
 use tracing::instrument;
-use zbus::wire::OwnedObjectPath;
+use zbus::OwnedObjectPath;
 
 /// The "child" interface that will be referenced by the property.
 struct Adapter {

--- a/zbus/tests/issue/issue_466.rs
+++ b/zbus/tests/issue/issue_466.rs
@@ -5,12 +5,9 @@ use test_log::test;
 fn issue_466() {
     #[zbus::proxy(interface = "org.Some.Thing1", assume_defaults = true)]
     trait MyGreeter {
-        fn foo(
-            &self,
-            arg: &(u32, zbus::wire::Value<'_>),
-        ) -> zbus::Result<(u32, zbus::wire::OwnedValue)>;
+        fn foo(&self, arg: &(u32, zbus::Value<'_>)) -> zbus::Result<(u32, zbus::OwnedValue)>;
 
         #[zbus(property)]
-        fn bar(&self) -> zbus::Result<(u32, zbus::wire::OwnedValue)>;
+        fn bar(&self) -> zbus::Result<(u32, zbus::OwnedValue)>;
     }
 }

--- a/zbus/tests/issue/issue_81.rs
+++ b/zbus/tests/issue/issue_81.rs
@@ -1,14 +1,11 @@
 use test_log::test;
 
-use zbus::wire::OwnedObjectPath;
+use zbus::OwnedObjectPath;
 
 #[test]
 #[ignore]
 fn issue_81() {
-    use zbus::{
-        proxy,
-        wire::{OwnedValue, Type},
-    };
+    use zbus::{OwnedValue, Type, proxy};
 
     #[derive(
         Debug, PartialEq, Eq, Clone, Type, OwnedValue, serde::Serialize, serde::Deserialize,

--- a/zbus/tests/issue/issue_813.rs
+++ b/zbus/tests/issue/issue_813.rs
@@ -22,7 +22,7 @@ fn issue_813() {
     use std::{os::fd::AsFd, vec};
     #[cfg(feature = "tokio")]
     use tokio::net::UnixStream;
-    use zbus::{conn::socket::WriteHalf, connection::Builder, wire::Fd};
+    use zbus::{Fd, conn::socket::WriteHalf, connection::Builder};
 
     #[derive(Debug)]
     struct Issue813Iface {

--- a/zbus/tests/uncached_propert.rs
+++ b/zbus/tests/uncached_propert.rs
@@ -98,10 +98,7 @@ async fn test_serde_property() -> Result<()> {
 
     use futures_util::StreamExt;
     use serde::{Deserialize, Serialize};
-    use zbus::{
-        names::OwnedUniqueName,
-        wire::{Optional, OwnedValue, Str, Type},
-    };
+    use zbus::{Optional, OwnedValue, Str, Type, names::OwnedUniqueName};
 
     #[derive(Debug, Deserialize, Serialize, Type, PartialEq)]
     #[zvariant(signature = "s")]

--- a/zbus/tests/wire/array_value.rs
+++ b/zbus/tests/wire/array_value.rs
@@ -1,5 +1,8 @@
 use std::vec;
-use zbus::wire::{Array, LE, Type, Value, serialized::Context, to_bytes};
+use zbus::{
+    Array, Type, Value,
+    wire::{LE, serialized::Context, to_bytes},
+};
 
 #[test]
 fn array_value() {
@@ -207,7 +210,7 @@ fn array_value() {
     assert_eq!(TryInto::<Vec<i32>>::try_into(val).unwrap(), vec);
 
     // Empty array should be treated as a unit type, which is encoded as a u8.
-    assert_eq!(<[u64; 0]>::SIGNATURE, &zbus::wire::Signature::U8);
+    assert_eq!(<[u64; 0]>::SIGNATURE, &zbus::Signature::U8);
     let array: [u64; 0] = [];
     let encoded = to_bytes(ctxt, &array).unwrap();
     assert_eq!(encoded.len(), 1);

--- a/zbus/tests/wire/common.rs
+++ b/zbus/tests/wire/common.rs
@@ -39,12 +39,12 @@ macro_rules! basic_type_test {
         let encoded = basic_type_test!($endian, $test_value, $expected_len, $expected_ty, $align);
 
         // As Value
-        let v: zbus::wire::Value<'_> = $test_value.into();
+        let v: zbus::Value<'_> = $test_value.into();
         assert_eq!(
             v.value_signature(),
-            <$expected_ty as zbus::wire::Basic>::SIGNATURE_STR
+            <$expected_ty as zbus::Basic>::SIGNATURE_STR
         );
-        assert_eq!(v, zbus::wire::Value::$kind($test_value));
+        assert_eq!(v, zbus::Value::$kind($test_value));
         value_test!($endian, v, $expected_value_len);
 
         let v: $expected_ty = v.try_into().unwrap();
@@ -64,7 +64,7 @@ macro_rules! value_test {
             $expected_len,
             "invalid encoding using `to_bytes`"
         );
-        let (decoded, parsed): (zbus::wire::Value<'_>, _) = encoded.deserialize().unwrap();
+        let (decoded, parsed): (zbus::Value<'_>, _) = encoded.deserialize().unwrap();
         assert!(decoded == $test_value, "invalid decoding");
         assert!(parsed == encoded.len(), "invalid parsing");
 
@@ -94,7 +94,7 @@ macro_rules! fd_value_test {
             "invalid encoding using `to_bytes`"
         );
         #[cfg(unix)]
-        let (_, parsed): (zbus::wire::Fd<'_>, _) = encoded.deserialize().unwrap();
+        let (_, parsed): (zbus::Fd<'_>, _) = encoded.deserialize().unwrap();
         assert!(
             parsed == encoded.len(),
             "invalid parsing using `from_slice`"
@@ -110,9 +110,9 @@ macro_rules! fd_value_test {
         );
 
         // As Value
-        let v: zbus::wire::Value<'_> = $test_value.into();
-        assert_eq!(v.value_signature(), zbus::wire::Fd::SIGNATURE_STR);
-        assert_eq!(v, zbus::wire::Value::Fd($test_value));
+        let v: zbus::Value<'_> = $test_value.into();
+        assert_eq!(v.value_signature(), zbus::Fd::SIGNATURE_STR);
+        assert_eq!(v, zbus::Value::Fd($test_value));
         let encoded = zbus::wire::to_bytes(ctxt, &v).unwrap();
         assert_eq!(encoded.fds().len(), 1, "invalid encoding using `to_bytes`");
         assert_eq!(
@@ -120,15 +120,15 @@ macro_rules! fd_value_test {
             $expected_value_len,
             "invalid encoding using `to_bytes`"
         );
-        let (decoded, parsed): (zbus::wire::Value<'_>, _) = encoded.deserialize().unwrap();
+        let (decoded, parsed): (zbus::Value<'_>, _) = encoded.deserialize().unwrap();
         assert_eq!(
             decoded,
-            zbus::wire::Fd::from(encoded.fds()[0].as_fd()).into(),
+            zbus::Fd::from(encoded.fds()[0].as_fd()).into(),
             "invalid decoding using `from_slice`"
         );
         assert_eq!(parsed, encoded.len(), "invalid parsing using `from_slice`");
 
-        let v: zbus::wire::Fd<'_> = v.try_into().unwrap();
+        let v: zbus::Fd<'_> = v.try_into().unwrap();
         assert_eq!(v, $test_value);
     }};
 }

--- a/zbus/tests/wire/dbus_maybe_rejection.rs
+++ b/zbus/tests/wire/dbus_maybe_rejection.rs
@@ -5,10 +5,13 @@
 //! A maybe can enter as the codec's layout signature, or dynamically as the content of a `g`
 //! (signature) or `v` (variant) value.
 
-use zbus::wire::{
-    LE, Signature, Value,
-    serialized::{Context, Data},
-    to_bytes_for_signature,
+use zbus::{
+    Signature, Value,
+    wire::{
+        LE,
+        serialized::{Context, Data},
+        to_bytes_for_signature,
+    },
 };
 
 #[test]

--- a/zbus/tests/wire/derive.rs
+++ b/zbus/tests/wire/derive.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use zbus::wire::{Error, LE, OwnedValue, Type, Value, serialized::Context, to_bytes};
+use zbus::{
+    OwnedValue, Type, Value,
+    wire::{Error, LE, serialized::Context, to_bytes},
+};
 
 #[test]
 fn derive() {

--- a/zbus/tests/wire/dict_compare.rs
+++ b/zbus/tests/wire/dict_compare.rs
@@ -1,4 +1,4 @@
-use zbus::wire::{Dict, Type, Value};
+use zbus::{Dict, Type, Value};
 
 #[test]
 fn dict_compare() {

--- a/zbus/tests/wire/dict_value.rs
+++ b/zbus/tests/wire/dict_value.rs
@@ -1,11 +1,10 @@
 use std::collections::{BTreeMap, HashMap};
 
 use endi::NATIVE_ENDIAN;
-use zbus::wire::{
+use zbus::{
     DeserializeDict, Dict, OwnedObjectPath, SerializeDict, Str, Type, Value,
     as_value::{Serialize, optional},
-    serialized::Context,
-    to_bytes,
+    wire::{serialized::Context, to_bytes},
 };
 
 #[test]
@@ -302,7 +301,7 @@ fn nested_dict_value() {
     // `a{sv}` (so the value type is `v`) where one variant value is itself an `a{sv}`. Unlike
     // `Interfaces` above, the outer value type here is `v`, so each field is wrapped in a
     // variant on the wire.
-    use zbus::wire::OwnedValue;
+    use zbus::OwnedValue;
 
     #[derive(DeserializeDict, SerializeDict, Type, PartialEq, Debug, Default)]
     #[zvariant(signature = "a{sv}", rename_all = "kebab-case")]

--- a/zbus/tests/wire/fd_value.rs
+++ b/zbus/tests/wire/fd_value.rs
@@ -2,7 +2,7 @@
 #[test]
 fn fd_value() {
     use std::os::fd::AsFd;
-    use zbus::wire::{Basic, Fd, LE};
+    use zbus::{Basic, Fd, wire::LE};
 
     let stdout = std::io::stdout();
     let fd = stdout.as_fd();

--- a/zbus/tests/wire/issue/issue_1819.rs
+++ b/zbus/tests/wire/issue/issue_1819.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
-use zbus::wire::{
-    DeserializeDict, Dict, LE, SerializeDict, Type, Value, serialized::Context, to_bytes,
+use zbus::{
+    DeserializeDict, Dict, SerializeDict, Type, Value,
+    wire::{LE, serialized::Context, to_bytes},
 };
 
 #[test]

--- a/zbus/tests/wire/number/f64_value.rs
+++ b/zbus/tests/wire/number/f64_value.rs
@@ -1,4 +1,7 @@
-use zbus::wire::{Basic, LE, NATIVE_ENDIAN, Value, serialized::Context, to_bytes};
+use zbus::{
+    Basic, Value,
+    wire::{LE, NATIVE_ENDIAN, serialized::Context, to_bytes},
+};
 
 #[test]
 fn f64_value() {

--- a/zbus/tests/wire/object_path_value.rs
+++ b/zbus/tests/wire/object_path_value.rs
@@ -1,4 +1,4 @@
-use zbus::wire::{LE, ObjectPath, Value};
+use zbus::{ObjectPath, Value, wire::LE};
 
 #[test]
 fn object_path_value() {

--- a/zbus/tests/wire/recursion_limits.rs
+++ b/zbus/tests/wire/recursion_limits.rs
@@ -1,6 +1,6 @@
 use zbus::{
-    Error, MaxDepthExceeded,
-    wire::{LE, Value, serialized::Context, to_bytes},
+    Error, MaxDepthExceeded, Value,
+    wire::{LE, serialized::Context, to_bytes},
 };
 
 #[test]

--- a/zbus/tests/wire/serde_bytes.rs
+++ b/zbus/tests/wire/serde_bytes.rs
@@ -3,7 +3,10 @@
 fn serde_bytes() {
     use serde::{Deserialize, Serialize};
     use serde_bytes::*;
-    use zbus::wire::{LE, Type, serialized::Context, to_bytes};
+    use zbus::{
+        Type,
+        wire::{LE, serialized::Context, to_bytes},
+    };
 
     let ctxt = Context::new(LE, 0);
     let ay = Bytes::new(&[77u8; 1_000_000]);

--- a/zbus/tests/wire/serialized_size.rs
+++ b/zbus/tests/wire/serialized_size.rs
@@ -1,7 +1,7 @@
 use zbus::wire::{LE, serialized::Context, serialized_size};
 
 #[cfg(unix)]
-use zbus::wire::Fd;
+use zbus::Fd;
 
 #[test]
 fn test_serialized_size() {

--- a/zbus/tests/wire/signature.rs
+++ b/zbus/tests/wire/signature.rs
@@ -1,4 +1,4 @@
-use zbus::wire::{LE, Signature, Value, signature};
+use zbus::{Signature, Value, signature, wire::LE};
 
 #[test]
 fn signature() {

--- a/zbus/tests/wire/str_value.rs
+++ b/zbus/tests/wire/str_value.rs
@@ -1,4 +1,7 @@
-use zbus::wire::{LE, Value, serialized::Context, to_bytes};
+use zbus::{
+    Value,
+    wire::{LE, serialized::Context, to_bytes},
+};
 
 #[test]
 fn str_value() {

--- a/zbus/tests/wire/struct_byte_array.rs
+++ b/zbus/tests/wire/struct_byte_array.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use zbus::wire::{Value, serialized::Context};
+use zbus::{Value, wire::serialized::Context};
 
 #[test]
 fn struct_byte_array() {

--- a/zbus/tests/wire/struct_value.rs
+++ b/zbus/tests/wire/struct_value.rs
@@ -1,5 +1,8 @@
 use serde::{Deserialize, Serialize};
-use zbus::wire::{LE, Str, Structure, Type, Value, as_value, serialized::Context, to_bytes};
+use zbus::{
+    Str, Structure, Type, Value, as_value,
+    wire::{LE, serialized::Context, to_bytes},
+};
 
 #[test]
 fn struct_value() {

--- a/zbus/tests/wire/struct_with_hashmap.rs
+++ b/zbus/tests/wire/struct_with_hashmap.rs
@@ -1,5 +1,8 @@
 use std::collections::HashMap;
-use zbus::wire::{LE, Type, serialized::Context, to_bytes};
+use zbus::{
+    Type,
+    wire::{LE, serialized::Context, to_bytes},
+};
 
 #[test]
 fn struct_with_hashmap() {

--- a/zbus/tests/wire/value_value.rs
+++ b/zbus/tests/wire/value_value.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use zbus::wire::{BE, LE, OwnedValue, Value, serialized::Context, to_bytes};
+use zbus::{
+    OwnedValue, Value,
+    wire::{BE, LE, serialized::Context, to_bytes},
+};
 
 #[test]
 fn value_value() {
@@ -51,11 +54,11 @@ fn value_value() {
         inner: OwnedValue,
     }
 
-    let value = zbus::wire::Value::new("variant-value");
-    let inner = zbus::wire::StructureBuilder::new()
+    let value = zbus::Value::new("variant-value");
+    let inner = zbus::Structure::builder()
         .add_field("value1".to_string())
         .add_field("value2")
-        .append_field(zbus::wire::Value::new(value)) // let's try to get a variant
+        .append_field(zbus::Value::new(value)) // let's try to get a variant
         .build()
         .unwrap()
         .try_into()

--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -586,7 +586,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                     };
                     let do_set = quote!({
                         #args_from_msg
-                        match #zbus::wire::as_value::deserialize_for_property::<#value_ty>(value) {
+                        match #zbus::as_value::deserialize_for_property::<#value_ty>(value) {
                             ::std::result::Result::Ok(__zbus__value) => {
                                 #value_arg
                                 match #set_call {
@@ -638,7 +638,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                     p.ty = Some(get_return_type(output)?.clone());
 
                     let value_convert = quote!(
-                        #zbus::wire::as_value::to_owned_value(&value)
+                        #zbus::as_value::to_owned_value(&value)
                             .map_err(|e| #zbus::fdo::Error::Failed(e.to_string()))
                     );
                     let inner = if is_fallible_property {
@@ -665,7 +665,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                             if let Ok(prop) = self.#ident(#args_names)#method_await {
                             props.insert(
                                 ::std::string::ToString::to_string(#member_name),
-                                #zbus::wire::as_value::to_owned_value(&prop)
+                                #zbus::as_value::to_owned_value(&prop)
                                     .map_err(|e| #zbus::fdo::Error::Failed(e.to_string()))?,
                             );
                         }})
@@ -676,7 +676,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                                 ::std::string::ToString::to_string(#member_name),
                                 {
                                     let value = self.#ident(#args_names)#method_await;
-                                    #zbus::wire::as_value::to_owned_value(&value)
+                                    #zbus::as_value::to_owned_value(&value)
                                         .map_err(|e| #zbus::fdo::Error::Failed(e.to_string()))?
                                 },
                             );
@@ -712,7 +712,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                                 let mut changed = ::std::collections::HashMap::new();
                                 changed.insert(
                                     #member_name,
-                                    #zbus::wire::as_value::Serialize(&value),
+                                    #zbus::as_value::Serialize(&value),
                                 );
                                 __zbus__signal_emitter.emit(
                                     "org.freedesktop.DBus.Properties",
@@ -877,7 +877,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                 __zbus__connection: &#zbus::Connection,
                 __zbus__header: Option<&#zbus::message::Header<'_>>,
                 __zbus__signal_emitter: &#zbus::object_server::SignalEmitter<'_>,
-            ) -> ::std::option::Option<#zbus::fdo::Result<#zbus::wire::OwnedValue>> {
+            ) -> ::std::option::Option<#zbus::fdo::Result<#zbus::OwnedValue>> {
                 match __zbus__property_name {
                     #get_dispatch
                     _ => ::std::option::Option::None,
@@ -893,11 +893,11 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                 __zbus__signal_emitter: &#zbus::object_server::SignalEmitter<'_>,
             ) -> #zbus::fdo::Result<::std::collections::HashMap<
                 ::std::string::String,
-                #zbus::wire::OwnedValue,
+                #zbus::OwnedValue,
             >> {
                 let mut props: ::std::collections::HashMap<
                     ::std::string::String,
-                    #zbus::wire::OwnedValue,
+                    #zbus::OwnedValue,
                 > = ::std::collections::HashMap::new();
                 #get_all
                 Ok(props)
@@ -907,7 +907,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
             fn set<'call>(
                 &'call self,
                 __zbus__property_name: &'call str,
-                value: &'call #zbus::wire::Value<'_>,
+                value: &'call #zbus::Value<'_>,
                 __zbus__object_server: &'call #zbus::ObjectServer,
                 __zbus__connection: &'call #zbus::Connection,
                 __zbus__header: Option<&'call #zbus::message::Header<'_>>,
@@ -923,7 +923,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
             async fn set_mut(
                 &mut self,
                 __zbus__property_name: &str,
-                value: &#zbus::wire::Value<'_>,
+                value: &#zbus::Value<'_>,
                 __zbus__object_server: &#zbus::ObjectServer,
                 __zbus__connection: &#zbus::Connection,
                 __zbus__header: Option<&#zbus::message::Header<'_>>,
@@ -972,7 +972,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                     indent = level
                 ).unwrap();
                 {
-                    use #zbus::wire::Type;
+                    use #zbus::Type;
 
                     let level = level + 2;
                     #introspect
@@ -1574,7 +1574,7 @@ impl Proxy {
                 quote! {
                     where
                         #generic_type: #zbus::export::serde::de::DeserializeOwned
-                            + #zbus::wire::Type
+                            + #zbus::Type
                 },
             )
         } else {
@@ -1769,7 +1769,7 @@ mod tests {
             "generated code names ::zbus instead of the requested crate: {expanded}"
         );
         assert!(
-            expanded.contains(":: mybus :: wire :: as_value :: deserialize_for_property"),
+            expanded.contains(":: mybus :: as_value :: deserialize_for_property"),
             "generated code lost the value deserialization: {expanded}"
         );
     }

--- a/zbus_macros/src/lib.rs
+++ b/zbus_macros/src/lib.rs
@@ -133,7 +133,7 @@ mod utils;
 /// ```no_run
 /// # use std::error::Error;
 /// use zbus::proxy;
-/// use zbus::{blocking::Connection, Result, fdo, wire::Value};
+/// use zbus::{blocking::Connection, Result, fdo, Value};
 /// use futures_util::stream::StreamExt;
 /// use async_io::block_on;
 ///
@@ -217,7 +217,7 @@ mod utils;
 /// [`zbus::blocking::Proxy`]: https://docs.rs/zbus/latest/zbus/blocking/proxy/struct.Proxy.html
 /// [`zbus::SignalStream`]: https://docs.rs/zbus/latest/zbus/proxy/struct.SignalStream.html
 /// [`zbus::blocking::SignalIterator`]: https://docs.rs/zbus/latest/zbus/blocking/proxy/struct.SignalIterator.html
-/// [`ObjectPath`]: https://docs.rs/zbus/latest/zbus/wire/struct.ObjectPath.html
+/// [`ObjectPath`]: https://docs.rs/zbus/latest/zbus/struct.ObjectPath.html
 /// [dbus_emits_changed_signal]: https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format
 #[cfg(feature = "proxy")]
 #[proc_macro_attribute]
@@ -483,7 +483,7 @@ pub fn derive_dbus_error(input: TokenStream) -> TokenStream {
 /// For structs it works just like serde's [`Serialize`] and [`Deserialize`] macros:
 ///
 /// ```
-/// use zbus::wire::{serialized::Context, to_bytes, Type, LE};
+/// use zbus::{Type, wire::{serialized::Context, to_bytes, LE}};
 /// use serde::{Deserialize, Serialize};
 ///
 /// #[derive(Deserialize, Serialize, Type, PartialEq, Debug)]
@@ -510,7 +510,7 @@ pub fn derive_dbus_error(input: TokenStream) -> TokenStream {
 /// `repr` attribute (like in the example below), you'll also need [serde_repr] crate.
 ///
 /// ```
-/// use zbus::wire::{serialized::Context, to_bytes, Type, LE};
+/// use zbus::{Type, wire::{serialized::Context, to_bytes, LE}};
 /// use serde::{Deserialize, Serialize};
 /// use serde_repr::{Deserialize_repr, Serialize_repr};
 ///
@@ -567,8 +567,8 @@ pub fn derive_dbus_error(input: TokenStream) -> TokenStream {
 /// an alias for `a{sv}`. Here is an example:
 ///
 /// ```
-/// use zbus::wire::{
-///     serialized::Context, as_value, to_bytes, Type, LE,
+/// use zbus::{
+///     as_value, Type, wire::{serialized::Context, to_bytes, LE},
 /// };
 /// use serde::{Deserialize, Serialize};
 ///
@@ -599,7 +599,7 @@ pub fn derive_dbus_error(input: TokenStream) -> TokenStream {
 /// Another common use for custom signatures is (de)serialization of unit enums as strings:
 ///
 /// ```
-/// use zbus::wire::{serialized::Context, to_bytes, Type, LE};
+/// use zbus::{Type, wire::{serialized::Context, to_bytes, LE}};
 /// use serde::{Deserialize, Serialize};
 ///
 /// #[derive(Deserialize, Serialize, Type, PartialEq, Debug)]
@@ -624,7 +624,7 @@ pub fn derive_dbus_error(input: TokenStream) -> TokenStream {
 /// the derive at the module holding the wire types with the `crate` attribute:
 ///
 /// ```
-/// use zbus::wire::Type;
+/// use zbus::Type;
 ///
 /// #[derive(Type)]
 /// #[zbus(crate = "zbus::wire")]
@@ -633,7 +633,7 @@ pub fn derive_dbus_error(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// [`Type`]: https://docs.rs/zbus/latest/zbus/wire/trait.Type.html
+/// [`Type`]: https://docs.rs/zbus/latest/zbus/trait.Type.html
 /// [`Serialize`]: https://docs.serde.rs/serde/trait.Serialize.html
 /// [`Deserialize`]: https://docs.serde.rs/serde/de/trait.Deserialize.html
 /// [serde_repr]: https://crates.io/crates/serde_repr
@@ -661,7 +661,7 @@ pub fn type_macro_derive(input: TokenStream) -> TokenStream {
 /// There are two approaches to serializing structs as dictionaries:
 ///
 /// 1. Using this macro (simpler, but less control).
-/// 2. Using the `Serialize` derive with `zbus::wire::as_value` (more verbose, but more control).
+/// 2. Using the `Serialize` derive with `zbus::as_value` (more verbose, but more control).
 ///
 /// See the example below and the relevant [FAQ entry] in our book for more details on the
 /// alternative approach.
@@ -671,7 +671,7 @@ pub fn type_macro_derive(input: TokenStream) -> TokenStream {
 /// ## Approach #1
 ///
 /// ```
-/// use zbus::wire::{SerializeDict, Type};
+/// use zbus::{SerializeDict, Type};
 ///
 /// #[derive(Debug, Default, SerializeDict, Type)]
 /// #[zvariant(signature = "a{sv}", rename_all = "PascalCase")]
@@ -685,7 +685,7 @@ pub fn type_macro_derive(input: TokenStream) -> TokenStream {
 ///
 /// ```
 /// use serde::Serialize;
-/// use zbus::wire::{Type, as_value};
+/// use zbus::{Type, as_value};
 ///
 /// #[derive(Debug, Default, Serialize, Type)]
 /// #[zvariant(signature = "a{sv}")]
@@ -705,7 +705,7 @@ pub fn type_macro_derive(input: TokenStream) -> TokenStream {
 /// `SerializeDict`/`DeserializeDict` struct inside another:
 ///
 /// ```
-/// use zbus::wire::{DeserializeDict, SerializeDict, Type};
+/// use zbus::{DeserializeDict, SerializeDict, Type};
 ///
 /// #[derive(SerializeDict, DeserializeDict, Type, Default)]
 /// #[zvariant(signature = "a{sv}", rename_all = "PascalCase")]
@@ -728,7 +728,7 @@ pub fn type_macro_derive(input: TokenStream) -> TokenStream {
 /// the derive at the module holding the wire types with the `crate` attribute:
 ///
 /// ```
-/// use zbus::wire::{SerializeDict, Type};
+/// use zbus::{SerializeDict, Type};
 ///
 /// #[derive(SerializeDict, Type)]
 /// #[zbus(signature = "a{sv}", crate = "zbus::wire")]
@@ -764,7 +764,7 @@ pub fn serialize_dict_macro_derive(input: TokenStream) -> TokenStream {
 /// There are two approaches to deserializing dictionaries as structs:
 ///
 /// 1. Using this macro (simpler, but less control).
-/// 2. Using the `Deserialize` derive with `zbus::wire::as_value` (more verbose, but more control).
+/// 2. Using the `Deserialize` derive with `zbus::as_value` (more verbose, but more control).
 ///
 /// See the example below and the relevant [FAQ entry] in our book for more details on the
 /// alternative approach.
@@ -774,7 +774,7 @@ pub fn serialize_dict_macro_derive(input: TokenStream) -> TokenStream {
 /// ## Approach #1
 ///
 /// ```
-/// use zbus::wire::{DeserializeDict, Type};
+/// use zbus::{DeserializeDict, Type};
 ///
 /// #[derive(Debug, Default, DeserializeDict, Type)]
 /// #[zvariant(signature = "a{sv}", rename_all = "PascalCase")]
@@ -788,7 +788,7 @@ pub fn serialize_dict_macro_derive(input: TokenStream) -> TokenStream {
 ///
 /// ```
 /// use serde::Deserialize;
-/// use zbus::wire::{Type, as_value};
+/// use zbus::{Type, as_value};
 ///
 /// #[derive(Debug, Default, Deserialize, Type)]
 /// #[zvariant(signature = "a{sv}")]
@@ -807,7 +807,7 @@ pub fn serialize_dict_macro_derive(input: TokenStream) -> TokenStream {
 /// the derive at the module holding the wire types with the `crate` attribute:
 ///
 /// ```
-/// use zbus::wire::{DeserializeDict, Type};
+/// use zbus::{DeserializeDict, Type};
 ///
 /// #[derive(DeserializeDict, Type)]
 /// #[zbus(signature = "a{sv}", crate = "zbus::wire")]
@@ -835,7 +835,7 @@ pub fn deserialize_dict_macro_derive(input: TokenStream) -> TokenStream {
 /// Simple owned strutures:
 ///
 /// ```
-/// use zbus::wire::{OwnedObjectPath, OwnedValue, Value};
+/// use zbus::{OwnedObjectPath, OwnedValue, Value};
 ///
 /// #[derive(Clone, Value, OwnedValue)]
 /// struct OwnedStruct {
@@ -858,8 +858,8 @@ pub fn deserialize_dict_macro_derive(input: TokenStream) -> TokenStream {
 /// Now for the more exciting case of unowned structures:
 ///
 /// ```
-/// use zbus::wire::{ObjectPath, Str};
-/// # use zbus::wire::{OwnedValue, Value};
+/// use zbus::{ObjectPath, Str};
+/// # use zbus::{OwnedValue, Value};
 /// #
 /// #[derive(Clone, Value, OwnedValue)]
 /// struct UnownedStruct<'a> {
@@ -884,7 +884,7 @@ pub fn deserialize_dict_macro_derive(input: TokenStream) -> TokenStream {
 /// Generic structures also supported:
 ///
 /// ```
-/// # use zbus::wire::{OwnedObjectPath, OwnedValue, Value};
+/// # use zbus::{OwnedObjectPath, OwnedValue, Value};
 /// #
 /// #[derive(Clone, Value, OwnedValue)]
 /// struct GenericStruct<S, O> {
@@ -907,7 +907,7 @@ pub fn deserialize_dict_macro_derive(input: TokenStream) -> TokenStream {
 /// Enums also supported but currently only with unit variants:
 ///
 /// ```
-/// # use zbus::wire::{OwnedValue, Value};
+/// # use zbus::{OwnedValue, Value};
 /// #
 /// #[derive(Debug, PartialEq, Value, OwnedValue)]
 /// // Default representation is `u32`.
@@ -929,7 +929,7 @@ pub fn deserialize_dict_macro_derive(input: TokenStream) -> TokenStream {
 /// String-encoded enums are also supported:
 ///
 /// ```
-/// # use zbus::wire::{OwnedValue, Value};
+/// # use zbus::{OwnedValue, Value};
 /// #
 /// #[derive(Debug, PartialEq, Value, OwnedValue)]
 /// #[zvariant(signature = "s")]
@@ -972,7 +972,7 @@ pub fn deserialize_dict_macro_derive(input: TokenStream) -> TokenStream {
 /// Here is an example using both `rename` and `rename_all`:
 ///
 /// ```
-/// # use zbus::wire::{OwnedValue, Value, Dict};
+/// # use zbus::{OwnedValue, Value, Dict};
 /// # use std::collections::HashMap;
 /// #
 /// #[derive(Clone, Value, OwnedValue)]
@@ -1006,7 +1006,7 @@ pub fn deserialize_dict_macro_derive(input: TokenStream) -> TokenStream {
 /// the derive at the module holding the wire types with the `crate` attribute:
 ///
 /// ```
-/// use zbus::wire::Value;
+/// use zbus::Value;
 ///
 /// #[derive(Clone, Value)]
 /// #[zbus(crate = "zbus::wire")]
@@ -1015,7 +1015,7 @@ pub fn deserialize_dict_macro_derive(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// [`Value`]: https://docs.rs/zbus/latest/zbus/wire/enum.Value.html
+/// [`Value`]: https://docs.rs/zbus/latest/zbus/enum.Value.html
 /// [`Type`]: crate::Type#custom-signatures
 #[proc_macro_derive(Value, attributes(zbus, zvariant))]
 pub fn value_macro_derive(input: TokenStream) -> TokenStream {
@@ -1035,7 +1035,7 @@ pub fn value_macro_derive(input: TokenStream) -> TokenStream {
 ///
 /// See [`Value`] documentation for examples.
 ///
-/// [`OwnedValue`]: https://docs.rs/zbus/latest/zbus/wire/struct.OwnedValue.html
+/// [`OwnedValue`]: https://docs.rs/zbus/latest/zbus/struct.OwnedValue.html
 #[proc_macro_derive(OwnedValue, attributes(zbus, zvariant))]
 pub fn owned_value_macro_derive(input: TokenStream) -> TokenStream {
     let ast: DeriveInput = syn::parse(input).unwrap();
@@ -1059,7 +1059,7 @@ pub fn owned_value_macro_derive(input: TokenStream) -> TokenStream {
 /// ## Basic usage
 ///
 /// ```
-/// use zbus::wire::signature;
+/// use zbus::signature;
 ///
 /// // Create signatures for basic types
 /// let sig = signature!("s");  // String signature
@@ -1072,7 +1072,7 @@ pub fn owned_value_macro_derive(input: TokenStream) -> TokenStream {
 /// ## Container types
 ///
 /// ```
-/// use zbus::wire::signature;
+/// use zbus::signature;
 ///
 /// // Array of strings
 /// let sig = signature!("as");
@@ -1093,7 +1093,7 @@ pub fn owned_value_macro_derive(input: TokenStream) -> TokenStream {
 /// for defining signatures at compile time:
 ///
 /// ```
-/// use zbus::wire::{signature, Signature};
+/// use zbus::{signature, Signature};
 ///
 /// const MY_SIGNATURE: Signature = signature!("a{sv}");
 ///
@@ -1107,7 +1107,7 @@ pub fn owned_value_macro_derive(input: TokenStream) -> TokenStream {
 /// For convenience, `dict` is an alias for `a{sv}` (string-to-variant dictionary):
 ///
 /// ```
-/// use zbus::wire::signature;
+/// use zbus::signature;
 ///
 /// let sig = signature!("dict");
 /// assert_eq!(sig.to_string(), "a{sv}");
@@ -1118,13 +1118,13 @@ pub fn owned_value_macro_derive(input: TokenStream) -> TokenStream {
 /// Invalid signatures will be caught at compile time:
 ///
 /// ```compile_fail
-/// use zbus::wire::signature;
+/// use zbus::signature;
 ///
 /// // This will fail to compile because 'z' is not a valid D-Bus type
 /// let sig = signature!("z");
 /// ```
 ///
-/// [`Signature`]: https://docs.rs/zbus/latest/zbus/wire/enum.Signature.html
+/// [`Signature`]: https://docs.rs/zbus/latest/zbus/enum.Signature.html
 #[proc_macro]
 pub fn signature(input: TokenStream) -> TokenStream {
     zbus_utils::derive::expand_signature_macro(input.into(), &utils::wire_path())

--- a/zbus_macros/src/proxy.rs
+++ b/zbus_macros/src/proxy.rs
@@ -322,7 +322,7 @@ pub fn create_proxy(
                 where
                     D: ::std::convert::TryInto<#zbus::names::BusName<'p>>,
                     D::Error: ::std::convert::Into<#zbus::Error>,
-                    P: ::std::convert::TryInto<#zbus::wire::ObjectPath<'p>>,
+                    P: ::std::convert::TryInto<#zbus::ObjectPath<'p>>,
                     P::Error: ::std::convert::Into<#zbus::Error>,
                 {
                     let obj_path = path.try_into().map_err(::std::convert::Into::into)?;
@@ -354,7 +354,7 @@ pub fn create_proxy(
                 /// Creates a new proxy with the given path, and the default destination.
                 pub #usage fn new<P>(conn: &#connection, path: P) -> #zbus::Result<#proxy_name<'p>>
                 where
-                    P: ::std::convert::TryInto<#zbus::wire::ObjectPath<'p>>,
+                    P: ::std::convert::TryInto<#zbus::ObjectPath<'p>>,
                     P::Error: ::std::convert::Into<#zbus::Error>,
                 {
                     let obj_path = path.try_into().map_err(::std::convert::Into::into)?;
@@ -374,7 +374,7 @@ pub fn create_proxy(
         }
     };
     let default_path = match default_path {
-        Some(p) => quote! { &Some(#zbus::wire::ObjectPath::from_static_str_unchecked(#p)) },
+        Some(p) => quote! { &Some(#zbus::ObjectPath::from_static_str_unchecked(#p)) },
         None => quote! { &None },
     };
     let default_service = match default_service {
@@ -401,7 +401,7 @@ pub fn create_proxy(
             const INTERFACE: &'static Option<#zbus::names::InterfaceName<'static>> =
                 &Some(#zbus::names::InterfaceName::from_static_str_unchecked(#iface_name));
             const DESTINATION: &'static Option<#zbus::names::BusName<'static>> = #default_service;
-            const PATH: &'static Option<#zbus::wire::ObjectPath<'static>> = #default_path;
+            const PATH: &'static Option<#zbus::ObjectPath<'static>> = #default_path;
         }
 
         #(#other_attrs)*
@@ -473,9 +473,9 @@ pub fn create_proxy(
             }
         }
 
-        impl<'p> #zbus::wire::Type for #proxy_name<'p> {
-            const SIGNATURE: &'static #zbus::wire::Signature =
-                &#zbus::wire::Signature::ObjectPath;
+        impl<'p> #zbus::Type for #proxy_name<'p> {
+            const SIGNATURE: &'static #zbus::Signature =
+                &#zbus::Signature::ObjectPath;
         }
 
         impl<'p> #zbus::export::serde::ser::Serialize for #proxy_name<'p> {
@@ -608,7 +608,7 @@ fn gen_proxy_method_call(
             parse_quote!(#zbus::export::serde::de::DeserializeOwned)
         };
         where_clause.predicates.push(parse_quote!(
-            #param: #serde_bound + #zbus::wire::Type
+            #param: #serde_bound + #zbus::Type
         ));
     }
     let (_, ty_generics, where_clause) = generics.split_for_impl();
@@ -634,13 +634,13 @@ fn gen_proxy_method_call(
         let method_call = quote! {
             self.0.call(
                 #dbus_member_name,
-                &#zbus::wire::DynamicTuple((#(#args,)*)),
+                &#zbus::DynamicTuple((#(#args,)*)),
             )
             #wait?
         };
         let body = if proxy_vec {
             quote! {
-                let object_paths: Vec<#zbus::wire::OwnedObjectPath> = #method_call;
+                let object_paths: Vec<#zbus::OwnedObjectPath> = #method_call;
 
                 let mut proxies = Vec::with_capacity(object_paths.len());
                 for object_path in object_paths {
@@ -652,7 +652,7 @@ fn gen_proxy_method_call(
             }
         } else {
             quote! {
-                let object_path: #zbus::wire::OwnedObjectPath = #method_call;
+                let object_path: #zbus::OwnedObjectPath = #method_call;
                 #proxy_build
             }
         };
@@ -668,11 +668,11 @@ fn gen_proxy_method_call(
             // the '()' from the signature that we add and not the actual intended ones.
             let arg = &args[0];
             quote! {
-                &#zbus::wire::DynamicTuple((#arg,))
+                &#zbus::DynamicTuple((#arg,))
             }
         } else {
             quote! {
-                &#zbus::wire::DynamicTuple((#(#args),*))
+                &#zbus::DynamicTuple((#(#args),*))
             }
         };
 
@@ -808,7 +808,7 @@ fn gen_proxy_property(
             };
             let body = if proxy_vec {
                 quote_spanned! {body_span =>
-                    let object_paths: Vec<#zbus::wire::OwnedObjectPath> =
+                    let object_paths: Vec<#zbus::OwnedObjectPath> =
                         #property_get;
 
                     let mut proxies = Vec::with_capacity(object_paths.len());
@@ -821,7 +821,7 @@ fn gen_proxy_property(
                 }
             } else {
                 quote_spanned! {body_span =>
-                    let object_path: #zbus::wire::OwnedObjectPath =
+                    let object_path: #zbus::OwnedObjectPath =
                         #property_get;
                     #proxy_build
                 }
@@ -994,7 +994,7 @@ fn gen_proxy_signal(
     {
         where_clause
                 .predicates
-                .push(parse_quote!(#param: #zbus::export::serde::de::Deserialize<'s> + #zbus::wire::Type + ::std::fmt::Debug));
+                .push(parse_quote!(#param: #zbus::export::serde::de::Deserialize<'s> + #zbus::Type + ::std::fmt::Debug));
     }
     generics.params.push(parse_quote!('s));
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();

--- a/zbus_macros/tests/derives.rs
+++ b/zbus_macros/tests/derives.rs
@@ -2,10 +2,10 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use zbus::wire::{
-    LE, OwnedValue, Signature, Type, Value,
+use zbus::{
+    OwnedValue, Signature, Type, Value,
     as_value::{self, optional},
-    serialized::Context,
+    wire::{LE, serialized::Context},
 };
 
 #[test]
@@ -152,7 +152,7 @@ fn derive_with_crate_attr() {
 
 #[test]
 fn signature_macro_uses_detected_crate_path() {
-    use zbus::wire::signature;
+    use zbus::signature;
 
     const DICT: Signature = signature!("a{sv}");
 

--- a/zbus_macros/tests/no_prelude.rs
+++ b/zbus_macros/tests/no_prelude.rs
@@ -2,7 +2,7 @@
 #![allow(dead_code)]
 
 use ::serde::{Deserialize, Serialize};
-use ::zbus::wire::{
+use ::zbus::{
     Type,
     as_value::{self, optional},
 };

--- a/zbus_macros/tests/tests.rs
+++ b/zbus_macros/tests/tests.rs
@@ -23,10 +23,7 @@ mod param {
 }
 
 mod test {
-    use zbus::{
-        fdo,
-        wire::{OwnedStructure, Structure},
-    };
+    use zbus::{OwnedStructure, Structure, fdo};
 
     #[zbus_macros::proxy(
         assume_defaults = false,
@@ -37,7 +34,7 @@ mod test {
         /// comment for a_test()
         fn a_test(&self, val: &str) -> zbus::Result<u32>;
 
-        /// The generated proxies implement both `zbus::wire::Type` and `serde::ser::Serialize`
+        /// The generated proxies implement both `zbus::Type` and `serde::ser::Serialize`
         /// which is useful to pass in a proxy as a param. It serializes it as an `ObjectPath`.
         fn some_method<T>(&self, object_path: &T) -> zbus::Result<()>;
 
@@ -132,7 +129,7 @@ fn test_derive_error() {
 #[test]
 fn test_interface() {
     use serde::{Deserialize, Serialize};
-    use zbus::{object_server::Interface, wire::Type};
+    use zbus::{Type, object_server::Interface};
 
     // Test write-only property
     struct TestWriteOnlyProperty;
@@ -166,7 +163,7 @@ fn test_interface() {
     #[interface(name = "org.freedesktop.zbus.Test", spawn = false)]
     impl<T: 'static> Test<T>
     where
-        T: serde::ser::Serialize + zbus::wire::Type + Send + Sync,
+        T: serde::ser::Serialize + zbus::Type + Send + Sync,
     {
         /// Testing `no_arg` documentation is reflected in XML.
         fn no_arg(&self) {
@@ -436,7 +433,7 @@ mod signal_from_message {
 fn test_proxy_object_list() {
     #[derive(Clone)]
     struct ObjectList {
-        paths: [zbus::wire::ObjectPath<'static>; 2],
+        paths: [zbus::ObjectPath<'static>; 2],
     }
 
     #[zbus_macros::interface(
@@ -445,22 +442,22 @@ fn test_proxy_object_list() {
     )]
     impl ObjectList {
         #[zbus(proxy(object = "ObjectList", object_vec))]
-        async fn get_test_objects(&self) -> Vec<zbus::wire::ObjectPath<'static>> {
+        async fn get_test_objects(&self) -> Vec<zbus::ObjectPath<'static>> {
             self.paths.to_vec()
         }
 
         #[zbus(property, proxy(object = "ObjectList", object_vec))]
-        fn objects(&self) -> Vec<zbus::wire::ObjectPath<'static>> {
+        fn objects(&self) -> Vec<zbus::ObjectPath<'static>> {
             self.paths.to_vec()
         }
     }
 
     static OBJECT_LIST: ObjectList = ObjectList {
         paths: [
-            zbus::wire::ObjectPath::from_static_str_unchecked(
+            zbus::ObjectPath::from_static_str_unchecked(
                 "/org/freedesktop/zbus_macros/object_list/0",
             ),
-            zbus::wire::ObjectPath::from_static_str_unchecked(
+            zbus::ObjectPath::from_static_str_unchecked(
                 "/org/freedesktop/zbus_macros/object_list/1",
             ),
         ],
@@ -496,7 +493,7 @@ fn test_proxy_object_list() {
 // through the `zbus` re-export.
 #[test]
 fn signature_macro_resolves_zvariant_through_zbus() {
-    use zbus::wire::{Signature, signature};
+    use zbus::{Signature, signature};
 
     const DICT: Signature = signature!("a{sv}");
 
@@ -506,7 +503,7 @@ fn signature_macro_resolves_zvariant_through_zbus() {
 
 #[test]
 fn interface_property_setter_with_crate_attr() {
-    use mybus::{object_server::Interface, wire::Value};
+    use mybus::{Value, object_server::Interface};
 
     struct CrateAttrProperties;
 
@@ -528,7 +525,7 @@ fn interface_property_setter_with_crate_attr() {
 #[test]
 fn interface_property_setter_with_serde() {
     use serde::{Deserialize, Serialize};
-    use zbus::{object_server::Interface, wire::Type};
+    use zbus::{Type, object_server::Interface};
 
     #[derive(Deserialize, Serialize, Type)]
     struct Fahrenheit(u32);

--- a/zbus_utils/src/signature/mod.rs
+++ b/zbus_utils/src/signature/mod.rs
@@ -17,7 +17,7 @@ use std::{
 
 /// A D-Bus signature in parsed form.
 ///
-/// This is the type that zbus re-exports as [`zbus::wire::Signature`] and zgvariant as
+/// This is the type that zbus re-exports as [`zbus::Signature`] and zgvariant as
 /// `zgvariant::Signature`, so a signature parsed by one of them is the same value in the other.
 /// Parsing a signature once, into this tree, is what lets their (de)serialization API stay
 /// efficient.
@@ -49,7 +49,7 @@ use std::{
 /// assert_eq!(SIGNATURE.to_string(), "av");
 /// ```
 ///
-/// [`zbus::wire::Signature`]: https://docs.rs/zbus/latest/zbus/wire/enum.Signature.html
+/// [`zbus::Signature`]: https://docs.rs/zbus/latest/zbus/enum.Signature.html
 #[derive(Debug, Default, Clone)]
 pub enum Signature {
     // Basic types

--- a/zbus_xml/src/lib.rs
+++ b/zbus_xml/src/lib.rs
@@ -629,21 +629,21 @@ impl<'a> TryFrom<&'a str> for Node<'a> {
     }
 }
 
-/// A thin wrapper around [`zbus::wire::Signature`].
+/// A thin wrapper around [`zbus::Signature`].
 ///
 /// This is to allow `Signature` to be deserialized from an owned string, which is what XML
 /// deserializers typically produce.
 #[derive(Debug, Serialize, Clone, PartialEq)]
-pub struct Signature(zbus::wire::Signature);
+pub struct Signature(zbus::Signature);
 
 impl Signature {
-    /// The inner [`zbus::wire::Signature`].
-    pub fn inner(&self) -> &zbus::wire::Signature {
+    /// The inner [`zbus::Signature`].
+    pub fn inner(&self) -> &zbus::Signature {
         &self.0
     }
 
-    /// Convert this `Signature` into the inner [`zbus::wire::Signature`].
-    pub fn into_inner(self) -> zbus::wire::Signature {
+    /// Convert this `Signature` into the inner [`zbus::Signature`].
+    pub fn into_inner(self) -> zbus::Signature {
         self.0
     }
 }
@@ -654,7 +654,7 @@ impl<'de> serde::de::Deserialize<'de> for Signature {
         D: serde::de::Deserializer<'de>,
     {
         String::deserialize(deserializer).and_then(|s| {
-            zbus::wire::Signature::try_from(s.as_bytes())
+            zbus::Signature::try_from(s.as_bytes())
                 .map_err(serde::de::Error::custom)
                 .map(Signature)
         })
@@ -662,7 +662,7 @@ impl<'de> serde::de::Deserialize<'de> for Signature {
 }
 
 impl Deref for Signature {
-    type Target = zbus::wire::Signature;
+    type Target = zbus::Signature;
 
     fn deref(&self) -> &Self::Target {
         self.inner()

--- a/zbus_xml/src/telepathy.rs
+++ b/zbus_xml/src/telepathy.rs
@@ -60,7 +60,7 @@ impl TypeDef {
     }
 
     /// The D-Bus signature of the defined type.
-    pub fn signature(&self) -> zbus::wire::Signature {
+    pub fn signature(&self) -> zbus::Signature {
         match self {
             TypeDef::SimpleType(t) => t.ty().inner().clone(),
             TypeDef::Enum(e) => e.ty().inner().clone(),
@@ -176,8 +176,8 @@ impl Struct {
     }
 
     /// The D-Bus signature of the structure.
-    pub fn signature(&self) -> zbus::wire::Signature {
-        zbus::wire::Signature::structure(
+    pub fn signature(&self) -> zbus::Signature {
+        zbus::Signature::structure(
             self.members
                 .iter()
                 .map(|m| m.ty().inner().clone())
@@ -248,8 +248,8 @@ impl Mapping {
     }
 
     /// The D-Bus signature of the dictionary.
-    pub fn signature(&self) -> zbus::wire::Signature {
-        zbus::wire::Signature::dict(
+    pub fn signature(&self) -> zbus::Signature {
+        zbus::Signature::dict(
             self.key.ty().inner().clone(),
             self.value.ty().inner().clone(),
         )
@@ -258,7 +258,7 @@ impl Mapping {
 
 /// Whether `ty` is a basic (i. e. non-container) D-Bus type, as required for dictionary keys.
 pub(crate) fn is_basic(ty: &Signature) -> bool {
-    use zbus::wire::Signature as S;
+    use zbus::Signature as S;
 
     match ty.inner() {
         S::U8

--- a/zbus_xml/src/xml.rs
+++ b/zbus_xml/src/xml.rs
@@ -660,11 +660,11 @@ impl SignatureAttr {
     fn parse(value: Option<&str>) -> Self {
         match value {
             None => SignatureAttr::Missing,
-            Some(value) => match zbus::wire::Signature::try_from(value.as_bytes()) {
+            Some(value) => match zbus::Signature::try_from(value.as_bytes()) {
                 // The empty signature parses as `Unit`, which is only valid as a top-level
                 // signature — inside a composed signature (`Struct`/`Mapping::signature`) it
                 // produces invalid signatures.
-                Ok(zbus::wire::Signature::Unit) | Err(_) => SignatureAttr::Invalid,
+                Ok(zbus::Signature::Unit) | Err(_) => SignatureAttr::Invalid,
                 Ok(signature) => SignatureAttr::Value(Signature(signature)),
             },
         }
@@ -1058,7 +1058,7 @@ impl<'i> Attrs<'i> {
 
     /// The required `type` attribute, parsed as a signature.
     fn signature(&self) -> PResult<Signature> {
-        zbus::wire::Signature::try_from(self.required("type")?.as_bytes())
+        zbus::Signature::try_from(self.required("type")?.as_bytes())
             .map(Signature)
             .map_err(|e| ParseError::domain(zbus::Error::from(e).into()))
     }

--- a/zbus_xml/tests/tests.rs
+++ b/zbus_xml/tests/tests.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 
-use zbus::wire::Signature;
+use zbus::Signature;
 use zbus_xml::{Arg, ArgDirection, Interface, Node, PropertyAccess};
 
 #[test]

--- a/zbus_xmlgen/src/lib.rs
+++ b/zbus_xmlgen/src/lib.rs
@@ -5,10 +5,7 @@ use std::{
     process::{Command, Stdio},
 };
 
-use zbus::{
-    names::BusName,
-    wire::{ObjectPath, Signature},
-};
+use zbus::{ObjectPath, Signature, names::BusName};
 use zbus_xml::{
     Arg, ArgDirection, Interface, Property,
     telepathy::{self, TypeDef},
@@ -856,7 +853,7 @@ fn write_enum<W: Write>(w: &mut W, e: &telepathy::Enum) -> std::fmt::Result {
                 w,
                 "#[derive(Debug, Clone, Copy, PartialEq, Eq, \
                  serde_repr::Deserialize_repr, serde_repr::Serialize_repr, \
-                 zbus::wire::Type, zbus::wire::Value, zbus::wire::OwnedValue)]"
+                 zbus::Type, zbus::Value, zbus::OwnedValue)]"
             )?;
             writeln!(w, "#[zvariant(crate = \"zbus::wire\")]")?;
             writeln!(w, "#[repr({int})]")?;
@@ -877,7 +874,7 @@ fn write_enum<W: Write>(w: &mut W, e: &telepathy::Enum) -> std::fmt::Result {
                 w,
                 "#[derive(Debug, Clone, Copy, PartialEq, Eq, \
                  serde::Serialize, serde::Deserialize, \
-                 zbus::wire::Type, zbus::wire::Value, zbus::wire::OwnedValue)]"
+                 zbus::Type, zbus::Value, zbus::OwnedValue)]"
             )?;
             writeln!(w, "#[zvariant(signature = \"s\", crate = \"zbus::wire\")]")?;
             writeln!(w, "pub enum {} {{", type_name(e.name()))?;
@@ -904,7 +901,7 @@ fn write_struct<W: Write>(w: &mut W, s: &telepathy::Struct, types: &Types<'_>) -
     writeln!(
         w,
         "#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, \
-         zbus::wire::Type, zbus::wire::Value, zbus::wire::OwnedValue)]"
+         zbus::Type, zbus::Value, zbus::OwnedValue)]"
     )?;
     writeln!(w, "#[zvariant(crate = \"zbus::wire\")]")?;
     writeln!(w, "pub struct {} {{", type_name(s.name()))?;
@@ -1083,31 +1080,31 @@ fn to_rust_type(ty: &Signature, input: bool, as_ref: bool) -> String {
             Signature::U64 => "u64".into(),
             Signature::F64 => "f64".into(),
             #[cfg(unix)]
-            Signature::Fd if input => "zbus::wire::Fd<'_>".into(),
+            Signature::Fd if input => "zbus::Fd<'_>".into(),
             #[cfg(unix)]
-            Signature::Fd => "zbus::wire::OwnedFd".into(),
+            Signature::Fd => "zbus::OwnedFd".into(),
             Signature::Str if input || as_ref => "&str".into(),
             Signature::Str => "String".into(),
             Signature::ObjectPath if input => {
                 if as_ref {
-                    "&zbus::wire::ObjectPath<'_>".into()
+                    "&zbus::ObjectPath<'_>".into()
                 } else {
-                    "zbus::wire::ObjectPath<'_>".into()
+                    "zbus::ObjectPath<'_>".into()
                 }
             }
-            Signature::ObjectPath => "zbus::wire::OwnedObjectPath".into(),
+            Signature::ObjectPath => "zbus::OwnedObjectPath".into(),
             // `Signature` has been lifetime-less (with no `Owned` counterpart)
             // since zvariant 5.
-            Signature::Signature if input && as_ref => "&zbus::wire::Signature".into(),
-            Signature::Signature => "zbus::wire::Signature".into(),
+            Signature::Signature if input && as_ref => "&zbus::Signature".into(),
+            Signature::Signature => "zbus::Signature".into(),
             Signature::Variant if input => {
                 if as_ref {
-                    "&zbus::wire::Value<'_>".into()
+                    "&zbus::Value<'_>".into()
                 } else {
-                    "zbus::wire::Value<'_>".into()
+                    "zbus::Value<'_>".into()
                 }
             }
-            Signature::Variant => "zbus::wire::OwnedValue".into(),
+            Signature::Variant => "zbus::OwnedValue".into(),
             Signature::Array(child) => {
                 let child_ty = signature_to_rust_type(child, input, as_ref);
                 if input && as_ref {
@@ -1150,7 +1147,7 @@ fn to_rust_type(ty: &Signature, input: bool, as_ref: bool) -> String {
 fn to_property_setter_type(ty: &Signature) -> String {
     fn inner(signature: &Signature) -> String {
         match signature {
-            Signature::Variant => "zbus::wire::Value<'_>".into(),
+            Signature::Variant => "zbus::Value<'_>".into(),
             Signature::Structure(fields) => {
                 let fields = fields.iter().map(inner).collect::<Vec<_>>();
                 if fields.len() > 1 {

--- a/zbus_xmlgen/src/main.rs
+++ b/zbus_xmlgen/src/main.rs
@@ -10,9 +10,9 @@ use std::{
 use clap::Parser;
 use snakecase::ascii::to_snakecase;
 use zbus::{
+    ObjectPath,
     blocking::{Connection, connection, fdo::IntrospectableProxy},
     names::BusName,
-    wire::ObjectPath,
 };
 use zbus_xml::{Interface, Node, Warning};
 

--- a/zbus_xmlgen/tests/data/property_setters.rs
+++ b/zbus_xmlgen/tests/data/property_setters.rs
@@ -8,19 +8,19 @@ pub trait PropertySetters {
 
     /// ArrayOfVariant property
     #[zbus(property)]
-    fn array_of_variant(&self) -> zbus::Result<Vec<zbus::wire::OwnedValue>>;
+    fn array_of_variant(&self) -> zbus::Result<Vec<zbus::OwnedValue>>;
     #[zbus(property)]
-    fn set_array_of_variant(&self, value: &[zbus::wire::Value<'_>]) -> zbus::Result<()>;
+    fn set_array_of_variant(&self, value: &[zbus::Value<'_>]) -> zbus::Result<()>;
 
     /// DictStrToVariant property
     #[zbus(property)]
     fn dict_str_to_variant(
         &self,
-    ) -> zbus::Result<std::collections::HashMap<String, zbus::wire::OwnedValue>>;
+    ) -> zbus::Result<std::collections::HashMap<String, zbus::OwnedValue>>;
     #[zbus(property)]
     fn set_dict_str_to_variant(
         &self,
-        value: std::collections::HashMap<&str, zbus::wire::Value<'_>>,
+        value: std::collections::HashMap<&str, zbus::Value<'_>>,
     ) -> zbus::Result<()>;
 
     /// StructPair property
@@ -37,16 +37,13 @@ pub trait PropertySetters {
 
     /// StructWithArrayOfVariant property
     #[zbus(property)]
-    fn struct_with_array_of_variant(&self) -> zbus::Result<(Vec<zbus::wire::OwnedValue>,)>;
+    fn struct_with_array_of_variant(&self) -> zbus::Result<(Vec<zbus::OwnedValue>,)>;
     #[zbus(property)]
-    fn set_struct_with_array_of_variant(
-        &self,
-        value: (&[zbus::wire::Value<'_>],),
-    ) -> zbus::Result<()>;
+    fn set_struct_with_array_of_variant(&self, value: (&[zbus::Value<'_>],)) -> zbus::Result<()>;
 
     /// Variant property
     #[zbus(property)]
-    fn variant(&self) -> zbus::Result<zbus::wire::OwnedValue>;
+    fn variant(&self) -> zbus::Result<zbus::OwnedValue>;
     #[zbus(property)]
-    fn set_variant(&self, value: zbus::wire::Value<'_>) -> zbus::Result<()>;
+    fn set_variant(&self, value: zbus::Value<'_>) -> zbus::Result<()>;
 }

--- a/zbus_xmlgen/tests/data/sample_object0.rs
+++ b/zbus_xmlgen/tests/data/sample_object0.rs
@@ -14,13 +14,13 @@ pub trait SampleInterface0 {
             i32,
             bool,
         ),
-    ) -> zbus::Result<Vec<(String, zbus::wire::OwnedObjectPath)>>;
+    ) -> zbus::Result<Vec<(String, zbus::OwnedObjectPath)>>;
 
     /// Bazic method
     fn bazic(&self, bar: &(i32, i32), foo: &(i32,)) -> zbus::Result<((i32, i32), Vec<(i32,)>)>;
 
     /// Bazify method
-    fn bazify(&self, bar: &(i32, i32, u32)) -> zbus::Result<zbus::wire::OwnedValue>;
+    fn bazify(&self, bar: &(i32, i32, u32)) -> zbus::Result<zbus::OwnedValue>;
 
     /// Frobate method
     fn frobate(
@@ -30,13 +30,10 @@ pub trait SampleInterface0 {
     ) -> zbus::Result<(String, std::collections::HashMap<u32, String>)>;
 
     /// GetSignature method
-    fn get_signature(
-        &self,
-        challenge: &zbus::wire::Signature,
-    ) -> zbus::Result<zbus::wire::Signature>;
+    fn get_signature(&self, challenge: &zbus::Signature) -> zbus::Result<zbus::Signature>;
 
     /// MogrifyMe method
-    fn mogrify_me(&self, bar: &(i32, i32, &[&zbus::wire::Value<'_>])) -> zbus::Result<()>;
+    fn mogrify_me(&self, bar: &(i32, i32, &[&zbus::Value<'_>])) -> zbus::Result<()>;
 
     /// Odyssey method
     #[allow(clippy::too_many_arguments)]
@@ -48,7 +45,7 @@ pub trait SampleInterface0 {
         circe: i32,
         athena: bool,
         polyphemus: i32,
-        calypso: &zbus::wire::Value<'_>,
+        calypso: &zbus::Value<'_>,
     ) -> zbus::Result<()>;
 
     /// Changed signal
@@ -67,12 +64,12 @@ pub trait SampleInterface0 {
     #[zbus(signal)]
     fn signal_dict_string_to_value(
         &self,
-        dict: std::collections::HashMap<&str, zbus::wire::Value<'_>>,
+        dict: std::collections::HashMap<&str, zbus::Value<'_>>,
     ) -> zbus::Result<()>;
 
     /// SignalValue signal
     #[zbus(signal)]
-    fn signal_value(&self, value: zbus::wire::Value<'_>) -> zbus::Result<()>;
+    fn signal_value(&self, value: zbus::Value<'_>) -> zbus::Result<()>;
 
     /// Bar property
     #[zbus(property)]
@@ -93,11 +90,11 @@ pub trait SampleInterface0 {
         &self,
     ) -> zbus::Result<
         Vec<(
-            zbus::wire::OwnedObjectPath,
+            zbus::OwnedObjectPath,
             i32,
             Vec<String>,
             u64,
-            std::collections::HashMap<String, zbus::wire::OwnedValue>,
+            std::collections::HashMap<String, zbus::OwnedValue>,
         )>,
     >;
 }

--- a/zbus_xmlgen/tests/data/telepathy_docstrings.rs
+++ b/zbus_xmlgen/tests/data/telepathy_docstrings.rs
@@ -6,9 +6,9 @@
     Eq,
     serde::Serialize,
     serde::Deserialize,
-    zbus::wire::Type,
-    zbus::wire::Value,
-    zbus::wire::OwnedValue,
+    zbus::Type,
+    zbus::Value,
+    zbus::OwnedValue,
 )]
 #[zvariant(signature = "s", crate = "zbus::wire")]
 pub enum PlaylistOrdering {
@@ -29,9 +29,9 @@ pub enum PlaylistOrdering {
     Eq,
     serde_repr::Deserialize_repr,
     serde_repr::Serialize_repr,
-    zbus::wire::Type,
-    zbus::wire::Value,
-    zbus::wire::OwnedValue,
+    zbus::Type,
+    zbus::Value,
+    zbus::OwnedValue,
 )]
 #[zvariant(crate = "zbus::wire")]
 #[repr(u32)]
@@ -51,9 +51,9 @@ pub enum LoopStatus {
     PartialEq,
     serde::Serialize,
     serde::Deserialize,
-    zbus::wire::Type,
-    zbus::wire::Value,
-    zbus::wire::OwnedValue,
+    zbus::Type,
+    zbus::Value,
+    zbus::OwnedValue,
 )]
 #[zvariant(crate = "zbus::wire")]
 pub struct Playlist {
@@ -72,9 +72,9 @@ pub struct Playlist {
     PartialEq,
     serde::Serialize,
     serde::Deserialize,
-    zbus::wire::Type,
-    zbus::wire::Value,
-    zbus::wire::OwnedValue,
+    zbus::Type,
+    zbus::Value,
+    zbus::OwnedValue,
 )]
 #[zvariant(crate = "zbus::wire")]
 pub struct MaybePlaylist {
@@ -85,10 +85,10 @@ pub struct MaybePlaylist {
 }
 
 /// A mapping from metadata attribute names to values.
-pub type MetadataMap = std::collections::HashMap<String, zbus::wire::OwnedValue>;
+pub type MetadataMap = std::collections::HashMap<String, zbus::OwnedValue>;
 
 /// Unique playlist identifier.
-pub type PlaylistId = zbus::wire::OwnedObjectPath;
+pub type PlaylistId = zbus::OwnedObjectPath;
 
 /// Provides access to the media player's playlists.
 ///

--- a/zbus_xmlgen/tests/data/telepathy_edge_cases.rs
+++ b/zbus_xmlgen/tests/data/telepathy_edge_cases.rs
@@ -4,9 +4,9 @@
     PartialEq,
     serde::Serialize,
     serde::Deserialize,
-    zbus::wire::Type,
-    zbus::wire::Value,
-    zbus::wire::OwnedValue,
+    zbus::Type,
+    zbus::Value,
+    zbus::OwnedValue,
 )]
 #[zvariant(crate = "zbus::wire")]
 pub struct PlayList {
@@ -21,9 +21,9 @@ pub struct PlayList {
     Eq,
     serde_repr::Deserialize_repr,
     serde_repr::Serialize_repr,
-    zbus::wire::Type,
-    zbus::wire::Value,
-    zbus::wire::OwnedValue,
+    zbus::Type,
+    zbus::Value,
+    zbus::OwnedValue,
 )]
 #[zvariant(crate = "zbus::wire")]
 #[repr(i32)]
@@ -40,9 +40,9 @@ pub enum OddValues {
     Eq,
     serde::Serialize,
     serde::Deserialize,
-    zbus::wire::Type,
-    zbus::wire::Value,
-    zbus::wire::OwnedValue,
+    zbus::Type,
+    zbus::Value,
+    zbus::OwnedValue,
 )]
 #[zvariant(signature = "s", crate = "zbus::wire")]
 pub enum Status {


### PR DESCRIPTION
Common D-Bus types now live at the `zbus` root, so callers can use `zbus::Value`,
`zbus::ObjectPath` and `zbus::Type` without going through `wire`. The re-exports also cover
the common containers, type traits, derives, `signature!` and `as_value`; direct encoding
and decoding APIs remain under `wire`.

Use `Structure::builder()` to construct dynamic structures without importing
`StructureBuilder`. Its existing `wire` path remains available for compatibility.
Internal callers, generated bindings, documentation, examples and migration guidance
use the shorter paths.

Validation: workspace all-feature tests under a D-Bus session, wire-only tests,
documentation build, standard Clippy and nightly formatting checks.

Generated by GPT-6.
