### PR TITLE
⚡️ zb,zm: Cut the binary size of zbus programs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -134,6 +134,9 @@ jobs:
           # `gvariant` feature on, and Cargo unification hands zbus the extra signature and
           # format variants it must keep rejecting.
           cargo --locked test -p zbus --no-default-features --features zbus_utils/gvariant
+          # The same graph with the D-Bus API on: the message header carries a body signature
+          # that must be rejected too.
+          cargo --locked test -p zbus --no-default-features --features zbus_utils/gvariant,async-io
       - name: Build and Test
         run: |
           dbus-run-session --config-file /tmp/dbus-session-abstract.conf -- cargo --locked test --release --verbose -- basic_connection

--- a/book/src/upgrading-to-6.md
+++ b/book/src/upgrading-to-6.md
@@ -471,6 +471,21 @@ Leaving out the half you don't use keeps its code out of your binary, which even
 not do before. Everything else in the D-Bus API (`Connection`, `Message`, `MessageStream`,
 `MatchRule`, the plain `fdo` types and errors, `Connection::request_name`) needs neither.
 
+### The `unixexec` transport is a feature
+
+The `unixexec:` address transport runs a command and talks D-Bus over its standard I/O, which
+pulls the async runtime's process support into every binary. It is behind the `unixexec` feature
+now, a default feature, so a plain `zbus = "6"` dependency keeps it. A `default-features = false`
+build that connects through it has to name it:
+
+```toml
+[dependencies]
+zbus = { version = "6", default-features = false, features = ["tokio", "proxy", "unixexec"] }
+```
+
+`Transport::Unixexec` and `transport::Unixexec` exist only with the feature, and
+`Address::from_str` rejects a `unixexec:` address without it.
+
 ### A proxy without properties has no properties cache
 
 `proxy::Defaults` has a new constant, `HAS_PROPERTIES`, which `#[proxy]` sets from the trait,

--- a/book/src/upgrading-to-6.md
+++ b/book/src/upgrading-to-6.md
@@ -471,20 +471,21 @@ Leaving out the half you don't use keeps its code out of your binary, which even
 not do before. Everything else in the D-Bus API (`Connection`, `Message`, `MessageStream`,
 `MatchRule`, the plain `fdo` types and errors, `Connection::request_name`) needs neither.
 
-### The `unixexec` transport is a feature
+### The `unixexec` and `ibus` transports are features
 
-The `unixexec:` address transport runs a command and talks D-Bus over its standard I/O, which
-pulls the async runtime's process support into every binary. It is behind the `unixexec` feature
-now, a default feature, so a plain `zbus = "6"` dependency keeps it. A `default-features = false`
-build that connects through it has to name it:
+The `unixexec:` and `ibus:` address transports run a command to reach the bus, which pulls the
+async runtime's process support into every binary. They are behind the `unixexec` and `ibus`
+features now, both default features, so a plain `zbus = "6"` dependency keeps them. A
+`default-features = false` build that connects through either has to name it:
 
 ```toml
 [dependencies]
 zbus = { version = "6", default-features = false, features = ["tokio", "proxy", "unixexec"] }
 ```
 
-`Transport::Unixexec` and `transport::Unixexec` exist only with the feature, and
-`Address::from_str` rejects a `unixexec:` address without it.
+`Transport::Unixexec`, `Transport::Ibus`, `transport::Unixexec`, `transport::Ibus` and
+`connection::Builder::ibus` exist only with their feature, and `Address::from_str` rejects the
+address of a transport that was left out.
 
 ### A proxy without properties has no properties cache
 

--- a/book/src/upgrading-to-6.md
+++ b/book/src/upgrading-to-6.md
@@ -471,6 +471,14 @@ Leaving out the half you don't use keeps its code out of your binary, which even
 not do before. Everything else in the D-Bus API (`Connection`, `Message`, `MessageStream`,
 `MatchRule`, the plain `fdo` types and errors, `Connection::request_name`) needs neither.
 
+### A proxy without properties has no properties cache
+
+`proxy::Defaults` has a new constant, `HAS_PROPERTIES`, which `#[proxy]` sets from the trait,
+and `proxy::Builder::build` requires the trait. A proxy whose interface has no properties never
+sets up the properties cache, whatever the `CacheProperties` setting, so a program whose proxies
+have none carries no cache code at all. A hand-written `Defaults` implementation can leave the
+constant at its default of `true`.
+
 ## A stale zvariant in the dependency graph
 
 If another crate in your tree still depends on zvariant 5, your build contains two unrelated

--- a/book/src/upgrading-to-6.md
+++ b/book/src/upgrading-to-6.md
@@ -487,6 +487,25 @@ zbus = { version = "6", default-features = false, features = ["tokio", "proxy", 
 `connection::Builder::ibus` exist only with their feature, and `Address::from_str` rejects the
 address of a transport that was left out.
 
+### The service-side `ObjectManager` is a feature
+
+The object server emits `InterfacesAdded` and `InterfacesRemoved` on behalf of any
+[`fdo::ObjectManager`] registered above an object, which links that interface, its signal
+emission and the property gathering behind it into every service. That is behind the new
+`object-manager` feature, a default feature which implies `service`, so a plain `zbus = "6"`
+dependency keeps it. A `default-features = false` build that registers an `ObjectManager` has to
+name it:
+
+```toml
+[dependencies]
+zbus = { version = "6", default-features = false, features = ["tokio", "object-manager"] }
+```
+
+`fdo::ObjectManager` exists only with the feature. The `ObjectManagerProxy` and its signal
+streams only need `proxy`, as before.
+
+[`fdo::ObjectManager`]: https://docs.rs/zbus/6/zbus/fdo/struct.ObjectManager.html
+
 ### A proxy without properties has no properties cache
 
 `proxy::Defaults` has a new constant, `HAS_PROPERTIES`, which `#[proxy]` sets from the trait,

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -13,7 +13,15 @@ categories = ["os::unix-apis"]
 readme = "README.md"
 
 [features]
-default = ["async-io", "blocking-api", "proxy", "service", "unixexec", "ibus"]
+default = [
+    "async-io",
+    "blocking-api",
+    "proxy",
+    "service",
+    "object-manager",
+    "unixexec",
+    "ibus",
+]
 
 # Wire-format optional impls — the former zvariant features, same names.
 arrayvec = ["dep:arrayvec"]
@@ -70,6 +78,9 @@ blocking-api = ["comms"]
 proxy = ["comms", "zbus_macros/proxy"]
 # The service-side (object server) API (default).
 service = ["comms", "zbus_macros/service"]
+# The service-side `ObjectManager` implementation, along with the `InterfacesAdded` and
+# `InterfacesRemoved` signals the object server emits on its behalf (default).
+object-manager = ["service"]
 # The `unixexec:` transport, which runs a command and talks D-Bus over its standard I/O
 # (default).
 unixexec = ["comms"]
@@ -199,6 +210,7 @@ features = [
     "bus-impl",
     "p2p",
     "tokio",
+    "object-manager",
     "unixexec",
     "ibus",
 ]

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["os::unix-apis"]
 readme = "README.md"
 
 [features]
-default = ["async-io", "blocking-api", "proxy", "service"]
+default = ["async-io", "blocking-api", "proxy", "service", "unixexec"]
 
 # Wire-format optional impls — the former zvariant features, same names.
 arrayvec = ["dep:arrayvec"]
@@ -70,6 +70,9 @@ blocking-api = ["comms"]
 proxy = ["comms", "zbus_macros/proxy"]
 # The service-side (object server) API (default).
 service = ["comms", "zbus_macros/service"]
+# The `unixexec:` transport, which runs a command and talks D-Bus over its standard I/O
+# (default).
+unixexec = ["comms"]
 # Enables API that is only needed for peer-to-peer (p2p) connections.
 p2p = ["comms", "uuid?/v4"]
 # Enables API that is only needed for bus implementations (enables `p2p`).
@@ -193,6 +196,7 @@ features = [
     "bus-impl",
     "p2p",
     "tokio",
+    "unixexec",
 ]
 targets = [
     "x86_64-unknown-linux-gnu",

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["os::unix-apis"]
 readme = "README.md"
 
 [features]
-default = ["async-io", "blocking-api", "proxy", "service", "unixexec"]
+default = ["async-io", "blocking-api", "proxy", "service", "unixexec", "ibus"]
 
 # Wire-format optional impls — the former zvariant features, same names.
 arrayvec = ["dep:arrayvec"]
@@ -73,6 +73,9 @@ service = ["comms", "zbus_macros/service"]
 # The `unixexec:` transport, which runs a command and talks D-Bus over its standard I/O
 # (default).
 unixexec = ["comms"]
+# The `ibus:` transport, which asks the IBus daemon for its bus address by running `ibus address`
+# (default).
+ibus = ["comms"]
 # Enables API that is only needed for peer-to-peer (p2p) connections.
 p2p = ["comms", "uuid?/v4"]
 # Enables API that is only needed for bus implementations (enables `p2p`).
@@ -197,6 +200,7 @@ features = [
     "p2p",
     "tokio",
     "unixexec",
+    "ibus",
 ]
 targets = [
     "x86_64-unknown-linux-gnu",

--- a/zbus/README.md
+++ b/zbus/README.md
@@ -28,8 +28,8 @@ That build compiles `zbus::wire` and `zbus::names` and nothing else — no conne
 object server. The optional wire-format features keep zvariant's names (`arrayvec`, `camino`,
 `chrono`, `enumflags2`, `heapless`, `option-as-array`, `serde_bytes`, `time`, `url`, `uuid`),
 and enabling any D-Bus feature (`comms`, `async-io`, `tokio`, `blocking-api`, `p2p`,
-`bus-impl`, `vsock`, `tokio-vsock`, `proxy`, `service`, `unixexec`) brings the D-Bus API
-back.
+`bus-impl`, `vsock`, `tokio-vsock`, `proxy`, `service`, `unixexec`, `ibus`) brings the D-Bus
+API back.
 
 ## Example code
 

--- a/zbus/README.md
+++ b/zbus/README.md
@@ -28,7 +28,8 @@ That build compiles `zbus::wire` and `zbus::names` and nothing else — no conne
 object server. The optional wire-format features keep zvariant's names (`arrayvec`, `camino`,
 `chrono`, `enumflags2`, `heapless`, `option-as-array`, `serde_bytes`, `time`, `url`, `uuid`),
 and enabling any D-Bus feature (`comms`, `async-io`, `tokio`, `blocking-api`, `p2p`,
-`bus-impl`, `vsock`, `tokio-vsock`, `proxy`, `service`) brings the D-Bus API back.
+`bus-impl`, `vsock`, `tokio-vsock`, `proxy`, `service`, `unixexec`) brings the D-Bus API
+back.
 
 ## Example code
 

--- a/zbus/src/abstractions/mod.rs
+++ b/zbus/src/abstractions/mod.rs
@@ -61,8 +61,8 @@ pub(crate) mod async_lock;
 pub use async_drop::*;
 pub(crate) mod timeout;
 
-// Not unix-specific itself but only used on unix.
-#[cfg(target_family = "unix")]
+// Only the `unixexec` and `ibus` transports and, on macOS, the `launchd` one run commands.
+#[cfg(all(unix, any(feature = "unixexec", feature = "ibus", target_os = "macos")))]
 pub(crate) mod process;
 
 #[cfg(all(test, feature = "tokio", feature = "async-io"))]

--- a/zbus/src/abstractions/process.rs
+++ b/zbus/src/abstractions/process.rs
@@ -2,7 +2,7 @@
 use crate::address::transport::Unixexec;
 #[cfg(all(feature = "async-io", feature = "unixexec"))]
 use async_process::{Child, unix::CommandExt};
-#[cfg(unix)]
+#[cfg(any(feature = "ibus", target_os = "macos"))]
 use std::process::Output;
 #[cfg(feature = "unixexec")]
 use std::process::Stdio;
@@ -71,7 +71,7 @@ impl Command {
 
     /// Executes the command as a child process, waiting for it to finish and
     /// collecting all of its output.
-    #[cfg(unix)]
+    #[cfg(any(feature = "ibus", target_os = "macos"))]
     pub async fn output(&mut self) -> Result<Output, Error> {
         self.0.output().await
     }
@@ -105,7 +105,7 @@ impl Command {
 }
 
 /// An asynchronous wrapper around running and getting command output
-#[cfg(unix)]
+#[cfg(any(feature = "ibus", target_os = "macos"))]
 pub async fn run<I, S>(program: S, args: I) -> Result<Output, Error>
 where
     I: IntoIterator<Item = S>,

--- a/zbus/src/abstractions/process.rs
+++ b/zbus/src/abstractions/process.rs
@@ -1,12 +1,14 @@
-#[cfg(feature = "async-io")]
+#[cfg(feature = "unixexec")]
+use crate::address::transport::Unixexec;
+#[cfg(all(feature = "async-io", feature = "unixexec"))]
 use async_process::{Child, unix::CommandExt};
 #[cfg(unix)]
 use std::process::Output;
-use std::{ffi::OsStr, io::Error, process::Stdio};
-#[cfg(all(feature = "tokio", not(feature = "async-io")))]
+#[cfg(feature = "unixexec")]
+use std::process::Stdio;
+use std::{ffi::OsStr, io::Error};
+#[cfg(all(feature = "tokio", not(feature = "async-io"), feature = "unixexec"))]
 use tokio::process::Child;
-
-use crate::address::transport::Unixexec;
 
 /// A wrapper around the command API of the underlying async runtime.
 ///
@@ -32,6 +34,7 @@ impl Command {
     }
 
     /// Constructs a new `Command` from a `unixexec` address.
+    #[cfg(feature = "unixexec")]
     pub fn for_unixexec(unixexec: &Unixexec) -> Self {
         let mut command = Self::new(unixexec.path());
         command.args(unixexec.args());
@@ -47,6 +50,7 @@ impl Command {
     ///
     /// Set the first process argument, `argv[0]`, to something other than the
     /// default executable path.
+    #[cfg(feature = "unixexec")]
     pub fn arg0<S>(&mut self, arg: S) -> &mut Self
     where
         S: AsRef<OsStr>,
@@ -73,24 +77,28 @@ impl Command {
     }
 
     /// Sets configuration for the child process's standard input (stdin) handle.
+    #[cfg(feature = "unixexec")]
     pub fn stdin<T: Into<Stdio>>(&mut self, cfg: T) -> &mut Self {
         self.0.stdin(cfg);
         self
     }
 
     /// Sets configuration for the child process's standard output (stdout) handle.
+    #[cfg(feature = "unixexec")]
     pub fn stdout<T: Into<Stdio>>(&mut self, cfg: T) -> &mut Self {
         self.0.stdout(cfg);
         self
     }
 
     /// Sets configuration for the child process's standard error (stderr) handle.
+    #[cfg(feature = "unixexec")]
     pub fn stderr<T: Into<Stdio>>(&mut self, cfg: T) -> &mut Self {
         self.0.stderr(cfg);
         self
     }
 
     /// Executes the command as a child process, returning a handle to it.
+    #[cfg(feature = "unixexec")]
     pub fn spawn(&mut self) -> Result<Child, Error> {
         self.0.spawn()
     }

--- a/zbus/src/address/mod.rs
+++ b/zbus/src/address/mod.rs
@@ -299,7 +299,7 @@ mod tests {
             Address::from_str("launchd:env=my_cool_env_key").unwrap(),
             Transport::Launchd(Launchd::new("my_cool_env_key")).into(),
         );
-        #[cfg(unix)]
+        #[cfg(all(unix, feature = "ibus"))]
         assert_eq!(
             Address::from_str("ibus:").unwrap(),
             Transport::Ibus(crate::address::transport::Ibus::new()).into(),
@@ -402,7 +402,7 @@ mod tests {
             Address::from(Transport::Launchd(Launchd::new("my_cool_key"))).to_string(),
             "launchd:env=my_cool_key"
         );
-        #[cfg(unix)]
+        #[cfg(all(unix, feature = "ibus"))]
         assert_eq!(
             Address::from(Transport::Ibus(crate::address::transport::Ibus::new())).to_string(),
             "ibus:"

--- a/zbus/src/address/mod.rs
+++ b/zbus/src/address/mod.rs
@@ -197,7 +197,7 @@ mod tests {
     };
     #[cfg(target_os = "macos")]
     use crate::address::transport::Launchd;
-    #[cfg(unix)]
+    #[cfg(all(unix, feature = "unixexec"))]
     use crate::address::transport::Unixexec;
     #[cfg(windows)]
     use crate::address::transport::{Autolaunch, AutolaunchScope};
@@ -240,7 +240,7 @@ mod tests {
                 .unwrap(),
             );
         }
-        #[cfg(unix)]
+        #[cfg(all(unix, feature = "unixexec"))]
         assert_eq!(
             Address::from_str("unixexec:path=/tmp/dbus-foo").unwrap(),
             Transport::Unixexec(Unixexec::new("/tmp/dbus-foo".into(), None, Vec::new())).into(),

--- a/zbus/src/address/transport/mod.rs
+++ b/zbus/src/address/transport/mod.rs
@@ -34,9 +34,9 @@ pub use autolaunch::{Autolaunch, AutolaunchScope};
 mod launchd;
 #[cfg(target_os = "macos")]
 pub use launchd::Launchd;
-#[cfg(unix)]
+#[cfg(all(unix, feature = "ibus"))]
 mod ibus;
-#[cfg(unix)]
+#[cfg(all(unix, feature = "ibus"))]
 pub use ibus::Ibus;
 #[cfg(any(feature = "vsock", feature = "tokio-vsock"))]
 #[path = "vsock.rs"]
@@ -65,7 +65,7 @@ pub enum Transport {
     ///
     /// IBus (Intelligent Input Bus) is an input method framework. This transport queries the
     /// IBus daemon for its D-Bus address using the `ibus address` command.
-    #[cfg(unix)]
+    #[cfg(all(unix, feature = "ibus"))]
     Ibus(Ibus),
     #[cfg(any(feature = "vsock", feature = "tokio-vsock"))]
     /// A VSOCK address.
@@ -222,7 +222,7 @@ impl Transport {
                 transport.connect(address).await
             }
 
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "ibus"))]
             Transport::Ibus(ibus) => {
                 let addr = ibus.bus_address().await?;
                 addr.connect().await
@@ -244,7 +244,7 @@ impl Transport {
             "autolaunch" => Autolaunch::from_options(options).map(Self::Autolaunch),
             #[cfg(target_os = "macos")]
             "launchd" => Launchd::from_options(options).map(Self::Launchd),
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "ibus"))]
             "ibus" => Ibus::from_options(options).map(Self::Ibus),
 
             _ => Err(Error::Address(format!(
@@ -400,7 +400,7 @@ impl Display for Transport {
             Self::Autolaunch(autolaunch) => write!(f, "{autolaunch}")?,
             #[cfg(target_os = "macos")]
             Self::Launchd(launchd) => write!(f, "{launchd}")?,
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "ibus"))]
             Self::Ibus(ibus) => write!(f, "{ibus}")?,
         }
 

--- a/zbus/src/address/transport/mod.rs
+++ b/zbus/src/address/transport/mod.rs
@@ -12,9 +12,9 @@ use std::os::unix::net::{SocketAddr, UnixStream};
 use std::{collections::HashMap, sync::Arc};
 #[cfg(windows)]
 use uds_windows::UnixStream;
-#[cfg(unix)]
+#[cfg(all(unix, feature = "unixexec"))]
 mod unixexec;
-#[cfg(unix)]
+#[cfg(all(unix, feature = "unixexec"))]
 pub use unixexec::Unixexec;
 
 use std::{
@@ -75,7 +75,7 @@ pub enum Transport {
     /// `tokio_vsock::VsockStream` with the `tokio-vsock` feature.
     Vsock(Vsock),
     /// A `unixexec` address.
-    #[cfg(unix)]
+    #[cfg(all(unix, feature = "unixexec"))]
     Unixexec(Unixexec),
 }
 
@@ -135,7 +135,7 @@ impl Transport {
                     Err(Error::Unsupported)
                 }
             }
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "unixexec"))]
             Transport::Unixexec(unixexec) => unixexec
                 .connect(&address)
                 .await
@@ -234,7 +234,7 @@ impl Transport {
     pub(super) fn from_options(transport: &str, options: HashMap<&str, &str>) -> Result<Self> {
         match transport {
             "unix" => Unix::from_options(options).map(Self::Unix),
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "unixexec"))]
             "unixexec" => Unixexec::from_options(options).map(Self::Unixexec),
             "tcp" => Tcp::from_options(options, false).map(Self::Tcp),
             "nonce-tcp" => Tcp::from_options(options, true).map(Self::Tcp),
@@ -258,7 +258,7 @@ impl Transport {
 pub(crate) enum Stream {
     #[cfg(any(unix, feature = "async-io"))]
     Unix(BoxedSplit),
-    #[cfg(unix)]
+    #[cfg(all(unix, feature = "unixexec"))]
     Unixexec(BoxedSplit),
     Tcp(BoxedSplit),
     #[cfg(any(feature = "vsock", feature = "tokio-vsock"))]
@@ -392,7 +392,7 @@ impl Display for Transport {
         match self {
             Self::Tcp(tcp) => write!(f, "{tcp}")?,
             Self::Unix(unix) => write!(f, "{unix}")?,
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "unixexec"))]
             Self::Unixexec(unixexec) => write!(f, "{unixexec}")?,
             #[cfg(any(feature = "vsock", feature = "tokio-vsock"))]
             Self::Vsock(vsock) => write!(f, "{}", vsock)?,

--- a/zbus/src/blocking/connection/builder.rs
+++ b/zbus/src/blocking/connection/builder.rs
@@ -59,7 +59,7 @@ impl<'a> Builder<'a> {
     /// // Use the connection to interact with IBus services.
     /// # Ok::<_, Box<dyn Error + Send + Sync>>(())
     /// ```
-    #[cfg(unix)]
+    #[cfg(all(unix, feature = "ibus"))]
     pub fn ibus() -> Result<Self> {
         crate::connection::Builder::ibus().map(Self)
     }

--- a/zbus/src/blocking/proxy/builder.rs
+++ b/zbus/src/blocking/proxy/builder.rs
@@ -59,7 +59,7 @@ impl<'a, T> Builder<'a, T> {
     /// Panics if the builder is lacking the necessary details to build a proxy.
     pub fn build(self) -> Result<T>
     where
-        T: From<crate::Proxy<'a>>,
+        T: From<crate::Proxy<'a>> + crate::proxy::Defaults,
     {
         block_on(self.0.build())
     }

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -763,7 +763,7 @@ impl<'a> Builder<'a> {
                 match address.connect().await? {
                     #[cfg(any(unix, feature = "async-io"))]
                     address::transport::Stream::Unix(split) => split,
-                    #[cfg(unix)]
+                    #[cfg(all(unix, feature = "unixexec"))]
                     address::transport::Stream::Unixexec(split) => split,
                     address::transport::Stream::Tcp(split) => split,
                     #[cfg(any(feature = "vsock", feature = "tokio-vsock"))]

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -149,7 +149,7 @@ impl<'a> Builder<'a> {
     /// #
     /// # Ok::<_, Box<dyn Error + Send + Sync>>(())
     /// ```
-    #[cfg(unix)]
+    #[cfg(all(unix, feature = "ibus"))]
     pub fn ibus() -> Result<Self> {
         use crate::address::transport::{Ibus, Transport};
         Ok(Self::new(Target::Address(Address::from(Transport::Ibus(
@@ -186,7 +186,7 @@ impl<'a> Builder<'a> {
     ///
     /// **Note:** The IBus address is different for each session. You can find the address for your
     /// current session using `ibus address` command. For a more convenient way to connect to IBus,
-    /// see [`Builder::ibus`].
+    /// see `Builder::ibus`, available with the `ibus` feature.
     ///
     /// [D-Bus bus address]: https://dbus.freedesktop.org/doc/dbus-specification.html#addresses
     pub fn address<A>(address: A) -> Result<Self>

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -422,16 +422,39 @@ impl Connection {
     {
         let _permit = acquire_serial_num_semaphore().await;
 
-        let mut b = Message::signal(path, interface, signal_name)?;
-        if let Some(sender) = self.unique_name() {
-            b = b.sender(sender)?;
-        }
-        if let Some(destination) = destination {
-            b = b.destination(destination)?;
-        }
-        let m = b.build(body)?;
+        let destination = destination
+            .map(TryInto::try_into)
+            .transpose()
+            .map_err(Into::into)?;
+        let path = path.try_into().map_err(Into::into)?;
+        let interface = interface.try_into().map_err(Into::into)?;
+        let signal_name = signal_name.try_into().map_err(Into::into)?;
+        let m = self
+            .signal_builder(destination, path, interface, signal_name)?
+            .build(body)?;
 
         self.send(&m).await
+    }
+
+    /// The builder for a signal message from this connection.
+    ///
+    /// Kept non-generic so that it is compiled once; see [`Self::method_call_builder`].
+    fn signal_builder<'b>(
+        &'b self,
+        destination: Option<BusName<'b>>,
+        path: ObjectPath<'b>,
+        interface: InterfaceName<'b>,
+        signal_name: MemberName<'b>,
+    ) -> Result<message::Builder<'b>> {
+        let mut builder = Message::signal(path, interface, signal_name)?;
+        if let Some(sender) = self.unique_name() {
+            builder = builder.sender(sender)?;
+        }
+        if let Some(destination) = destination {
+            builder = builder.destination(destination)?;
+        }
+
+        Ok(builder)
     }
 
     /// Reply to a message.

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -4,7 +4,6 @@ use enumflags2::BitFlags;
 use event_listener::{Event, EventListener};
 use std::{
     collections::HashMap,
-    future::Future,
     io,
     sync::{
         Arc, OnceLock, Weak,
@@ -17,7 +16,6 @@ use tracing::{Instrument, info_span, trace, trace_span, warn};
 use tracing::{debug, instrument};
 
 use futures_lite::StreamExt;
-use ordered_stream::OrderedFuture;
 
 #[cfg(feature = "service")]
 use crate::ObjectServer;
@@ -41,7 +39,7 @@ mod socket_reader;
 use socket_reader::{SocketReader, SocketStatus};
 
 mod pending_method_calls;
-use pending_method_calls::PendingMethodCalls;
+use pending_method_calls::{PendingMethodCall, PendingMethodCalls};
 
 pub(crate) mod handshake;
 pub use handshake::AuthMechanism;
@@ -321,12 +319,7 @@ impl Connection {
         method_name: M,
         flags: BitFlags<Flags>,
         body: &B,
-    ) -> Result<
-        Option<
-            impl Future<Output = Result<Message>>
-            + OrderedFuture<Output = Result<Message>, Ordering = crate::message::Sequence>,
-        >,
-    >
+    ) -> Result<Option<PendingMethodCall>>
     where
         D: TryInto<BusName<'d>>,
         P: TryInto<ObjectPath<'p>>,
@@ -340,6 +333,35 @@ impl Connection {
     {
         let _permit = acquire_serial_num_semaphore().await;
 
+        let destination = destination
+            .map(TryInto::try_into)
+            .transpose()
+            .map_err(Into::into)?;
+        let path = path.try_into().map_err(Into::into)?;
+        let interface = interface
+            .map(TryInto::try_into)
+            .transpose()
+            .map_err(Into::into)?;
+        let method_name = method_name.try_into().map_err(Into::into)?;
+        let msg = self
+            .method_call_builder(destination, path, interface, method_name, flags)?
+            .build(body)?;
+
+        self.send_method_call(msg, flags).await
+    }
+
+    /// The builder for a method call message from this connection.
+    ///
+    /// The generic entry points convert their arguments and serialize the body; everything else
+    /// about sending a method call lives here and in [`Self::send_method_call`], compiled once.
+    fn method_call_builder<'b>(
+        &'b self,
+        destination: Option<BusName<'b>>,
+        path: ObjectPath<'b>,
+        interface: Option<InterfaceName<'b>>,
+        method_name: MemberName<'b>,
+        flags: BitFlags<Flags>,
+    ) -> Result<message::Builder<'b>> {
         let mut builder = Message::method_call(path, method_name)?;
         if let Some(sender) = self.unique_name() {
             builder = builder.sender(sender)?
@@ -353,8 +375,16 @@ impl Connection {
         for flag in flags {
             builder = builder.with_flags(flag)?;
         }
-        let msg = builder.build(body)?;
 
+        Ok(builder)
+    }
+
+    /// Send a method call message and register for its reply, unless none is expected.
+    async fn send_method_call(
+        &self,
+        msg: Message,
+        flags: BitFlags<Flags>,
+    ) -> Result<Option<PendingMethodCall>> {
         let serial = msg.primary_header().serial_num();
         if flags.contains(Flags::NoReplyExpected) {
             self.send(&msg).await?;

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     async_lock::{Mutex, Semaphore, SemaphorePermit},
     fdo::{ConnectionCredentials, ReleaseNameReply, RequestNameFlags, RequestNameReply},
     is_flatpak,
-    message::{Flags, Message, Type},
+    message::{self, Flags, Message, Type},
     names::{BusName, ErrorName, InterfaceName, MemberName, OwnedUniqueName, WellKnownName},
     timeout::timeout,
 };
@@ -414,11 +414,7 @@ impl Connection {
     {
         let _permit = acquire_serial_num_semaphore().await;
 
-        let mut b = Message::method_return(call)?;
-        if let Some(sender) = self.unique_name() {
-            b = b.sender(sender)?;
-        }
-        let m = b.build(body)?;
+        let m = self.reply_message(Message::method_return(call), &mut |b| b.build(body))?;
         self.send(&m).await
     }
 
@@ -439,12 +435,24 @@ impl Connection {
     {
         let _permit = acquire_serial_num_semaphore().await;
 
-        let mut b = Message::error(call, error_name)?;
-        if let Some(sender) = self.unique_name() {
-            b = b.sender(sender)?;
-        }
-        let m = b.build(body)?;
+        let m = self.reply_message(Message::error(call, error_name), &mut |b| b.build(body))?;
         self.send(&m).await
+    }
+
+    /// Build a reply from `builder`, with this connection's unique name as the sender.
+    ///
+    /// The body is written through a trait object so that this is compiled once rather than once
+    /// per body type.
+    fn reply_message(
+        &self,
+        builder: Result<message::Builder<'_>>,
+        build: &mut dyn FnMut(message::Builder<'_>) -> Result<Message>,
+    ) -> Result<Message> {
+        let mut builder = builder?;
+        if let Some(sender) = self.unique_name() {
+            builder = builder.sender(sender)?;
+        }
+        build(builder)
     }
 
     /// Reply an error to a message.

--- a/zbus/src/connection/pending_method_calls.rs
+++ b/zbus/src/connection/pending_method_calls.rs
@@ -20,11 +20,7 @@ pub struct PendingMethodCalls {
 }
 
 impl PendingMethodCalls {
-    pub fn register_call(
-        &self,
-        serial: NonZeroU32,
-    ) -> impl Future<Output = Result<Message>>
-    + OrderedFuture<Output = Result<Message>, Ordering = Sequence> {
+    pub fn register_call(&self, serial: NonZeroU32) -> PendingMethodCall {
         use std::collections::hash_map::Entry;
 
         let (reply_sender, reply_receiver) = broadcast(1);
@@ -103,7 +99,7 @@ impl Default for PendingMethodCalls {
 /// stream can be used to ensure that cache updates are not overwritten by a cache population whose
 /// task is scheduled later.
 #[derive(Debug)]
-struct PendingMethodCall {
+pub struct PendingMethodCall {
     serial: NonZeroU32,
     reply_receiver: Receiver<PendingMethodReply>,
     pending_method_calls: PendingMethodCalls,

--- a/zbus/src/connection/socket/mod.rs
+++ b/zbus/src/connection/socket/mod.rs
@@ -6,9 +6,9 @@ pub use channel::Channel;
 mod split;
 pub use split::{BoxedSplit, Split};
 
-#[cfg(unix)]
+#[cfg(all(unix, feature = "unixexec"))]
 pub(crate) mod command;
-#[cfg(unix)]
+#[cfg(all(unix, feature = "unixexec"))]
 pub(crate) use command::Command;
 mod tcp;
 mod unix;

--- a/zbus/src/error.rs
+++ b/zbus/src/error.rs
@@ -244,6 +244,16 @@ impl fmt::Display for Error {
 }
 
 impl Error {
+    /// A [`SignatureMismatch`](Error::SignatureMismatch) for `signature` where `expected` was
+    /// needed.
+    ///
+    /// The (de)serializers hit this from generic code. Building the error here keeps that error
+    /// path out of every instantiation.
+    #[cold]
+    pub(crate) fn signature_mismatch(signature: &Signature, expected: &str) -> Self {
+        Self::SignatureMismatch(signature.clone(), expected.to_string())
+    }
+
     /// A description of the error.
     ///
     /// This is a generic description of the error (if any). For a more detailed description

--- a/zbus/src/fdo/mod.rs
+++ b/zbus/src/fdo/mod.rs
@@ -25,7 +25,7 @@ pub use monitoring::MonitoringProxy;
 
 pub(crate) mod object_manager;
 pub use object_manager::ManagedObjects;
-#[cfg(feature = "service")]
+#[cfg(feature = "object-manager")]
 pub use object_manager::ObjectManager;
 #[cfg(feature = "proxy")]
 pub use object_manager::{
@@ -153,12 +153,14 @@ mod tests {
             });
     }
 
+    #[cfg(feature = "object-manager")]
     #[test]
     #[timeout(15000)]
     fn no_object_manager_signals_before_hello() {
         crate::block_on(no_object_manager_signals_before_hello_async());
     }
 
+    #[cfg(feature = "object-manager")]
     async fn no_object_manager_signals_before_hello_async() {
         // We were emitting `InterfacesAdded` signals before `Hello` was called, which is wrong and
         // results in us getting disconnected by the bus. This test case ensures we don't do that

--- a/zbus/src/fdo/object_manager.rs
+++ b/zbus/src/fdo/object_manager.rs
@@ -3,17 +3,17 @@
 //! The D-Bus specification defines the message bus messages and some standard interfaces that may
 //! be useful across various D-Bus applications. This module provides their proxy.
 
-#[cfg(any(feature = "proxy", feature = "service"))]
+#[cfg(any(feature = "proxy", feature = "object-manager"))]
 use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap};
 
-#[cfg(feature = "service")]
+#[cfg(feature = "object-manager")]
 use super::Error;
-#[cfg(any(feature = "proxy", feature = "service"))]
+#[cfg(any(feature = "proxy", feature = "object-manager"))]
 use super::Result;
-#[cfg(feature = "service")]
+#[cfg(feature = "object-manager")]
 use crate::{Connection, ObjectServer, interface, message::Header, object_server::SignalEmitter};
-#[cfg(any(feature = "proxy", feature = "service"))]
+#[cfg(any(feature = "proxy", feature = "object-manager"))]
 use crate::{ObjectPath, Value, names::InterfaceName};
 use crate::{OwnedObjectPath, OwnedValue, names::OwnedInterfaceName};
 
@@ -89,11 +89,11 @@ pub type ManagedObjects =
 /// ```
 ///
 /// [om]: https://dbus.freedesktop.org/doc/dbus-specification.html#standard-interfaces-objectmanager
-#[cfg(feature = "service")]
+#[cfg(feature = "object-manager")]
 #[derive(Debug, Clone)]
 pub struct ObjectManager;
 
-#[cfg(feature = "service")]
+#[cfg(feature = "object-manager")]
 #[interface(
     name = "org.freedesktop.DBus.ObjectManager",
     introspection_docs = false

--- a/zbus/src/message/builder.rs
+++ b/zbus/src/message/builder.rs
@@ -1,11 +1,6 @@
 #[cfg(unix)]
 use crate::OwnedFd;
-use std::{
-    borrow::Cow,
-    io::{Cursor, Write},
-    num::NonZeroU32,
-    sync::Arc,
-};
+use std::{borrow::Cow, io::Cursor, num::NonZeroU32, sync::Arc};
 
 use enumflags2::BitFlags;
 
@@ -238,21 +233,20 @@ impl<'a> Builder<'a> {
             }
         }
 
-        let hdr_len = *crate::wire::serialized_size(ctxt, &header)?;
+        let mut bytes = Vec::new();
+        let mut cursor = Cursor::new(&mut bytes);
+        // SAFETY: There are no FDs involved.
+        unsafe { crate::wire::to_writer(&mut cursor, ctxt, &header) }?;
+        let hdr_len = bytes.len();
         // We need to align the body to 8-byte boundary.
-        let body_padding = padding_for_8_bytes(hdr_len);
-        let body_offset = hdr_len + body_padding;
+        let body_offset = hdr_len + padding_for_8_bytes(hdr_len);
         let total_len = body_offset + body.len();
         if total_len > MAX_MESSAGE_SIZE {
             return Err(Error::ExcessData);
         }
-        let mut bytes: Vec<u8> = Vec::with_capacity(total_len);
-        let mut cursor = Cursor::new(&mut bytes);
-
-        // SAFETY: There are no FDs involved.
-        unsafe { crate::wire::to_writer(&mut cursor, ctxt, &header) }?;
-        cursor.write_all(&[0u8; 8][..body_padding])?;
-        cursor.write_all(body)?;
+        bytes.reserve_exact(total_len - hdr_len);
+        bytes.resize(body_offset, 0);
+        bytes.extend_from_slice(body);
 
         let primary_header = header.into_primary();
         #[cfg(unix)]

--- a/zbus/src/message/builder.rs
+++ b/zbus/src/message/builder.rs
@@ -19,12 +19,6 @@ use crate::{
 
 use crate::message::header::MAX_MESSAGE_SIZE;
 
-#[cfg(unix)]
-type BuildGenericResult = Vec<OwnedFd>;
-
-#[cfg(not(unix))]
-type BuildGenericResult = ();
-
 macro_rules! dbus_context {
     ($self:ident, $n_bytes_before: expr) => {
         Context::new($self.header.primary().endian_sig().into(), $n_bytes_before)
@@ -171,26 +165,28 @@ impl<'a> Builder<'a> {
         B: serde::ser::Serialize + DynamicType,
     {
         let ctxt = dbus_context!(self, 0);
-
-        // Note: this iterates the body twice, but we prefer efficient handling of large messages
-        // to efficient handling of ones that are complex to serialize.
-        let body_size = crate::wire::serialized_size(ctxt, body)?;
-
         let signature = body.signature();
 
-        self.build_generic(signature, body_size, &mut move |cursor| {
-            // SAFETY: build_generic puts FDs and the body in the same Message.
-            unsafe { crate::wire::to_writer(cursor, ctxt, body) }.map(|s| {
-                #[cfg(unix)]
-                {
-                    s.into_fds()
-                }
-                #[cfg(not(unix))]
-                {
-                    let _ = s;
-                }
-            })
-        })
+        // The header carries the body's length and FD count, so the body is serialized first,
+        // into its own buffer, and copied into place behind the header. One pass over the body
+        // plus a copy of its bytes beats the extra serialization pass that measuring it first
+        // would cost, and keeps this generic function down to the serialization itself.
+        let mut body_bytes = Vec::new();
+        let mut cursor = Cursor::new(&mut body_bytes);
+        // SAFETY: The FDs end up in the same Message as the body.
+        let written =
+            unsafe { crate::wire::to_writer_for_signature(&mut cursor, ctxt, &signature, body) }?;
+        #[cfg(unix)]
+        let fds = written.into_fds();
+        #[cfg(not(unix))]
+        let _ = written;
+
+        self.build_from_bytes(
+            signature,
+            &body_bytes,
+            #[cfg(unix)]
+            fds,
+        )
     }
 
     /// Create a new message from a raw slice of bytes to populate the body with, rather than by
@@ -210,47 +206,33 @@ impl<'a> Builder<'a> {
         S::Error: Into<Error>,
     {
         let signature = signature.try_into().map_err(Into::into)?;
-        let body_size = serialized::Size::new(body_bytes.len(), dbus_context!(self, 0));
-        #[cfg(unix)]
-        let body_size = {
-            let num_fds = fds.len().try_into().map_err(|_| Error::ExcessData)?;
-            body_size.set_num_fds(num_fds)
-        };
 
-        #[cfg(unix)]
-        let mut fds = Some(fds);
-        let mut write_body = move |cursor: &mut Cursor<&mut Vec<u8>>| {
-            cursor.write_all(body_bytes)?;
-
+        self.build_from_bytes(
+            signature,
+            body_bytes,
             #[cfg(unix)]
-            return Ok::<Vec<OwnedFd>, Error>(fds.take().unwrap_or_default());
-
-            #[cfg(not(unix))]
-            return Ok::<(), Error>(());
-        };
-
-        self.build_generic(signature, body_size, &mut write_body)
+            fds,
+        )
     }
 
-    /// The body writer is a trait object so that this function is compiled once rather than once
-    /// per body type.
-    fn build_generic(
+    /// Build the message around an already serialized body.
+    fn build_from_bytes(
         self,
         signature: Signature,
-        body_size: serialized::Size,
-        write_body: &mut dyn FnMut(&mut Cursor<&mut Vec<u8>>) -> Result<BuildGenericResult>,
+        body: &[u8],
+        #[cfg(unix)] fds: Vec<OwnedFd>,
     ) -> Result<Message> {
         let ctxt = dbus_context!(self, 0);
         let mut header = self.header;
 
         header.fields_mut().signature = Cow::Owned(signature);
 
-        let body_len_u32 = body_size.size().try_into().map_err(|_| Error::ExcessData)?;
+        let body_len_u32 = body.len().try_into().map_err(|_| Error::ExcessData)?;
         header.primary_mut().set_body_len(body_len_u32);
 
         #[cfg(unix)]
         {
-            let fds_len = body_size.num_fds();
+            let fds_len: u32 = fds.len().try_into().map_err(|_| Error::ExcessData)?;
             if fds_len != 0 {
                 header.fields_mut().unix_fds = Some(fds_len);
             }
@@ -260,7 +242,7 @@ impl<'a> Builder<'a> {
         // We need to align the body to 8-byte boundary.
         let body_padding = padding_for_8_bytes(hdr_len);
         let body_offset = hdr_len + body_padding;
-        let total_len = body_offset + body_size.size();
+        let total_len = body_offset + body.len();
         if total_len > MAX_MESSAGE_SIZE {
             return Err(Error::ExcessData);
         }
@@ -270,10 +252,7 @@ impl<'a> Builder<'a> {
         // SAFETY: There are no FDs involved.
         unsafe { crate::wire::to_writer(&mut cursor, ctxt, &header) }?;
         cursor.write_all(&[0u8; 8][..body_padding])?;
-        #[cfg(unix)]
-        let fds: Vec<_> = write_body(&mut cursor)?.into_iter().collect();
-        #[cfg(not(unix))]
-        write_body(&mut cursor)?;
+        cursor.write_all(body)?;
 
         let primary_header = header.into_primary();
         #[cfg(unix)]

--- a/zbus/src/message/builder.rs
+++ b/zbus/src/message/builder.rs
@@ -178,7 +178,7 @@ impl<'a> Builder<'a> {
 
         let signature = body.signature();
 
-        self.build_generic(signature, body_size, move |cursor| {
+        self.build_generic(signature, body_size, &mut move |cursor| {
             // SAFETY: build_generic puts FDs and the body in the same Message.
             unsafe { crate::wire::to_writer(cursor, ctxt, body) }.map(|s| {
                 #[cfg(unix)]
@@ -217,30 +217,29 @@ impl<'a> Builder<'a> {
             body_size.set_num_fds(num_fds)
         };
 
-        self.build_generic(
-            signature,
-            body_size,
-            move |cursor: &mut Cursor<&mut Vec<u8>>| {
-                cursor.write_all(body_bytes)?;
+        #[cfg(unix)]
+        let mut fds = Some(fds);
+        let mut write_body = move |cursor: &mut Cursor<&mut Vec<u8>>| {
+            cursor.write_all(body_bytes)?;
 
-                #[cfg(unix)]
-                return Ok::<Vec<OwnedFd>, Error>(fds);
+            #[cfg(unix)]
+            return Ok::<Vec<OwnedFd>, Error>(fds.take().unwrap_or_default());
 
-                #[cfg(not(unix))]
-                return Ok::<(), Error>(());
-            },
-        )
+            #[cfg(not(unix))]
+            return Ok::<(), Error>(());
+        };
+
+        self.build_generic(signature, body_size, &mut write_body)
     }
 
-    fn build_generic<WriteFunc>(
+    /// The body writer is a trait object so that this function is compiled once rather than once
+    /// per body type.
+    fn build_generic(
         self,
         signature: Signature,
         body_size: serialized::Size,
-        write_body: WriteFunc,
-    ) -> Result<Message>
-    where
-        WriteFunc: FnOnce(&mut Cursor<&mut Vec<u8>>) -> Result<BuildGenericResult>,
-    {
+        write_body: &mut dyn FnMut(&mut Cursor<&mut Vec<u8>>) -> Result<BuildGenericResult>,
+    ) -> Result<Message> {
         let ctxt = dbus_context!(self, 0);
         let mut header = self.header;
 

--- a/zbus/src/object_server/interface/dispatch_result.rs
+++ b/zbus/src/object_server/interface/dispatch_result.rs
@@ -2,7 +2,7 @@ use std::{future::Future, pin::Pin};
 
 use zbus::message::Flags;
 
-use crate::{Connection, DynamicType, fdo, message::Message};
+use crate::{Connection, DynamicType, Error, fdo, message::Message};
 use tracing::trace;
 
 /// A helper type returned by [`Interface`](`crate::object_server::Interface`) callbacks.
@@ -47,5 +47,29 @@ impl<'a> DispatchResult2<'a> {
                 Ok(())
             }
         }))
+    }
+
+    /// Wrap the future of a generated method handler as the `Async` variant.
+    ///
+    /// The `#[interface]` macro emits a call to this for every method so that the error conversion
+    /// is compiled once rather than inlined into each handler.
+    #[doc(hidden)]
+    pub fn from_handler<F>(f: F) -> Self
+    where
+        F: Future<Output = crate::Result<()>> + Send + 'a,
+    {
+        DispatchResult2::Async(Box::pin(async move { f.await.map_err(handler_error) }))
+    }
+}
+
+/// The D-Bus error a method handler's failure is reported as.
+///
+/// A [`DBusError`](crate::DBusError) is passed through unchanged. Anything else becomes
+/// `org.freedesktop.DBus.Error.Failed` with the error's text as its description.
+#[cold]
+fn handler_error(e: Error) -> fdo::Error {
+    match e {
+        Error::FDO(e) => *e,
+        e => fdo::Error::Failed(e.to_string()),
     }
 }

--- a/zbus/src/object_server/interface/mod.rs
+++ b/zbus/src/object_server/interface/mod.rs
@@ -23,6 +23,22 @@ use crate::{
     object_server::SignalEmitter,
 };
 
+/// Write `lines` as an XML comment at the given indentation level.
+///
+/// This is what the `#[interface]` macro uses to write doc comments in the introspection data.
+#[doc(hidden)]
+pub fn introspect_doc_comment(writer: &mut dyn Write, level: usize, lines: &str) {
+    writeln!(writer, "{:indent$}<!--", "", indent = level).unwrap();
+    for line in lines.split('\n') {
+        if line.is_empty() {
+            writeln!(writer).unwrap();
+        } else {
+            writeln!(writer, "{:indent$}{line}", "", indent = level).unwrap();
+        }
+    }
+    writeln!(writer, "{:indent$} -->", "", indent = level).unwrap();
+}
+
 /// This trait is used to dispatch messages to an interface instance.
 ///
 /// This trait should be treated as an unstable API and compatibility may break in minor

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -1,17 +1,20 @@
 //! The object server API.
 
-use std::{collections::HashMap, marker::PhantomData, sync::Arc};
+#[cfg(feature = "object-manager")]
+use std::collections::HashMap;
+use std::{marker::PhantomData, sync::Arc};
 use tracing::{Instrument, debug, instrument, trace, trace_span};
 
 use crate::{
-    Connection, Error, ObjectPath, Result, Value,
+    Connection, Error, ObjectPath, Result,
     async_lock::RwLock,
     connection::WeakConnection,
     fdo,
-    fdo::ObjectManager,
     message::{Header, Message},
     names::InterfaceName,
 };
+#[cfg(feature = "object-manager")]
+use crate::{Value, fdo::ObjectManager};
 
 mod interface;
 pub(crate) use interface::ArcInterface;
@@ -119,7 +122,7 @@ impl ObjectServer {
     ///
     /// It is fine to call this method from within an interface method (e.g. to register a child or
     /// sibling object on demand), including from a `&mut self` method. There is however one
-    /// exception: registering an [`ObjectManager`] at an ancestor of the currently-executing
+    /// exception: registering an `fdo::ObjectManager` at an ancestor of the currently-executing
     /// interface from within one of its `&mut self` methods will **deadlock**.
     ///
     /// This is because adding an `ObjectManager` reads the properties of every object under it (to
@@ -158,37 +161,8 @@ impl ObjectServer {
             root.remove_node(&path);
             return Ok(false);
         }
-        if name == ObjectManager::name() {
-            // Just added an object manager. Need to signal all managed objects under it.
-            let emitter = SignalEmitter::new(&self.connection(), path)?;
-            let objects = node.get_managed_objects(self, &self.connection()).await?;
-            for (path, owned_interfaces) in objects {
-                let interfaces = owned_interfaces
-                    .iter()
-                    .map(|(i, props)| {
-                        let props = props
-                            .iter()
-                            .map(|(k, v)| Ok((k.as_str(), Value::try_from(v)?)))
-                            .collect::<Result<_>>();
-                        Ok((i.into(), props?))
-                    })
-                    .collect::<Result<_>>()?;
-                ObjectManager::interfaces_added(&emitter, path.into(), interfaces).await?;
-            }
-        } else if let Some(manager_path) = manager_path {
-            let emitter = SignalEmitter::new(&self.connection(), manager_path)?;
-            let mut interfaces = HashMap::new();
-            let owned_props = node
-                .get_properties(self, &self.connection(), name.clone())
-                .await?;
-            let props = owned_props
-                .iter()
-                .map(|(k, v)| Ok((k.as_str(), Value::try_from(v)?)))
-                .collect::<Result<_>>()?;
-            interfaces.insert(name, props);
-
-            ObjectManager::interfaces_added(&emitter, path, interfaces).await?;
-        }
+        self.interfaces_added(node, name, path, manager_path)
+            .await?;
 
         Ok(true)
     }
@@ -234,12 +208,96 @@ impl ObjectServer {
         // Prune before emitting the (fallible) signal, so that an emission failure can't leave
         // empty nodes behind.
         let destroyed = root.remove_node(&path);
+        self.interfaces_removed(path, interface_name, manager_path)
+            .await?;
+
+        Ok(destroyed)
+    }
+
+    /// Emit `InterfacesAdded` for the interface `name` just registered at `path`.
+    ///
+    /// When the interface is itself an `ObjectManager`, every object under `path` is announced
+    /// instead. Otherwise the signal goes out from `manager_path`, the closest ancestor serving an
+    /// `ObjectManager`, if there is one.
+    #[cfg(feature = "object-manager")]
+    async fn interfaces_added(
+        &self,
+        node: &Node,
+        name: InterfaceName<'static>,
+        path: ObjectPath<'_>,
+        manager_path: Option<ObjectPath<'_>>,
+    ) -> Result<()> {
+        if name == ObjectManager::name() {
+            // Just added an object manager. Need to signal all managed objects under it.
+            let emitter = SignalEmitter::new(&self.connection(), path)?;
+            let objects = node.get_managed_objects(self, &self.connection()).await?;
+            for (path, owned_interfaces) in objects {
+                let interfaces = owned_interfaces
+                    .iter()
+                    .map(|(i, props)| {
+                        let props = props
+                            .iter()
+                            .map(|(k, v)| Ok((k.as_str(), Value::try_from(v)?)))
+                            .collect::<Result<_>>();
+                        Ok((i.into(), props?))
+                    })
+                    .collect::<Result<_>>()?;
+                ObjectManager::interfaces_added(&emitter, path.into(), interfaces).await?;
+            }
+        } else if let Some(manager_path) = manager_path {
+            let emitter = SignalEmitter::new(&self.connection(), manager_path)?;
+            let mut interfaces = HashMap::new();
+            let owned_props = node
+                .get_properties(self, &self.connection(), name.clone())
+                .await?;
+            let props = owned_props
+                .iter()
+                .map(|(k, v)| Ok((k.as_str(), Value::try_from(v)?)))
+                .collect::<Result<_>>()?;
+            interfaces.insert(name, props);
+
+            ObjectManager::interfaces_added(&emitter, path, interfaces).await?;
+        }
+
+        Ok(())
+    }
+
+    #[cfg(not(feature = "object-manager"))]
+    async fn interfaces_added(
+        &self,
+        _node: &Node,
+        _name: InterfaceName<'static>,
+        _path: ObjectPath<'_>,
+        _manager_path: Option<ObjectPath<'_>>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    /// Emit `InterfacesRemoved` for `interface_name`, unregistered from `path`, from
+    /// `manager_path`, the closest ancestor serving an `ObjectManager`, if there is one.
+    #[cfg(feature = "object-manager")]
+    async fn interfaces_removed(
+        &self,
+        path: ObjectPath<'_>,
+        interface_name: InterfaceName<'static>,
+        manager_path: Option<ObjectPath<'static>>,
+    ) -> Result<()> {
         if let Some(manager_path) = manager_path {
             let ctxt = SignalEmitter::new(&self.connection(), manager_path)?;
-            ObjectManager::interfaces_removed(&ctxt, path.clone(), (&[interface_name]).into())
-                .await?;
+            ObjectManager::interfaces_removed(&ctxt, path, (&[interface_name]).into()).await?;
         }
-        Ok(destroyed)
+
+        Ok(())
+    }
+
+    #[cfg(not(feature = "object-manager"))]
+    async fn interfaces_removed(
+        &self,
+        _path: ObjectPath<'_>,
+        _interface_name: InterfaceName<'static>,
+        _manager_path: Option<ObjectPath<'static>>,
+    ) -> Result<()> {
+        Ok(())
     }
 
     /// Get the interface at the given path.

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -15,6 +15,8 @@ use crate::{
 
 mod interface;
 pub(crate) use interface::ArcInterface;
+#[doc(hidden)]
+pub use interface::introspect_doc_comment;
 pub use interface::{DispatchResult2, Interface, InterfaceDeref, InterfaceDerefMut, InterfaceRef};
 
 mod signal_emitter;

--- a/zbus/src/object_server/node.rs
+++ b/zbus/src/object_server/node.rs
@@ -5,11 +5,16 @@ use std::{
     fmt::Write,
 };
 
+#[cfg(feature = "object-manager")]
 use crate::{
-    Connection, ObjectPath, ObjectServer, OwnedObjectPath, OwnedValue,
-    fdo::{self, Introspectable, ManagedObjects, ObjectManager, Peer, Properties},
-    names::InterfaceName,
+    Connection, ObjectServer, OwnedValue,
+    fdo::{self, ManagedObjects, ObjectManager},
     object_server::SignalEmitter,
+};
+use crate::{
+    ObjectPath, OwnedObjectPath,
+    fdo::{Introspectable, Peer, Properties},
+    names::InterfaceName,
 };
 
 use super::{ArcInterface, Interface};
@@ -67,7 +72,7 @@ impl Node {
                 continue;
             }
 
-            if node.interfaces.contains_key(&ObjectManager::name()) {
+            if node.serves_object_manager() {
                 obj_manager_path = Some((*node.path).clone());
             }
 
@@ -255,6 +260,18 @@ impl Node {
         xml
     }
 
+    /// Whether an `ObjectManager` is registered at this node.
+    #[cfg(feature = "object-manager")]
+    fn serves_object_manager(&self) -> bool {
+        self.interfaces.contains_key(&ObjectManager::name())
+    }
+
+    #[cfg(not(feature = "object-manager"))]
+    fn serves_object_manager(&self) -> bool {
+        false
+    }
+
+    #[cfg(feature = "object-manager")]
     pub(crate) async fn get_managed_objects(
         &self,
         object_server: &ObjectServer,
@@ -284,6 +301,7 @@ impl Node {
         Ok(managed_objects)
     }
 
+    #[cfg(feature = "object-manager")]
     pub(super) async fn get_properties(
         &self,
         object_server: &ObjectServer,

--- a/zbus/src/proxy/builder.rs
+++ b/zbus/src/proxy/builder.rs
@@ -124,9 +124,11 @@ impl<'a, T> Builder<'a, T> {
     /// [`Error::MissingParameter`] is returned.
     pub async fn build(self) -> Result<T>
     where
-        T: From<Proxy<'a>>,
+        T: From<Proxy<'a>> + super::Defaults,
     {
-        let cache_upfront = self.cache == CacheProperties::Yes;
+        // The constant lets the whole properties cache be dropped from a program whose proxies
+        // have no properties.
+        let cache_upfront = T::HAS_PROPERTIES && self.cache == CacheProperties::Yes;
         let proxy = self.build_internal()?;
 
         if cache_upfront {

--- a/zbus/src/proxy/defaults.rs
+++ b/zbus/src/proxy/defaults.rs
@@ -11,6 +11,13 @@ pub trait Defaults {
     const INTERFACE: &'static Option<InterfaceName<'static>>;
     const DESTINATION: &'static Option<BusName<'static>>;
     const PATH: &'static Option<ObjectPath<'static>>;
+    /// Whether the interface has any properties.
+    ///
+    /// A proxy for an interface without properties never sets up a properties cache, so a build
+    /// with [`CacheProperties::Yes`](super::CacheProperties::Yes) has nothing to populate. The
+    /// `#[proxy]` macro sets this from the trait; a hand-written implementation can leave the
+    /// default.
+    const HAS_PROPERTIES: bool = true;
 }
 
 impl Defaults for super::Proxy<'_> {

--- a/zbus/src/wire/array.rs
+++ b/zbus/src/wire/array.rs
@@ -53,9 +53,9 @@ impl<'a> Array<'a> {
     pub fn append<'e: 'a>(&mut self, element: Value<'e>) -> Result<()> {
         match &self.signature {
             Signature::Array(child) if element.value_signature() != child.signature() => {
-                return Err(Error::SignatureMismatch(
-                    element.value_signature().clone(),
-                    child.signature().clone().to_string(),
+                return Err(Error::signature_mismatch(
+                    element.value_signature(),
+                    &child.signature().to_string(),
                 ));
             }
             Signature::Array(_) => (),
@@ -230,9 +230,9 @@ impl<'a> DynamicDeserialize<'a> for Array<'a> {
 
     fn deserializer_for_signature(signature: &Signature) -> crate::Result<Self::Deserializer> {
         if !matches!(signature, Signature::Array(_)) {
-            return Err(crate::Error::SignatureMismatch(
-                signature.clone(),
-                "an array signature".to_owned(),
+            return Err(crate::Error::signature_mismatch(
+                signature,
+                "an array signature",
             ));
         };
 

--- a/zbus/src/wire/as_value/property.rs
+++ b/zbus/src/wire/as_value/property.rs
@@ -45,9 +45,9 @@ impl<'de, 'sig> ValueDeserializer<'de, 'sig> {
         {
             Ok(value)
         } else {
-            Err(crate::Error::SignatureMismatch(
-                value.value_signature().clone(),
-                self.expected.to_string(),
+            Err(crate::Error::signature_mismatch(
+                value.value_signature(),
+                &self.expected.to_string(),
             ))
         }
     }
@@ -71,10 +71,7 @@ impl<'de, 'sig> ValueDeserializer<'de, 'sig> {
     }
 
     fn mismatch(&self, expected: &'static str) -> crate::Error {
-        crate::Error::SignatureMismatch(
-            self.actual().value_signature().clone(),
-            expected.to_owned(),
-        )
+        crate::Error::signature_mismatch(self.actual().value_signature(), expected)
     }
 
     fn bytes(&self) -> crate::Result<Vec<u8>> {
@@ -669,9 +666,9 @@ impl<'de> ValueEnumAccess<'de> {
 
     fn structure(value: &'de [Value<'de>], expected: &Signature) -> crate::Result<Self> {
         let Signature::Structure(signatures) = expected else {
-            return Err(crate::Error::SignatureMismatch(
-                expected.clone(),
-                "an enum structure".to_owned(),
+            return Err(crate::Error::signature_mismatch(
+                expected,
+                "an enum structure",
             ));
         };
         let Some(discriminant) = value.first() else {

--- a/zbus/src/wire/as_value/value_serializer.rs
+++ b/zbus/src/wire/as_value/value_serializer.rs
@@ -51,7 +51,7 @@ impl ValueSerializer {
     }
 
     fn mismatch(&self, expected: &str) -> crate::Error {
-        crate::Error::SignatureMismatch(self.signature.clone(), expected.to_owned())
+        crate::Error::signature_mismatch(&self.signature, expected)
     }
 
     fn expect(&self, signature: Signature) -> crate::Result<()> {
@@ -456,9 +456,9 @@ impl StructSerializer {
                 unreachable!()
             };
             let Some(signature) = fields.get(*inner_idx) else {
-                return Err(crate::Error::SignatureMismatch(
-                    inner_signature.clone(),
-                    "an enum variant with the expected number of fields".to_owned(),
+                return Err(crate::Error::signature_mismatch(
+                    inner_signature,
+                    "an enum variant with the expected number of fields",
                 ));
             };
             *inner_idx += 1;
@@ -471,9 +471,9 @@ impl StructSerializer {
             return Err(crate::Error::Unsupported);
         };
         let Some(signature) = fields.get(self.field_idx) else {
-            return Err(crate::Error::SignatureMismatch(
-                self.expected.clone(),
-                "a struct with the expected number of fields".to_owned(),
+            return Err(crate::Error::signature_mismatch(
+                &self.expected,
+                "a struct with the expected number of fields",
             ));
         };
         self.field_idx += 1;
@@ -488,9 +488,9 @@ impl StructSerializer {
                 unreachable!()
             };
             if inner_idx != fields.len() {
-                return Err(crate::Error::SignatureMismatch(
-                    inner_signature,
-                    "an enum variant with the expected number of fields".to_owned(),
+                return Err(crate::Error::signature_mismatch(
+                    &inner_signature,
+                    "an enum variant with the expected number of fields",
                 ));
             }
             let mut builder = Structure::builder();
@@ -512,9 +512,9 @@ impl StructSerializer {
 
         if let Signature::Structure(fields) = &self.expected {
             if self.fields.len() != fields.len() {
-                return Err(crate::Error::SignatureMismatch(
-                    self.expected,
-                    "a struct with the expected number of fields".to_owned(),
+                return Err(crate::Error::signature_mismatch(
+                    &self.expected,
+                    "a struct with the expected number of fields",
                 ));
             }
         }
@@ -581,9 +581,9 @@ impl VariantSerializer {
             ));
         };
         if value.value_signature() != &signature {
-            return Err(crate::Error::SignatureMismatch(
-                value.value_signature().clone(),
-                format!("`{signature}`"),
+            return Err(crate::Error::signature_mismatch(
+                value.value_signature(),
+                &format!("`{signature}`"),
             ));
         }
         Ok(Value::Value(Box::new(value)))

--- a/zbus/src/wire/dbus/de.rs
+++ b/zbus/src/wire/dbus/de.rs
@@ -226,7 +226,7 @@ impl<'de, #[cfg(unix)] F: AsFd, #[cfg(not(unix))] F> de::Deserializer<'de>
                     ObjectPath::SIGNATURE_STR,
                     VARIANT_SIGNATURE_CHAR,
                 );
-                return Err(Error::SignatureMismatch(self.0.signature.clone(), expected));
+                return Err(Error::signature_mismatch(self.0.signature, &expected));
             }
         };
         let slice = self.0.next_slice(len)?;
@@ -325,9 +325,9 @@ impl<'de, #[cfg(unix)] F: AsFd, #[cfg(not(unix))] F> de::Deserializer<'de>
                     num_fields: 0,
                 })
             }
-            _ => Err(Error::SignatureMismatch(
-                self.0.signature.clone(),
-                "a variant, array, dict, structure or u8".to_string(),
+            _ => Err(Error::signature_mismatch(
+                self.0.signature,
+                "a variant, array, dict, structure or u8",
             )),
         }
     }
@@ -363,26 +363,26 @@ impl<'de, #[cfg(unix)] F: AsFd, #[cfg(not(unix))] F> de::Deserializer<'de>
             Signature::Structure(fields) => {
                 let mut fields = fields.iter();
                 let index_signature = fields.next().ok_or_else(|| {
-                    Error::SignatureMismatch(
-                        self.0.signature.clone(),
-                        "a structure with 2 fields and u32 as its first field".to_string(),
+                    Error::signature_mismatch(
+                        self.0.signature,
+                        "a structure with 2 fields and u32 as its first field",
                     )
                 })?;
                 self.0.signature = index_signature;
                 let v = self.deserialize_u32(visitor);
 
                 self.0.signature = fields.next().ok_or_else(|| {
-                    Error::SignatureMismatch(
-                        self.0.signature.clone(),
-                        "a structure with 2 fields and u32 as its first field".to_string(),
+                    Error::signature_mismatch(
+                        self.0.signature,
+                        "a structure with 2 fields and u32 as its first field",
                     )
                 })?;
 
                 v
             }
-            _ => Err(Error::SignatureMismatch(
-                self.0.signature.clone(),
-                "a string, object path or signature".to_string(),
+            _ => Err(Error::signature_mismatch(
+                self.0.signature,
+                "a string, object path or signature",
             )),
         }
     }
@@ -416,9 +416,9 @@ impl<'d, 'de, 'sig, 'f, #[cfg(unix)] F: AsFd, #[cfg(not(unix))] F>
             Signature::Array(child) => (child.alignment_dbus(), child.signature()),
             Signature::Dict { key, .. } => (DICT_ENTRY_ALIGNMENT_DBUS, key.signature()),
             _ => {
-                return Err(Error::SignatureMismatch(
-                    de.0.signature.clone(),
-                    "an array or dict".to_string(),
+                return Err(Error::signature_mismatch(
+                    de.0.signature,
+                    "an array or dict",
                 ));
             }
         };
@@ -523,10 +523,7 @@ impl<'d, 'de, 'sig, 'f, #[cfg(unix)] F: AsFd, #[cfg(not(unix))] F>
         let (key_signature, value_signature) = match de.0.signature {
             Signature::Dict { key, value } => (key.signature(), value.signature()),
             _ => {
-                return Err(Error::SignatureMismatch(
-                    de.0.signature.clone(),
-                    "a dict".to_string(),
-                ));
+                return Err(Error::signature_mismatch(de.0.signature, "a dict"));
             }
         };
         let ad = ArrayDeserializer::new(de)?;
@@ -607,9 +604,9 @@ impl<'de, #[cfg(unix)] F: AsFd, #[cfg(not(unix))] F> SeqAccess<'de>
         let signature = self.de.0.signature;
         let field_signature = match signature {
             Signature::Structure(fields) => {
-                let signature = fields.get(self.field_idx).ok_or_else(|| {
-                    Error::SignatureMismatch(signature.clone(), "a struct".to_string())
-                })?;
+                let signature = fields
+                    .get(self.field_idx)
+                    .ok_or_else(|| Error::signature_mismatch(signature, "a struct"))?;
                 self.field_idx += 1;
 
                 signature

--- a/zbus/src/wire/dbus/ser.rs
+++ b/zbus/src/wire/dbus/ser.rs
@@ -153,7 +153,7 @@ where
                     ObjectPath::SIGNATURE_STR,
                     VARIANT_SIGNATURE_CHAR,
                 );
-                return Err(Error::SignatureMismatch(signature.clone(), expected));
+                return Err(Error::signature_mismatch(signature, &expected));
             }
         }
 
@@ -266,9 +266,9 @@ where
             Signature::Array(child) => (child.alignment_dbus(), child.signature()),
             Signature::Dict { key, .. } => (DICT_ENTRY_ALIGNMENT_DBUS, key.signature()),
             _ => {
-                return Err(Error::SignatureMismatch(
-                    self.0.signature.clone(),
-                    "an array or dict".to_string(),
+                return Err(Error::signature_mismatch(
+                    self.0.signature,
+                    "an array or dict",
                 ));
             }
         };
@@ -317,10 +317,7 @@ where
         let (key_signature, value_signature) = match self.0.signature {
             Signature::Dict { key, value } => (key.signature(), value.signature()),
             _ => {
-                return Err(Error::SignatureMismatch(
-                    self.0.signature.clone(),
-                    "a dict".to_string(),
-                ));
+                return Err(Error::signature_mismatch(self.0.signature, "a dict"));
             }
         };
 
@@ -343,9 +340,9 @@ where
                 StructSerializer::structure(self).map(StructSeqSerializer::Struct)
             }
             Signature::Dict { .. } => self.serialize_map(Some(len)).map(StructSeqSerializer::Map),
-            _ => Err(Error::SignatureMismatch(
-                self.0.signature.clone(),
-                "a struct, array, u8 or variant".to_string(),
+            _ => Err(Error::signature_mismatch(
+                self.0.signature,
+                "a struct, array, u8 or variant",
             )),
         }
     }
@@ -475,10 +472,7 @@ where
     fn enum_variant(ser: &'b mut Serializer<'ser, W>, variant_index: u32) -> Result<Self> {
         // Encode enum variants as a struct with first field as variant index
         let Signature::Structure(fields) = ser.0.signature else {
-            return Err(Error::SignatureMismatch(
-                ser.0.signature.clone(),
-                "a struct".to_string(),
-            ));
+            return Err(Error::signature_mismatch(ser.0.signature, "a struct"));
         };
         let struct_field = fields
             .get(1)
@@ -514,9 +508,9 @@ where
                 }
             }
             Signature::Structure(fields) => {
-                let signature = fields.get(self.field_idx).ok_or_else(|| {
-                    Error::SignatureMismatch(signature.clone(), "a struct".to_string())
-                })?;
+                let signature = fields
+                    .get(self.field_idx)
+                    .ok_or_else(|| Error::signature_mismatch(signature, "a struct"))?;
                 self.field_idx += 1;
 
                 signature

--- a/zbus/src/wire/de.rs
+++ b/zbus/src/wire/de.rs
@@ -215,9 +215,9 @@ where
         // explicitly here without breaking the common case where it doesn't exist at all.
         // Fall back to a wildcard instead.
         #[allow(unreachable_patterns)]
-        _ => Err(Error::SignatureMismatch(
-            signature.clone(),
-            "GVariant `Maybe` support has moved to the `zgvariant` crate".to_string(),
+        _ => Err(Error::signature_mismatch(
+            signature,
+            "GVariant `Maybe` support has moved to the `zgvariant` crate",
         )),
     }
 }

--- a/zbus/src/wire/dict.rs
+++ b/zbus/src/wire/dict.rs
@@ -52,17 +52,17 @@ impl<'k, 'v> Dict<'k, 'v> {
             Signature::Dict { key: key_sig, .. }
                 if key.value_signature() != key_sig.signature() =>
             {
-                return Err(Error::SignatureMismatch(
-                    key.value_signature().clone(),
-                    key_sig.signature().clone().to_string(),
+                return Err(Error::signature_mismatch(
+                    key.value_signature(),
+                    &key_sig.signature().to_string(),
                 ));
             }
             Signature::Dict {
                 value: value_sig, ..
             } if value.value_signature() != value_sig.signature() => {
-                return Err(Error::SignatureMismatch(
-                    value.value_signature().clone(),
-                    value_sig.signature().clone().to_string(),
+                return Err(Error::signature_mismatch(
+                    value.value_signature(),
+                    &value_sig.signature().to_string(),
                 ));
             }
             Signature::Dict { .. } => (),

--- a/zbus/src/wire/type/dynamic.rs
+++ b/zbus/src/wire/type/dynamic.rs
@@ -54,9 +54,9 @@ where
                     // deserialized as a single-field struct. No need to be super strict here.
                 }
                 _ => {
-                    return Err(crate::Error::SignatureMismatch(
-                        signature.clone(),
-                        format!("`{expected}`"),
+                    return Err(crate::Error::signature_mismatch(
+                        signature,
+                        &format!("`{expected}`"),
                     ));
                 }
             }

--- a/zbus/tests/basic.rs
+++ b/zbus/tests/basic.rs
@@ -365,7 +365,7 @@ async fn test_freedesktop_credentials() -> Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, feature = "ibus"))]
 #[tokio::test]
 #[timeout(15000)]
 async fn ibus_connection() {
@@ -425,7 +425,7 @@ async fn ibus_connection() {
     result.unwrap();
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, feature = "ibus"))]
 async fn test_ibus_connection() -> Result<()> {
     let connection = zbus::connection::Builder::ibus()?.build().await?;
 

--- a/zbus/tests/e2e.rs
+++ b/zbus/tests/e2e.rs
@@ -13,7 +13,9 @@ use ntest::timeout;
 use test_log::test;
 use tokio::sync::mpsc::channel;
 use tracing::{debug, instrument};
-use zbus::{block_on, connection, fdo::ObjectManager, object_server::InterfaceRef};
+#[cfg(feature = "object-manager")]
+use zbus::fdo::ObjectManager;
+use zbus::{block_on, connection, object_server::InterfaceRef};
 
 use iface_and_proxy::{
     client::my_iface_test,
@@ -134,7 +136,9 @@ async fn iface_and_proxy_(#[allow(unused)] p2p: bool) {
     let iface = MyIface::new(next_tx.clone());
     let service_conn_builder = service_conn_builder
         .serve_at("/org/freedesktop/MyService", iface)
-        .unwrap()
+        .unwrap();
+    #[cfg(feature = "object-manager")]
+    let service_conn_builder = service_conn_builder
         .serve_at("/zbus/test", ObjectManager)
         .unwrap();
     debug!("ObjectServer set-up.");

--- a/zbus/tests/iface_and_proxy/client.rs
+++ b/zbus/tests/iface_and_proxy/client.rs
@@ -2,10 +2,10 @@ use event_listener::Event;
 use futures_util::{StreamExt, TryStreamExt};
 use std::convert::TryInto;
 use tracing::{debug, instrument};
+#[cfg(feature = "object-manager")]
+use zbus::fdo::ObjectManagerProxy;
 use zbus::{
-    Connection, DBusError, Error, Message, MessageStream, Value,
-    fdo::{ObjectManagerProxy, PropertiesProxy},
-    message,
+    Connection, DBusError, Error, Message, MessageStream, Value, fdo::PropertiesProxy, message,
     proxy::CacheProperties,
 };
 
@@ -268,28 +268,36 @@ pub async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> 
 
     let val = proxy.ping().await?;
 
+    #[cfg(feature = "object-manager")]
     let obj_manager_proxy = ObjectManagerProxy::builder(&conn)
         .destination("org.freedesktop.MyService")?
         .path("/zbus/test")?
         .build()
         .await?;
-    debug!("Created: {:?}", obj_manager_proxy);
-    let mut ifaces_added_stream = obj_manager_proxy.receive_interfaces_added().await?;
-    debug!("Created: {:?}", ifaces_added_stream);
+    #[cfg(feature = "object-manager")]
+    let ifaces_added = {
+        debug!("Created: {:?}", obj_manager_proxy);
+        let mut ifaces_added_stream = obj_manager_proxy.receive_interfaces_added().await?;
+        debug!("Created: {:?}", ifaces_added_stream);
 
-    // Must process in parallel, so the stream listener does not block receiving
-    // the method return message.
-    let (ifaces_added, _) = futures_util::future::join(
-        async {
-            let ret = ifaces_added_stream.next().await.unwrap();
-            drop(ifaces_added_stream);
-            ret
-        },
-        async {
-            proxy.create_obj("MyObj").await.unwrap();
-        },
-    )
-    .await;
+        // Must process in parallel, so the stream listener does not block receiving
+        // the method return message.
+        let (ifaces_added, _) = futures_util::future::join(
+            async {
+                let ret = ifaces_added_stream.next().await.unwrap();
+                drop(ifaces_added_stream);
+                ret
+            },
+            async {
+                proxy.create_obj("MyObj").await.unwrap();
+            },
+        )
+        .await;
+
+        ifaces_added
+    };
+    #[cfg(not(feature = "object-manager"))]
+    proxy.create_obj("MyObj").await.unwrap();
 
     #[cfg(feature = "option-as-array")]
     {
@@ -300,11 +308,14 @@ pub async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> 
         );
     }
 
-    assert_eq!(ifaces_added.args()?.object_path(), "/zbus/test/MyObj");
-    let args = ifaces_added.args()?;
-    let ifaces = args.interfaces_and_properties();
-    let _ = ifaces.get("org.freedesktop.MyIface").unwrap();
-    // TODO: Check if the properties are correct.
+    #[cfg(feature = "object-manager")]
+    {
+        assert_eq!(ifaces_added.args()?.object_path(), "/zbus/test/MyObj");
+        let args = ifaces_added.args()?;
+        let ifaces = args.interfaces_and_properties();
+        let _ = ifaces.get("org.freedesktop.MyIface").unwrap();
+        // TODO: Check if the properties are correct.
+    }
 
     // issue#207: interface panics on incorrect number of args.
     assert!(proxy.inner().call_method("CreateObj", &()).await.is_err());
@@ -337,25 +348,30 @@ pub async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> 
         assert_eq!(test_case, value);
     }
 
-    let mut ifaces_removed_stream = obj_manager_proxy.receive_interfaces_removed().await?;
-    debug!("Created: {:?}", ifaces_removed_stream);
-    // Must process in parallel, so the stream listener does not block receiving
-    // the method return message.
-    let (ifaces_removed, _) = futures_util::future::join(
-        async {
-            let ret = ifaces_removed_stream.next().await.unwrap();
-            drop(ifaces_removed_stream);
-            ret
-        },
-        async {
-            proxy.destroy_obj("MyObj").await.unwrap();
-        },
-    )
-    .await;
+    #[cfg(feature = "object-manager")]
+    {
+        let mut ifaces_removed_stream = obj_manager_proxy.receive_interfaces_removed().await?;
+        debug!("Created: {:?}", ifaces_removed_stream);
+        // Must process in parallel, so the stream listener does not block receiving
+        // the method return message.
+        let (ifaces_removed, _) = futures_util::future::join(
+            async {
+                let ret = ifaces_removed_stream.next().await.unwrap();
+                drop(ifaces_removed_stream);
+                ret
+            },
+            async {
+                proxy.destroy_obj("MyObj").await.unwrap();
+            },
+        )
+        .await;
 
-    let args = ifaces_removed.args()?;
-    assert_eq!(args.object_path(), "/zbus/test/MyObj");
-    assert_eq!(args.interfaces().as_ref(), &["org.freedesktop.MyIface"]);
+        let args = ifaces_removed.args()?;
+        assert_eq!(args.object_path(), "/zbus/test/MyObj");
+        assert_eq!(args.interfaces().as_ref(), &["org.freedesktop.MyIface"]);
+    }
+    #[cfg(not(feature = "object-manager"))]
+    proxy.destroy_obj("MyObj").await.unwrap();
 
     assert!(my_obj_proxy.inner().introspect().await.is_err());
     assert!(my_obj_proxy.ping().await.is_err());

--- a/zbus/tests/issue/issue_1478.rs
+++ b/zbus/tests/issue/issue_1478.rs
@@ -3,7 +3,7 @@ use zbus::{Error, connection};
 
 const UNIX_ADDRESS: &str = "unix:path=/this/path/does/not/exist";
 const TCP_ADDRESS: &str = "tcp:host=localhost,port=4142,family=ipv4";
-#[cfg(unix)]
+#[cfg(all(unix, feature = "unixexec"))]
 const UNIXEXEC_ADDRESS: &str = "unixexec:path=/this/path/does/not/exist";
 #[cfg(any(
     all(feature = "vsock", not(feature = "tokio")),
@@ -24,7 +24,7 @@ fn connection_error() {
 async fn connection_error_async() {
     #[allow(unused_mut)]
     let mut addresses = vec![UNIX_ADDRESS, TCP_ADDRESS];
-    #[cfg(unix)]
+    #[cfg(all(unix, feature = "unixexec"))]
     addresses.push(UNIXEXEC_ADDRESS);
     #[cfg(any(
         all(feature = "vsock", not(feature = "tokio")),

--- a/zbus/tests/issue/mod.rs
+++ b/zbus/tests/issue/mod.rs
@@ -11,7 +11,7 @@ mod issue_122;
 mod issue_1478;
 #[cfg(all(feature = "proxy", feature = "service"))]
 mod issue_173;
-#[cfg(all(feature = "proxy", feature = "service"))]
+#[cfg(all(feature = "proxy", feature = "object-manager"))]
 mod issue_1916;
 #[cfg(feature = "proxy")]
 mod issue_260;

--- a/zbus/tests/unixexec.rs
+++ b/zbus/tests/unixexec.rs
@@ -1,5 +1,4 @@
-#![cfg(feature = "comms")]
-#![cfg(not(target_os = "windows"))]
+#![cfg(all(feature = "unixexec", not(target_os = "windows")))]
 
 use ntest::timeout;
 use test_log::test;

--- a/zbus/tests/wire/dbus_maybe_rejection.rs
+++ b/zbus/tests/wire/dbus_maybe_rejection.rs
@@ -85,6 +85,27 @@ fn dbus_deserialize_rejects_variant_carrying_maybe() {
     assert_maybe_rejected(res, "deserialize variant carrying maybe");
 }
 
+// The body signature in a message header is a `g` value in the header's fields array, so the
+// check must hold when a whole message is read. The message is a little-endian header with
+// nothing but a `mi` signature field and an empty body.
+#[cfg(feature = "comms")]
+#[test]
+fn dbus_message_rejects_header_signature_carrying_maybe() {
+    use zbus::message::Message;
+
+    if !maybe_supported() {
+        return;
+    }
+    let mut bytes = vec![b'l', 4, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0];
+    bytes.extend_from_slice(&[8, 0, 0, 0, 8, 1, b'g', 0, 2, b'm', b'i', 0]);
+    let data = Data::new(bytes, Context::new(LE, 0));
+
+    // SAFETY: the bytes are a well-formed header with no body; the point is that the reader
+    // rejects the signature rather than accepting it.
+    let res = unsafe { Message::from_bytes(data) };
+    assert_maybe_rejected(res, "read header carrying maybe body signature");
+}
+
 // The maybe type is unavailable when `zbus_utils/gvariant` is not in the graph: `m` does
 // not parse, so the hazard cannot arise and there is nothing to assert.
 fn maybe_supported() -> bool {

--- a/zbus_macros/src/error.rs
+++ b/zbus_macros/src/error.rs
@@ -146,23 +146,18 @@ pub fn expand_derive(input: DeriveInput) -> Result<TokenStream, Error> {
             quote! {
                 impl ::std::convert::From<#zbus::Error> for #name {
                     fn from(value: #zbus::Error) -> #name {
-                        match &value {
+                        let (name, desc) = match &value {
                             #zbus::Error::MethodError(name, desc, _) => {
-                                let desc = desc.as_deref();
-                                match name.as_str() {
-                                    #error_converts
-                                    _ => Self::#ident(value),
-                                }
+                                (name.as_ref(), desc.as_deref())
                             }
                             #zbus::Error::FDO(e) => {
                                 let e = ::std::convert::AsRef::as_ref(e);
-                                let name = #zbus::DBusError::name(e);
-                                let desc = #zbus::DBusError::description(e);
-                                match name.as_str() {
-                                    #error_converts
-                                    _ => Self::#ident(value),
-                                }
+                                (#zbus::DBusError::name(e), #zbus::DBusError::description(e))
                             }
+                            _ => return Self::#ident(value),
+                        };
+                        match name.as_str() {
+                            #error_converts
                             _ => Self::#ident(value),
                         }
                     }

--- a/zbus_macros/src/error.rs
+++ b/zbus_macros/src/error.rs
@@ -1,4 +1,4 @@
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, quote};
 use syn::{Data, DeriveInput, Error, Fields, Ident, Variant, spanned::Spanned};
 use zbus_utils::def_attrs;
@@ -37,6 +37,8 @@ pub fn expand_derive(input: DeriveInput) -> Result<TokenStream, Error> {
 
     let zbus = zbus_path(crate_path.as_ref());
     let mut replies = quote! {};
+    // Hygienic so that a variant field of the same name does not shadow it in the reply arms.
+    let builder = Ident::new("builder", Span::mixed_site());
     let mut error_names = quote! {};
     let mut error_descriptions = quote! {};
     let mut error_converts = quote! {};
@@ -137,7 +139,7 @@ pub fn expand_derive(input: DeriveInput) -> Result<TokenStream, Error> {
             error_converts.extend(e);
         }
 
-        let r = gen_reply_for_variant(&variant, error, &zbus)?;
+        let r = gen_reply_for_variant(&variant, error, &zbus, &builder)?;
         replies.extend(r);
     }
 
@@ -196,6 +198,7 @@ pub fn expand_derive(input: DeriveInput) -> Result<TokenStream, Error> {
 
             fn create_reply(&self, call: &#zbus::message::Header) -> #zbus::Result<#zbus::message::Message> {
                 let name = self.name();
+                let #builder = #zbus::message::Message::error(call, name)?;
                 match self {
                     #replies
                 }
@@ -214,11 +217,12 @@ fn gen_reply_for_variant(
     variant: &Variant,
     zbus_error_variant: bool,
     zbus: &TokenStream,
+    builder: &Ident,
 ) -> Result<TokenStream, Error> {
     let ident = &variant.ident;
     match &variant.fields {
         Fields::Unit => Ok(quote! {
-            Self::#ident => #zbus::message::Message::error(call, name)?.build(&()),
+            Self::#ident => #builder.build(&()),
         }),
         Fields::Unnamed(f) => {
             // Name the unnamed fields as the number of the field with an 'f' in front.
@@ -248,13 +252,13 @@ fn gen_reply_for_variant(
             };
 
             Ok(quote! {
-                Self::#ident(#(#in_fields),*) => #zbus::message::Message::error(call, name)?.build(&(#(#out_fields),*)),
+                Self::#ident(#(#in_fields),*) => #builder.build(&(#(#out_fields),*)),
             })
         }
         Fields::Named(f) => {
             let fields = f.named.iter().map(|v| v.ident.as_ref()).collect::<Vec<_>>();
             Ok(quote! {
-                Self::#ident { #(#fields),* } => #zbus::message::Message::error(call, name)?.build(&(#(#fields),*)),
+                Self::#ident { #(#fields),* } => #builder.build(&(#(#fields),*)),
             })
         }
     }

--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -172,7 +172,7 @@ impl MethodInfo {
                     }
                 })
                 .collect();
-            to_xml_docs(docs)
+            to_xml_docs(docs, zbus)
         } else {
             quote!()
         };
@@ -1420,9 +1420,11 @@ fn introspect_properties(
     Ok(())
 }
 
-pub fn to_xml_docs(lines: Vec<String>) -> TokenStream {
-    let mut docs = quote!();
-
+/// The code writing `lines` as an XML comment in the introspection data.
+///
+/// The lines are joined into one literal and written by a runtime helper, rather than a `writeln!`
+/// per line, to keep the generated code small.
+pub fn to_xml_docs(lines: Vec<String>, zbus: &TokenStream) -> TokenStream {
     let mut lines: Vec<&str> = lines
         .iter()
         .skip_while(|s| is_blank(s))
@@ -1434,22 +1436,12 @@ pub fn to_xml_docs(lines: Vec<String>) -> TokenStream {
     }
 
     if lines.is_empty() {
-        return docs;
+        return quote!();
     }
 
-    docs.extend(quote!(::std::writeln!(writer, "{:indent$}<!--", "", indent = level).unwrap();));
-    for line in lines {
-        if !line.is_empty() {
-            docs.extend(
-                quote!(::std::writeln!(writer, "{:indent$}{}", "", #line, indent = level).unwrap();),
-            );
-        } else {
-            docs.extend(quote!(::std::writeln!(writer, "").unwrap();));
-        }
-    }
-    docs.extend(quote!(::std::writeln!(writer, "{:indent$} -->", "", indent = level).unwrap();));
+    let lines = lines.join("\n");
 
-    docs
+    quote!(#zbus::object_server::introspect_doc_comment(writer, level, #lines);)
 }
 
 // Like ImplItemFn, but with a semicolon at the end instead of a body block

--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -775,12 +775,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                                 #reply
                             }
                         };
-                        #zbus::object_server::DispatchResult2::Async(::std::boxed::Box::pin(async move {
-                            future.await.map_err(|e| match e {
-                                #zbus::Error::FDO(e) => *e,
-                                e => #zbus::fdo::Error::Failed(::std::format!("{e}")),
-                            })
-                        }))
+                        #zbus::object_server::DispatchResult2::from_handler(future)
                     },
                 };
 

--- a/zbus_macros/src/proxy.rs
+++ b/zbus_macros/src/proxy.rs
@@ -402,6 +402,7 @@ pub fn create_proxy(
                 &Some(#zbus::names::InterfaceName::from_static_str_unchecked(#iface_name));
             const DESTINATION: &'static Option<#zbus::names::BusName<'static>> = #default_service;
             const PATH: &'static Option<#zbus::ObjectPath<'static>> = #default_path;
+            const HAS_PROPERTIES: bool = #has_properties;
         }
 
         #(#other_attrs)*

--- a/zbus_macros/tests/tests.rs
+++ b/zbus_macros/tests/tests.rs
@@ -123,6 +123,10 @@ fn test_derive_error() {
         LetItBe {
             desc: String,
         },
+        // A named field must not clash with the locals the generated `create_reply` binds.
+        Shadowing {
+            builder: String,
+        },
     }
 }
 


### PR DESCRIPTION
Follow-up to the busd size regression: busd built against zbus 6.0 came out larger than against 5.x. This PR shrinks every zbus program by moving generic, per-interface and per-method code out of line, by serializing the message header once, and by making three rarely-used pieces optional.

## Changes

**Less monomorphized code**

- Message bodies are written through a trait object and serialized in one pass, so the serializer is instantiated once instead of per body type.
- Replies, method-handler error conversion and signature-mismatch errors are built in non-generic helpers. `#[interface]` emits the `DBusError` conversion arms once per interface instead of once per method.
- The method call and signal paths on `Connection` stay non-generic. `#[proxy]` no longer instantiates the properties cache for proxies without properties (a behavior change, see below).
- Introspection doc comments go through a small helper instead of being formatted inline per member.

**The message header is serialized once**

The builder measured the header with a size-counting serializer before writing it, which is a second, complete instantiation of the header serializer. It now writes the header straight into the message buffer and takes the padding and body offset from its length. This alone is about 39 KB on every program, busd included.

A coexistence test also reads a whole message carrying a GVariant maybe body signature and checks it is refused.

**New cargo features (all on by default)**

- `unixexec` and `ibus`: the two exec-based transports.
- `object-manager` (implies `service`): the service-side `fdo::ObjectManager` and the object server's `InterfacesAdded`/`InterfacesRemoved` emission. `ObjectManagerProxy` stays with `proxy`.

The upgrade guide covers the features and the properties-cache change.

The D-Bus codec's hot paths are untouched. Two things were tried and dropped: sharing one `SeqAccess` between array, structure and variant visitors saved a further 3 to 4% but cost 5 to 25% on deserialization benchmarks; carrying header fields in a purpose-built type instead of `Value` saved 20 KB on programs that never use `Value` but cost 6 to 8 KB on everything that does, busd included.

## Results

`.text` bytes, fat LTO, `opt-level = "s"`, linux x86_64:

| program | before | after | change |
|---|---|---|---|
| bare connection | 845,396 | 806,200 | -4.6% |
| proxy, one method | 870,295 | 831,118 | -4.5% |
| service, one method | 1,007,039 | 924,982 | -8.1% |
| busd | 2,321,957 | 2,243,901 | -3.4% (9.8% below zbus main) |

## Verification

Every commit compiles on its own with all features and without default features. Under a session bus the all-features zbus suite passes, as does the suite with only `tokio,proxy,service,p2p`, and the coexistence tests pass wire-only and with the D-Bus API on. Clippy is clean on five feature combinations including `--all-targets`. Docs build warning-free with and without the new features. The wire and message deserialization benchmarks match main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jxv7KpDPUqYLEvX6Z8tPMX