### PR TITLE
♻️ zb: Make `tracing` an optional feature

### DIFF
--- a/book/src/upgrading-to-6.md
+++ b/book/src/upgrading-to-6.md
@@ -506,6 +506,22 @@ streams only need `proxy`, as before.
 
 [`fdo::ObjectManager`]: https://docs.rs/zbus/6/zbus/fdo/struct.ObjectManager.html
 
+### Logging through `tracing` is a feature
+
+zbus's log events and spans go through [`tracing`], which is now behind the `tracing`
+feature. It is a default feature, so a plain `zbus = "6"` dependency is unaffected. A
+`default-features = false` build that wants zbus's logs has to name it:
+
+```toml
+[dependencies]
+zbus = { version = "6", default-features = false, features = ["tokio", "proxy", "tracing"] }
+```
+
+With the feature off, zbus emits no log events or spans at all, and it no longer enables
+`tokio`'s own `tracing` feature either.
+
+[`tracing`]: https://docs.rs/tracing
+
 ### A proxy without properties has no properties cache
 
 `proxy::Defaults` has a new constant, `HAS_PROPERTIES`, which `#[proxy]` sets from the trait,

--- a/zbus/Cargo.toml
+++ b/zbus/Cargo.toml
@@ -21,6 +21,7 @@ default = [
     "object-manager",
     "unixexec",
     "ibus",
+    "tracing",
 ]
 
 # Wire-format optional impls — the former zvariant features, same names.
@@ -48,7 +49,6 @@ comms = [
     "dep:ordered-stream",
     "dep:event-listener",
     "dep:async-trait",
-    "dep:tracing",
     "dep:async-recursion",
     "dep:rustix",
     "dep:libc",
@@ -70,6 +70,9 @@ async-io = [
     "blocking",
 ]
 tokio = ["comms", "dep:tokio"]
+# Logging through `tracing` (default). With this off, zbus emits no log events or spans, and
+# `tokio`'s own `tracing` feature is not enabled either.
+tracing = ["dep:tracing", "tokio?/tracing"]
 vsock = ["dep:vsock", "async-io"]
 tokio-vsock = ["dep:tokio-vsock", "tokio"]
 # Enable blocking API (default).
@@ -137,7 +140,6 @@ tokio = { workspace = true, optional = true, features = [
     # on why we can't.
     "process",
     "sync",
-    "tracing",
 ] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -179,6 +181,7 @@ tokio = { workspace = true, features = [
     "time",
     "test-util",
 ] }
+tracing.workspace = true
 tracing-subscriber.workspace = true
 tempfile.workspace = true
 criterion.workspace = true
@@ -213,6 +216,7 @@ features = [
     "object-manager",
     "unixexec",
     "ibus",
+    "tracing",
 ]
 targets = [
     "x86_64-unknown-linux-gnu",

--- a/zbus/README.md
+++ b/zbus/README.md
@@ -31,6 +31,9 @@ and enabling any D-Bus feature (`comms`, `async-io`, `tokio`, `blocking-api`, `p
 `bus-impl`, `vsock`, `tokio-vsock`, `proxy`, `service`, `unixexec`, `ibus`) brings the D-Bus
 API back.
 
+zbus logs through [`tracing`], behind the default `tracing` feature; a `default-features =
+false` build that wants zbus's logs must re-enable it explicitly.
+
 ## Example code
 
 We'll create a simple D-Bus service and client to demonstrate the usage of zbus. Note that these
@@ -174,3 +177,4 @@ see [the corresponding tokio issue on GitHub][tctiog].
 [`tokio`]: https://crates.io/crates/tokio
 [`async-io`]: https://crates.io/crates/async-io
 [serde]: https://crates.io/crates/serde
+[`tracing`]: https://crates.io/crates/tracing

--- a/zbus/src/connection/handshake/client.rs
+++ b/zbus/src/connection/handshake/client.rs
@@ -1,7 +1,12 @@
 use async_trait::async_trait;
-use tracing::{instrument, trace, warn};
 
-use crate::{Message, conn::socket::ReadHalf, is_flatpak, names::OwnedUniqueName};
+use crate::{
+    Message,
+    conn::socket::ReadHalf,
+    is_flatpak,
+    log::{trace, warn},
+    names::OwnedUniqueName,
+};
 
 use super::{
     AuthMechanism, Authenticated, BoxedSplit, Command, Common, Error, Handshake, OwnedGuid, Result,
@@ -58,7 +63,7 @@ impl Client {
 
     // The dbus daemon on some platforms requires sending the zero byte as a
     // separate message with SCM_CREDS.
-    #[instrument(skip(self), level = "trace")]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), level = "trace"))]
     #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
     async fn send_zero_byte(&mut self) -> Result<()> {
         let write = self.common.socket_mut().write_mut();
@@ -82,7 +87,7 @@ impl Client {
     }
 
     /// Perform the authentication handshake with the server.
-    #[instrument(skip(self), level = "trace")]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), level = "trace"))]
     async fn authenticate(&mut self) -> Result<()> {
         let mechanism = self.common.mechanism();
         trace!("Trying {mechanism} mechanism");
@@ -114,7 +119,7 @@ impl Client {
     }
 
     /// Sends out all commands after authentication.
-    #[instrument(skip(self), level = "trace")]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), level = "trace"))]
     async fn send_secondary_commands(&mut self) -> Result<usize> {
         let mut commands = Vec::with_capacity(4);
 
@@ -153,7 +158,7 @@ impl Client {
         Ok(commands.len() - 1)
     }
 
-    #[instrument(skip(self), level = "trace")]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), level = "trace"))]
     async fn receive_secondary_responses(&mut self, expected_n_responses: usize) -> Result<()> {
         for response in self.common.read_commands(expected_n_responses).await? {
             match response {
@@ -177,7 +182,7 @@ impl Client {
 
 #[async_trait]
 impl Handshake for Client {
-    #[instrument(skip(self), level = "trace")]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), level = "trace"))]
     async fn perform(mut self) -> Result<Authenticated> {
         trace!("Initializing");
 

--- a/zbus/src/connection/handshake/common.rs
+++ b/zbus/src/connection/handshake/common.rs
@@ -1,7 +1,5 @@
-use tracing::{instrument, trace};
-
 use super::{AuthMechanism, BoxedSplit, Command};
-use crate::{Error, Result};
+use crate::{Error, Result, log::trace};
 
 // Common code for the client and server side of the handshake.
 #[derive(Debug)]
@@ -57,12 +55,12 @@ impl Common {
         )
     }
 
-    #[instrument(skip(self))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     pub async fn write_command(&mut self, command: Command) -> Result<()> {
         self.write_commands(&[command], None).await
     }
 
-    #[instrument(skip(self))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     pub async fn write_commands(
         &mut self,
         commands: &[Command],
@@ -103,14 +101,14 @@ impl Common {
         Ok(())
     }
 
-    #[instrument(skip(self))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     pub async fn read_command(&mut self) -> Result<Command> {
         self.read_commands(1)
             .await
             .map(|cmds| cmds.into_iter().next().unwrap())
     }
 
-    #[instrument(skip(self))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     pub async fn read_commands(&mut self, n_commands: usize) -> Result<Vec<Command>> {
         let mut commands = Vec::with_capacity(n_commands);
         let mut n_received_commands = 0;

--- a/zbus/src/connection/handshake/server.rs
+++ b/zbus/src/connection/handshake/server.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
-use tracing::{instrument, trace};
 
-use crate::names::OwnedUniqueName;
+use crate::{log::trace, names::OwnedUniqueName};
 
 use super::{
     AuthMechanism, Authenticated, BoxedSplit, Command, Common, Error, Handshake, OwnedGuid, Result,
@@ -57,7 +56,7 @@ impl Server {
         })
     }
 
-    #[instrument(skip(self))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     async fn auth_ok(&mut self) -> Result<()> {
         let guid = self.guid.clone();
         let cmd = Command::Ok(guid);
@@ -92,7 +91,7 @@ impl Server {
         }
     }
 
-    #[instrument(skip(self))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     async fn unsupported_command_error(&mut self) -> Result<()> {
         let cmd = Command::Error("Unsupported or misplaced command".to_string());
         self.common.write_command(cmd).await?;
@@ -100,7 +99,7 @@ impl Server {
         Ok(())
     }
 
-    #[instrument(skip(self))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     async fn rejected_error(&mut self) -> Result<()> {
         let cmd = Command::Rejected(self.common.mechanism().as_str().into());
         trace!("Sending authentication error");
@@ -111,7 +110,7 @@ impl Server {
     }
 
     /// Perform the next step in the handshake.
-    #[instrument(skip(self))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     async fn next_step(&mut self) -> Result<bool> {
         match self.step {
             ServerHandshakeStep::WaitingForAuth => self.handle_auth().await?,
@@ -124,7 +123,7 @@ impl Server {
     }
 
     /// Handle the authentication step of the handshake.
-    #[instrument(skip(self))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     async fn handle_auth(&mut self) -> Result<()> {
         assert_eq!(self.step, ServerHandshakeStep::WaitingForAuth);
 
@@ -162,7 +161,7 @@ impl Server {
     }
 
     /// Handle the authentication data receiving step of the handshake.
-    #[instrument(skip(self))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     async fn handle_auth_data(&mut self, mech: AuthMechanism) -> Result<()> {
         assert!(matches!(self.step, ServerHandshakeStep::WaitingForData(_)));
 
@@ -180,7 +179,7 @@ impl Server {
     }
 
     /// Finalize the handshake.
-    #[instrument(skip(self))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     async fn finalize(&mut self) -> Result<()> {
         assert_eq!(self.step, ServerHandshakeStep::WaitingForBegin);
 
@@ -218,7 +217,7 @@ impl Server {
 
 #[async_trait]
 impl Handshake for Server {
-    #[instrument(skip(self))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     async fn perform(mut self) -> Result<Authenticated> {
         while !self.next_step().await? {}
 

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -2,6 +2,7 @@
 use async_broadcast::{InactiveReceiver, Receiver, Sender as Broadcaster, broadcast};
 use enumflags2::BitFlags;
 use event_listener::{Event, EventListener};
+use futures_lite::StreamExt;
 use std::{
     collections::HashMap,
     io,
@@ -11,19 +12,17 @@ use std::{
     },
     time::Duration,
 };
-use tracing::{Instrument, info_span, trace, trace_span, warn};
-#[cfg(feature = "service")]
-use tracing::{debug, instrument};
-
-use futures_lite::StreamExt;
 
 #[cfg(feature = "service")]
 use crate::ObjectServer;
+#[cfg(feature = "service")]
+use crate::log::debug;
 use crate::{
     DBusError, Error, Executor, MatchRule, ObjectPath, OwnedGuid, OwnedMatchRule, Result, Task,
     async_lock::{Mutex, Semaphore, SemaphorePermit},
     fdo::{ConnectionCredentials, ReleaseNameReply, RequestNameFlags, RequestNameReply},
     is_flatpak,
+    log::{Instrument, info, info_span, trace, trace_span, warn},
     message::{self, Flags, Message, Type},
     names::{BusName, ErrorName, InterfaceName, MemberName, OwnedUniqueName, WellKnownName},
     timeout::timeout,
@@ -738,7 +737,7 @@ impl Connection {
                         match signal {
                             Some(signal) => match signal {
                                 Ok(_) => {
-                                    tracing::info!(
+                                    info!(
                                         "Connection `{}` lost name `{}`",
                                         // SAFETY: This is bus connection so unique name can't be
                                         // None.
@@ -1011,7 +1010,7 @@ impl Connection {
     }
 
     #[cfg(feature = "service")]
-    #[instrument(skip(self))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     pub(crate) fn start_object_server(&self, started_event: Option<Event>) {
         self.inner.object_server_dispatch_task.get_or_init(|| {
             trace!("starting ObjectServer task");

--- a/zbus/src/connection/socket/mod.rs
+++ b/zbus/src/connection/socket/mod.rs
@@ -19,12 +19,12 @@ use async_io::Async;
 #[cfg(feature = "async-io")]
 use std::sync::Arc;
 use std::{io, mem};
-use tracing::trace;
 
 use crate::{
     Message,
     conn::AuthMechanism,
     fdo::ConnectionCredentials,
+    log::trace,
     message::{
         PrimaryHeader,
         header::{MAX_MESSAGE_SIZE, MIN_MESSAGE_SIZE},

--- a/zbus/src/connection/socket/unix.rs
+++ b/zbus/src/connection/socket/unix.rs
@@ -375,8 +375,8 @@ fn get_unix_peer_creds_blocking(fd: RawFd) -> std::io::Result<crate::fdo::Connec
 
     #[cfg(any(target_os = "android", target_os = "linux"))]
     {
+        use crate::log::debug;
         use rustix::net::sockopt::socket_peercred;
-        use tracing::debug;
 
         let ucred = socket_peercred(fd)?;
         let uid = ucred.uid.as_raw();

--- a/zbus/src/connection/socket_reader.rs
+++ b/zbus/src/connection/socket_reader.rs
@@ -7,12 +7,12 @@ use std::{
 };
 
 use event_listener::Event;
-use tracing::{debug, instrument, trace};
 
 use crate::{
     Executor, Message, OwnedMatchRule, Task,
     async_lock::Mutex,
     connection::{MsgBroadcaster, PendingMethodCalls},
+    log::{debug, trace},
     message::Type,
 };
 
@@ -56,7 +56,10 @@ impl SocketReader {
     }
 
     // Keep receiving messages and put them on the queue.
-    #[instrument(name = "socket reader", skip(self), level = "trace")]
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(name = "socket reader", skip(self), level = "trace")
+    )]
     async fn receive_msg(mut self) {
         loop {
             trace!("Waiting for message on the socket..");
@@ -143,7 +146,7 @@ impl SocketReader {
         self.pending_method_calls.fail_all(error);
     }
 
-    #[instrument(skip(self), level = "trace")]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), level = "trace"))]
     async fn read_socket(&mut self) -> crate::Result<Message> {
         self.socket_status.activity_event.notify(usize::MAX);
         let seq = self.prev_seq + 1;

--- a/zbus/src/lib.rs
+++ b/zbus/src/lib.rs
@@ -150,6 +150,8 @@ pub mod object_server;
 pub use object_server::ObjectServer;
 
 #[cfg(feature = "comms")]
+mod log;
+#[cfg(feature = "comms")]
 mod utils;
 #[cfg(feature = "comms")]
 pub use utils::*;

--- a/zbus/src/log.rs
+++ b/zbus/src/log.rs
@@ -1,0 +1,73 @@
+//! Internal logging shims.
+//!
+//! This module forwards to [`tracing`] when the `tracing` feature is enabled, and compiles to
+//! no-op macros and types otherwise, so the rest of the crate can log unconditionally without
+//! caring whether the feature is on.
+
+#[cfg(feature = "tracing")]
+pub(crate) use tracing::{Instrument, debug, info, info_span, trace, trace_span, warn};
+
+#[cfg(not(feature = "tracing"))]
+mod noop {
+    // The event shims type-check their arguments in a branch that is never taken, the way the
+    // `log` crate does when a level is compiled out. Nothing is evaluated at runtime, but the
+    // bindings a call site only uses in its log message do not become unused, so the no-`tracing`
+    // build stays free of warnings without any `#[allow]` or `_`-prefixed names.
+    macro_rules! event {
+        ($fmt:literal $(, $arg:expr)* $(,)?) => {
+            if false {
+                let _ = ::std::format_args!($fmt $(, $arg)*);
+            }
+        };
+    }
+    macro_rules! trace {
+        ($($arg:tt)*) => { $crate::log::event!($($arg)*) };
+    }
+    macro_rules! debug {
+        ($($arg:tt)*) => { $crate::log::event!($($arg)*) };
+    }
+    macro_rules! info {
+        ($($arg:tt)*) => { $crate::log::event!($($arg)*) };
+    }
+    // Named differently from `warn` (and re-exported as such below) because `use`-ing it
+    // directly as `warn` is ambiguous with the built-in `#[warn(..)]` attribute.
+    macro_rules! warn_event {
+        ($($arg:tt)*) => { $crate::log::event!($($arg)*) };
+    }
+    macro_rules! trace_span {
+        ($($arg:tt)*) => {
+            $crate::log::Span
+        };
+    }
+    macro_rules! info_span {
+        ($($arg:tt)*) => {
+            $crate::log::Span
+        };
+    }
+
+    pub(crate) use debug;
+    pub(crate) use event;
+    pub(crate) use info;
+    pub(crate) use info_span;
+    pub(crate) use trace;
+    pub(crate) use trace_span;
+    pub(crate) use warn_event as warn;
+}
+
+#[cfg(not(feature = "tracing"))]
+pub(crate) use noop::{debug, event, info, info_span, trace, trace_span, warn};
+
+/// A no-op stand-in for `tracing::Span`, used when the `tracing` feature is disabled.
+#[cfg(not(feature = "tracing"))]
+pub(crate) struct Span;
+
+/// A no-op stand-in for `tracing::Instrument`, used when the `tracing` feature is disabled.
+#[cfg(not(feature = "tracing"))]
+pub(crate) trait Instrument: Sized {
+    fn instrument(self, _span: Span) -> Self {
+        self
+    }
+}
+
+#[cfg(not(feature = "tracing"))]
+impl<T> Instrument for T {}

--- a/zbus/src/message_stream.rs
+++ b/zbus/src/message_stream.rs
@@ -7,11 +7,11 @@ use std::{
 use async_broadcast::Receiver as ActiveReceiver;
 use futures_core::stream::{self, FusedStream};
 use ordered_stream::{OrderedStream, PollResult};
-use tracing::warn;
 
 use crate::{
     AsyncDrop, Connection, MatchRule, OwnedMatchRule, Result,
     connection::ConnectionInner,
+    log::warn,
     message::{Message, Sequence},
 };
 

--- a/zbus/src/object_server/interface/dispatch_result.rs
+++ b/zbus/src/object_server/interface/dispatch_result.rs
@@ -2,8 +2,7 @@ use std::{future::Future, pin::Pin};
 
 use zbus::message::Flags;
 
-use crate::{Connection, DynamicType, Error, fdo, message::Message};
-use tracing::trace;
+use crate::{Connection, DynamicType, Error, fdo, log::trace, message::Message};
 
 /// A helper type returned by [`Interface`](`crate::object_server::Interface`) callbacks.
 ///

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -3,13 +3,13 @@
 #[cfg(feature = "object-manager")]
 use std::collections::HashMap;
 use std::{marker::PhantomData, sync::Arc};
-use tracing::{Instrument, debug, instrument, trace, trace_span};
 
 use crate::{
     Connection, Error, ObjectPath, Result,
     async_lock::RwLock,
     connection::WeakConnection,
     fdo,
+    log::{Instrument, debug, trace, trace_span},
     message::{Header, Message},
     names::InterfaceName,
 };
@@ -515,7 +515,7 @@ impl ObjectServer {
     ///   the caller through the associated server connection.
     ///
     /// Returns an error if the message is malformed.
-    #[instrument(skip(self))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     pub(crate) async fn dispatch_call(&self, msg: &Message, hdr: &Header<'_>) -> Result<()> {
         let conn = self.connection();
 

--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -1,5 +1,13 @@
 //! The client-side proxy API.
 
+use crate::{
+    AsyncDrop, Connection, Error, Executor, MatchRule, MessageStream, ObjectPath, OwnedMatchRule,
+    OwnedValue, Result, Str, Task, Value, as_value,
+    fdo::{self, IntrospectableProxy, NameOwnerChanged, PropertiesChangedStream, PropertiesProxy},
+    log::{Instrument, debug, info_span, trace, warn},
+    message::{Flags, Message, Sequence, Type},
+    names::{BusName, InterfaceName, MemberName, UniqueName},
+};
 use enumflags2::{BitFlags, bitflags};
 use event_listener::{Event, EventListener};
 use futures_core::{ready, stream};
@@ -12,15 +20,6 @@ use std::{
     pin::Pin,
     sync::{Arc, OnceLock, RwLock, RwLockReadGuard},
     task::{Context, Poll},
-};
-use tracing::{Instrument, debug, info_span, instrument, trace, warn};
-
-use crate::{
-    AsyncDrop, Connection, Error, Executor, MatchRule, MessageStream, ObjectPath, OwnedMatchRule,
-    OwnedValue, Result, Str, Task, Value, as_value,
-    fdo::{self, IntrospectableProxy, NameOwnerChanged, PropertiesChangedStream, PropertiesProxy},
-    message::{Flags, Message, Sequence, Type},
-    names::{BusName, InterfaceName, MemberName, UniqueName},
 };
 
 mod builder;
@@ -260,7 +259,7 @@ enum CachingResult {
 }
 
 impl PropertiesCache {
-    #[instrument(skip_all, level = "trace")]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip_all, level = "trace"))]
     fn new(
         proxy: PropertiesProxy<'static>,
         interface: InterfaceName<'static>,
@@ -389,7 +388,7 @@ impl PropertiesCache {
     }
 
     /// new() runs this in a task it spawns for keeping the cache in sync.
-    #[instrument(skip_all, level = "trace")]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip_all, level = "trace"))]
     async fn keep_updated(
         &self,
         mut prop_changes: PropertiesChangedStream,


### PR DESCRIPTION
Fixes #331.

Put the `tracing` dependency behind a new `tracing` feature, following the approach sketched in the last comment on the issue:

- `tracing = ["dep:tracing", "tokio?/tracing"]`, on by default; `dep:tracing` dropped from `comms` and `"tracing"` dropped from the `tokio` dependency's feature list.
- A private `log` module provides the logging surface. With the feature it re-exports `tracing`'s event and span macros and the `Instrument` trait. Without it, the event macros type-check their arguments in a branch that is never taken (the way the `log` crate compiles a level out), so no binding becomes unused, and the span macros produce a no-op `Span`.
- The `#[instrument(...)]` attributes become `#[cfg_attr(feature = "tracing", tracing::instrument(...))]`.
- `tracing` becomes a dev-dependency, since the tests use it directly.
- The README and the 6.0 upgrade guide document the feature.

`cargo tree -p zbus --no-default-features --features tokio,proxy,service -e no-dev -i tracing` reports nothing. Clippy with `-D warnings` is clean with and without the feature (the existing `--no-default-features --features ...` CI jobs cover the no-`tracing` build), and the test suite passes in both configurations.

The busd side is on z-galaxy/busd#351.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CY8gXkQ45xLvYRq6aVApKJ