### PR TITLE
🥅 zb,zm: Let property handlers fail with any `DBusError`

### DIFF
--- a/book/src/service.md
+++ b/book/src/service.md
@@ -309,8 +309,10 @@ trait, and should cover most common use cases. However, when a custom error type
 from the method as an error reply, it can be created using `derive(zbus::DBusError)`, and used in
 the returned `Result<T, E>`.
 
-Property methods may also return errors, but they must be [`zbus::fdo::Error`]. Most often you'll
-want to use [`zbus::fdo::Error::UnknownProperty`] variant.
+Property getters and setters follow the same rule as methods: the error is any type that
+implements [`zbus::DBusError`], so a custom `derive(zbus::DBusError)` type works there too.
+[`zbus::fdo::Error`] covers the common cases; [`zbus::fdo::Error::UnknownProperty`] is the one
+you'll reach for most often.
 
 ### Sending signals
 

--- a/zbus/src/dbus_error.rs
+++ b/zbus/src/dbus_error.rs
@@ -1,5 +1,7 @@
+use std::fmt;
+
 use crate::{
-    Result,
+    Error, Result, fdo,
     message::{Header, Message},
     names::ErrorName,
 };
@@ -23,4 +25,47 @@ pub trait DBusError {
 
     // The optional description for the error.
     fn description(&self) -> Option<&str>;
+}
+
+/// A [`DBusError`] of any concrete type.
+///
+/// This is how the object server carries a property getter's or setter's failure, whatever error
+/// type the handler fails with. The box is only allocated on failure.
+pub type BoxDBusError = Box<dyn DBusError + Send + Sync>;
+
+impl fmt::Display for dyn DBusError + Send + Sync {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let description = self.description().unwrap_or("no description");
+        write!(f, "{}: {description}", self.name())
+    }
+}
+
+impl<E> DBusError for Box<E>
+where
+    E: DBusError + ?Sized,
+{
+    fn create_reply(&self, msg: &Header<'_>) -> Result<Message> {
+        (**self).create_reply(msg)
+    }
+
+    fn name(&self) -> ErrorName<'_> {
+        (**self).name()
+    }
+
+    fn description(&self) -> Option<&str> {
+        (**self).description()
+    }
+}
+
+impl From<fdo::Error> for BoxDBusError {
+    fn from(e: fdo::Error) -> Self {
+        Box::new(e)
+    }
+}
+
+/// A plain [`Error`] is not a D-Bus error; it is reported the way [`fdo::Error`] reports it.
+impl From<Error> for BoxDBusError {
+    fn from(e: Error) -> Self {
+        Box::new(fdo::Error::from(e))
+    }
 }

--- a/zbus/src/fdo/properties.rs
+++ b/zbus/src/fdo/properties.rs
@@ -9,7 +9,10 @@ use std::{borrow::Cow, collections::HashMap};
 use super::Error;
 use super::Result;
 #[cfg(feature = "service")]
-use crate::{Connection, ObjectServer, interface, message::Header, object_server::SignalEmitter};
+use crate::{
+    BoxDBusError, Connection, ObjectServer, interface, message::Header,
+    object_server::SignalEmitter,
+};
 use crate::{OwnedValue, Value, names::InterfaceName};
 
 /// Service-side implementation for the `org.freedesktop.DBus.Properties` interface.
@@ -30,7 +33,7 @@ impl Properties {
         #[zbus(object_server)] server: &ObjectServer,
         #[zbus(header)] header: Header<'_>,
         #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
-    ) -> Result<OwnedValue> {
+    ) -> std::result::Result<OwnedValue, BoxDBusError> {
         let path = header.path().ok_or(crate::Error::MissingField)?;
         let root = server.root().read().await;
         let iface = root
@@ -47,9 +50,7 @@ impl Properties {
             .get(property_name, server, conn, Some(&header), &emitter)
             .await;
         res.unwrap_or_else(|| {
-            Err(Error::UnknownProperty(format!(
-                "Unknown property '{property_name}'"
-            )))
+            Err(Error::UnknownProperty(format!("Unknown property '{property_name}'")).into())
         })
     }
 
@@ -64,7 +65,7 @@ impl Properties {
         #[zbus(connection)] connection: &Connection,
         #[zbus(header)] header: Header<'_>,
         #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
-    ) -> Result<()> {
+    ) -> std::result::Result<(), BoxDBusError> {
         let path = header.path().ok_or(crate::Error::MissingField)?;
         let root = server.root().read().await;
         let iface = root
@@ -84,9 +85,9 @@ impl Properties {
         ) {
             zbus::object_server::DispatchResult2::RequiresMut => {}
             zbus::object_server::DispatchResult2::NotFound => {
-                return Err(Error::UnknownProperty(format!(
-                    "Unknown property '{property_name}'"
-                )));
+                return Err(
+                    Error::UnknownProperty(format!("Unknown property '{property_name}'")).into(),
+                );
             }
             zbus::object_server::DispatchResult2::Async(f) => {
                 return f.await;
@@ -106,9 +107,7 @@ impl Properties {
             )
             .await;
         res.unwrap_or_else(|| {
-            Err(Error::UnknownProperty(format!(
-                "Unknown property '{property_name}'"
-            )))
+            Err(Error::UnknownProperty(format!("Unknown property '{property_name}'")).into())
         })
     }
 

--- a/zbus/src/object_server/interface/dispatch_result.rs
+++ b/zbus/src/object_server/interface/dispatch_result.rs
@@ -2,12 +2,12 @@ use std::{future::Future, pin::Pin};
 
 use zbus::message::Flags;
 
-use crate::{Connection, DynamicType, Error, fdo, log::trace, message::Message};
+use crate::{BoxDBusError, Connection, DynamicType, Error, fdo, log::trace, message::Message};
 
 /// A helper type returned by [`Interface`](`crate::object_server::Interface`) callbacks.
 ///
-/// The [`Async`](DispatchResult2::Async) variant uses [`fdo::Result`] so that D-Bus error names are
-/// preserved without nesting through intermediate [`crate::Error`] conversions.
+/// The [`Async`](DispatchResult2::Async) variant carries a boxed [`DBusError`](crate::DBusError)
+/// so that any D-Bus error name can be reported, not just the fixed set in [`fdo::Error`].
 ///
 /// This is an unstable type — compatibility may break in minor version bumps.
 pub enum DispatchResult2<'a> {
@@ -20,7 +20,7 @@ pub enum DispatchResult2<'a> {
     RequiresMut,
 
     /// The method was found and will be completed by running this Future.
-    Async(Pin<Box<dyn Future<Output = fdo::Result<()>> + Send + 'a>>),
+    Async(Pin<Box<dyn Future<Output = Result<(), BoxDBusError>> + Send + 'a>>),
 }
 
 impl<'a> DispatchResult2<'a> {
@@ -40,7 +40,7 @@ impl<'a> DispatchResult2<'a> {
                     Err(e) => conn.reply_dbus_error(&hdr, e).await,
                 }
                 .map(|_seq| ())
-                .map_err(|e| fdo::Error::Failed(e.to_string()))
+                .map_err(handler_error)
             } else {
                 trace!("No reply expected for {:?} by the caller.", msg);
                 Ok(())
@@ -66,9 +66,9 @@ impl<'a> DispatchResult2<'a> {
 /// A [`DBusError`](crate::DBusError) is passed through unchanged. Anything else becomes
 /// `org.freedesktop.DBus.Error.Failed` with the error's text as its description.
 #[cold]
-fn handler_error(e: Error) -> fdo::Error {
+fn handler_error(e: Error) -> BoxDBusError {
     match e {
-        Error::FDO(e) => *e,
-        e => fdo::Error::Failed(e.to_string()),
+        Error::FDO(e) => e,
+        e => Box::new(fdo::Error::Failed(e.to_string())),
     }
 }

--- a/zbus/src/object_server/interface/mod.rs
+++ b/zbus/src/object_server/interface/mod.rs
@@ -15,7 +15,7 @@ use std::{
 use async_trait::async_trait;
 
 use crate::{
-    Connection, ObjectServer, OwnedValue, Value,
+    BoxDBusError, Connection, DBusError, Error, ObjectServer, OwnedValue, Value,
     async_lock::RwLock,
     fdo,
     message::{self, Header, Message},
@@ -71,6 +71,8 @@ pub trait Interface: Any + Send + Sync {
 
     /// Get a property value. Returns `None` if the property doesn't exist.
     ///
+    /// A getter may fail with any D-Bus error, hence the boxed error type.
+    ///
     /// Note: The header parameter will be None when the getter is not being called as part
     /// of D-Bus communication (for example, when it is called as part of initial object setup,
     /// before it is registered on the bus, or when we manually send out property changed
@@ -82,9 +84,12 @@ pub trait Interface: Any + Send + Sync {
         connection: &Connection,
         header: Option<&message::Header<'_>>,
         emitter: &SignalEmitter<'_>,
-    ) -> Option<fdo::Result<OwnedValue>>;
+    ) -> Option<Result<OwnedValue, BoxDBusError>>;
 
     /// Return all the properties.
+    ///
+    /// A property whose getter fails is left out, so this only fails when a value cannot be
+    /// serialized.
     async fn get_all(
         &self,
         object_server: &ObjectServer,
@@ -97,7 +102,8 @@ pub trait Interface: Any + Send + Sync {
     ///
     /// Return [`DispatchResult2::NotFound`] if the property doesn't exist, or
     /// [`DispatchResult2::RequiresMut`] if `set_mut` should be used instead. The default
-    /// implementation just returns `RequiresMut`.
+    /// implementation just returns `RequiresMut`. The [`DispatchResult2::Async`] future fails
+    /// with whatever D-Bus error the setter fails with.
     fn set<'call>(
         &'call self,
         property_name: &'call str,
@@ -120,7 +126,8 @@ pub trait Interface: Any + Send + Sync {
 
     /// Set a property value.
     ///
-    /// Returns `None` if the property doesn't exist.
+    /// Returns `None` if the property doesn't exist. A setter may fail with any D-Bus error,
+    /// hence the boxed error type.
     ///
     /// This will only be invoked if `set` returned `RequiresMut`.
     async fn set_mut(
@@ -131,7 +138,7 @@ pub trait Interface: Any + Send + Sync {
         connection: &Connection,
         header: Option<&Header<'_>>,
         emitter: &SignalEmitter<'_>,
-    ) -> Option<fdo::Result<()>>;
+    ) -> Option<Result<(), BoxDBusError>>;
 
     /// Call a method.
     ///
@@ -160,6 +167,31 @@ pub trait Interface: Any + Send + Sync {
 
     /// Write introspection XML to the writer, with the given indentation level.
     fn introspect_to_writer(&self, writer: &mut dyn Write, level: usize);
+}
+
+/// Conversion of a property handler's failure into the boxed error [`Interface`] carries.
+///
+/// The `#[interface]` macro applies it to whatever a getter or setter returns. Any `'static`
+/// [`DBusError`] is boxed as is. A plain [`Error`] is not a D-Bus error, so it is reported the
+/// way [`fdo::Error`] reports it.
+#[doc(hidden)]
+pub trait IntoDBusError {
+    fn into_dbus_error(self) -> BoxDBusError;
+}
+
+impl<E> IntoDBusError for E
+where
+    E: DBusError + Send + Sync + 'static,
+{
+    fn into_dbus_error(self) -> BoxDBusError {
+        Box::new(self)
+    }
+}
+
+impl IntoDBusError for Error {
+    fn into_dbus_error(self) -> BoxDBusError {
+        self.into()
+    }
 }
 
 /// A type for a reference-counted Interface trait-object, with associated run-time details and a

--- a/zbus/src/object_server/mod.rs
+++ b/zbus/src/object_server/mod.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::{marker::PhantomData, sync::Arc};
 
 use crate::{
-    Connection, Error, ObjectPath, Result,
+    BoxDBusError, Connection, Error, ObjectPath, Result,
     async_lock::RwLock,
     connection::WeakConnection,
     fdo,
@@ -20,7 +20,9 @@ mod interface;
 pub(crate) use interface::ArcInterface;
 #[doc(hidden)]
 pub use interface::introspect_doc_comment;
-pub use interface::{DispatchResult2, Interface, InterfaceDeref, InterfaceDerefMut, InterfaceRef};
+pub use interface::{
+    DispatchResult2, Interface, InterfaceDeref, InterfaceDerefMut, InterfaceRef, IntoDBusError,
+};
 
 mod signal_emitter;
 pub use signal_emitter::SignalEmitter;
@@ -409,7 +411,7 @@ impl ObjectServer {
         connection: &Connection,
         msg: &Message,
         hdr: &Header<'_>,
-    ) -> fdo::Result<()> {
+    ) -> std::result::Result<(), BoxDBusError> {
         let member = hdr
             .member()
             .ok_or_else(|| fdo::Error::Failed("Missing member".into()))?;
@@ -422,9 +424,7 @@ impl ObjectServer {
         trace!("acquired read lock on interface `{}`", iface_name);
         match read_lock.call(self, connection, msg, member.as_ref()) {
             DispatchResult2::NotFound => {
-                return Err(fdo::Error::UnknownMethod(format!(
-                    "Unknown method '{member}'"
-                )));
+                return Err(fdo::Error::UnknownMethod(format!("Unknown method '{member}'")).into());
             }
             DispatchResult2::Async(f) => {
                 return f.await;
@@ -443,9 +443,7 @@ impl ObjectServer {
             }
         }
         drop(write_lock);
-        Err(fdo::Error::UnknownMethod(format!(
-            "Unknown method '{member}'"
-        )))
+        Err(fdo::Error::UnknownMethod(format!("Unknown method '{member}'")).into())
     }
 
     async fn dispatch_method_call_try(
@@ -453,7 +451,7 @@ impl ObjectServer {
         connection: &Connection,
         msg: &Message,
         hdr: &Header<'_>,
-    ) -> fdo::Result<()> {
+    ) -> std::result::Result<(), BoxDBusError> {
         let path = hdr
             .path()
             .ok_or_else(|| fdo::Error::Failed("Missing object path".into()))?;

--- a/zbus/tests/iface_and_proxy/client.rs
+++ b/zbus/tests/iface_and_proxy/client.rs
@@ -218,6 +218,67 @@ pub async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> 
         ))),
     );
 
+    // A property getter failing with a custom `DBusError` should surface its error name too.
+    let err = proxy.fail_property_custom_error().await.unwrap_err();
+    let Error::MethodError(name, ..) = &err else {
+        panic!("Expected Error::MethodError, got {err:?}");
+    };
+    assert_eq!(
+        name.as_str(),
+        "org.freedesktop.MyIface.Error.SomethingWentWrong"
+    );
+    assert_eq!(
+        MyIfaceError::from(err),
+        MyIfaceError::SomethingWentWrong("oops".to_string())
+    );
+
+    // Property setters (both `&self` and `&mut self`) failing with a custom `DBusError` should
+    // likewise surface their error name to the client.
+    proxy.set_custom_error_prop(60).await?;
+    let err = proxy
+        .set_custom_error_prop(61)
+        .await
+        .expect_err("Setting value above 60 should fail");
+    assert_eq!(
+        MyIfaceError::from(err),
+        MyIfaceError::SomethingWentWrong(
+            "Provided value is 61; values above 60 not accepted".to_string()
+        )
+    );
+
+    proxy.set_custom_error_mut_prop(60).await?;
+    let err = proxy
+        .set_custom_error_mut_prop(61)
+        .await
+        .expect_err("Setting value above 60 should fail");
+    assert_eq!(
+        MyIfaceError::from(err),
+        MyIfaceError::SomethingWentWrong(
+            "Provided value is 61; values above 60 not accepted".to_string()
+        )
+    );
+
+    // A successful set is followed by the getter for the `PropertiesChanged` emission. A getter
+    // failing there must keep its own error name in the `Set` reply, for a standard error and a
+    // custom one alike.
+    let err = proxy
+        .set_locked_prop(1)
+        .await
+        .expect_err("Setting a locked property should fail");
+    let Error::FDO(fdo_err) = err else {
+        panic!("Expected Error::FDO, got {err:?}");
+    };
+    assert!(matches!(*fdo_err, zbus::fdo::Error::AccessDenied(_)));
+    assert_eq!(fdo_err.name(), "org.freedesktop.DBus.Error.AccessDenied");
+    let err = proxy
+        .set_custom_locked_prop(1)
+        .await
+        .expect_err("Setting a locked property should fail");
+    assert_eq!(
+        MyIfaceError::from(err),
+        MyIfaceError::SomethingWentWrong("locked".to_string())
+    );
+
     assert_eq!(proxy.optional_property().await?, Some(42).into());
 
     let xml = proxy.inner().introspect().await?;

--- a/zbus/tests/iface_and_proxy/iface.rs
+++ b/zbus/tests/iface_and_proxy/iface.rs
@@ -549,6 +549,87 @@ impl MyIface {
         Ok(())
     }
 
+    /// A property whose getter fails with a custom `DBusError`, to check that its error name
+    /// reaches the client.
+    #[instrument]
+    #[zbus(property)]
+    fn fail_property_custom_error(&self) -> Result<u32, MyIfaceError> {
+        debug!("`FailPropertyCustomError` getter called.");
+        Err(MyIfaceError::SomethingWentWrong("oops".to_string()))
+    }
+
+    /// A property with a fallible `&self` setter that fails with a custom `DBusError`, to
+    /// exercise the `Interface::set` (`DispatchResult2::Async`) path.
+    #[instrument]
+    #[zbus(property)]
+    fn custom_error_prop(&self) -> u32 {
+        debug!("`CustomErrorProp` getter called.");
+        0
+    }
+
+    #[instrument]
+    #[zbus(property)]
+    fn set_custom_error_prop(&self, val: u32) -> Result<(), MyIfaceError> {
+        debug!("`CustomErrorProp` setter called.");
+        if val > 60 {
+            return Err(MyIfaceError::SomethingWentWrong(format!(
+                "Provided value is {val}; values above 60 not accepted"
+            )));
+        }
+        Ok(())
+    }
+
+    /// A property with a fallible `&mut self` setter that fails with a custom `DBusError`, to
+    /// exercise the `Interface::set_mut` path.
+    #[instrument]
+    #[zbus(property)]
+    fn custom_error_mut_prop(&self) -> u32 {
+        debug!("`CustomErrorMutProp` getter called.");
+        0
+    }
+
+    #[instrument]
+    #[zbus(property)]
+    fn set_custom_error_mut_prop(&mut self, val: u32) -> Result<(), MyIfaceError> {
+        debug!("`CustomErrorMutProp` setter called.");
+        if val > 60 {
+            return Err(MyIfaceError::SomethingWentWrong(format!(
+                "Provided value is {val}; values above 60 not accepted"
+            )));
+        }
+        Ok(())
+    }
+
+    /// A property whose getter fails after a successful set, the way a locked Secret Service item
+    /// reports `IsLocked`. The setter emits `PropertiesChanged` with the new value, so the
+    /// getter's error name must survive that path into the `Set` reply.
+    #[instrument]
+    #[zbus(property)]
+    fn locked_prop(&self) -> zbus::fdo::Result<u32> {
+        debug!("`LockedProp` getter called.");
+        Err(zbus::fdo::Error::AccessDenied("locked".to_string()))
+    }
+
+    #[instrument]
+    #[zbus(property)]
+    fn set_locked_prop(&mut self, val: u32) {
+        debug!("`LockedProp` setter called with {val}.");
+    }
+
+    /// Like `locked_prop`, with the getter failing with a custom `DBusError` and a `&self` setter.
+    #[instrument]
+    #[zbus(property)]
+    fn custom_locked_prop(&self) -> Result<u32, MyIfaceError> {
+        debug!("`CustomLockedProp` getter called.");
+        Err(MyIfaceError::SomethingWentWrong("locked".to_string()))
+    }
+
+    #[instrument]
+    #[zbus(property)]
+    fn set_custom_locked_prop(&self, val: u32) {
+        debug!("`CustomLockedProp` setter called with {val}.");
+    }
+
     async fn never_return(&self) {
         debug!("`NeverReturn` called.");
 

--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -518,6 +518,22 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                 let sk_member_name = case::snake_or_kebab_case(&member_name, true);
                 let prop_changed_method_name = format_ident!("{sk_member_name}_changed");
                 let prop_invalidate_method_name = format_ident!("{sk_member_name}_invalidate");
+                let prop_value_method_name = format_ident!("__zbus_{sk_member_name}_value");
+                // Emits `PropertiesChanged` for the property, with `value` in scope holding its
+                // current value.
+                let emit_changed = quote!({
+                    let mut changed = ::std::collections::HashMap::new();
+                    changed.insert(#member_name, #zbus::as_value::Serialize(&value));
+                    __zbus__signal_emitter.emit(
+                        "org.freedesktop.DBus.Properties",
+                        "PropertiesChanged",
+                        &(
+                            #zbus::names::InterfaceName::from_static_str_unchecked(#iface_name),
+                            changed,
+                            ::std::borrow::Cow::<[&str]>::Borrowed(&[]),
+                        ),
+                    ).await
+                });
 
                 p.doc_comments.extend(doc_comments);
                 if has_inputs {
@@ -563,13 +579,19 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                             let #value_param_name = __zbus__value;
                         }
                     };
+                    // Each arm yields `Result<(), BoxDBusError>`. The getter's own error must
+                    // reach the caller unchanged, so the value is fetched through the hidden
+                    // method rather than the public `*_changed` helper, which returns
+                    // `zbus::Result`.
                     let prop_changed_method = match p.emits_changed_signal {
                         PropertyEmitsChangedSignal::True => {
                             quote!({
-                                self
-                                    .#prop_changed_method_name(&__zbus__signal_emitter)
-                                    .await
-                                    .map(|_| set_result)
+                                match self.#prop_value_method_name(&__zbus__signal_emitter).await {
+                                    ::std::result::Result::Ok(value) => #emit_changed.map_err(|e| {
+                                        #zbus::object_server::IntoDBusError::into_dbus_error(e)
+                                    }),
+                                    ::std::result::Result::Err(e) => ::std::result::Result::Err(e),
+                                }
                             })
                         }
                         PropertyEmitsChangedSignal::Invalidates => {
@@ -577,11 +599,13 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                                 self
                                     .#prop_invalidate_method_name(&__zbus__signal_emitter)
                                     .await
-                                    .map(|_| set_result)
+                                    .map_err(|e| {
+                                        #zbus::object_server::IntoDBusError::into_dbus_error(e)
+                                    })
                             })
                         }
                         PropertyEmitsChangedSignal::False | PropertyEmitsChangedSignal::Const => {
-                            quote!({ ::std::result::Result::<_, #zbus::Error>::Ok(()) })
+                            quote!({ ::std::result::Result::<_, #zbus::BoxDBusError>::Ok(()) })
                         }
                     };
                     let do_set = quote!({
@@ -590,19 +614,18 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                             ::std::result::Result::Ok(__zbus__value) => {
                                 #value_arg
                                 match #set_call {
-                                    ::std::result::Result::Ok(set_result) => {
-                                        (#prop_changed_method)
-                                            .map_err(|e| #zbus::fdo::Error::from(e))
-                                    }
+                                    ::std::result::Result::Ok(()) => #prop_changed_method,
                                     ::std::result::Result::Err(e) => {
                                         ::std::result::Result::Err(
-                                            #zbus::fdo::Error::from(e),
+                                            #zbus::object_server::IntoDBusError::into_dbus_error(e),
                                         )
                                     }
                                 }
                             }
                             ::std::result::Result::Err(e) => {
-                                ::std::result::Result::Err(#zbus::fdo::Error::from(e))
+                                ::std::result::Result::Err(
+                                    #zbus::object_server::IntoDBusError::into_dbus_error(e),
+                                )
                             }
                         }
                     });
@@ -638,11 +661,21 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                     p.ty = Some(get_return_type(output)?.clone());
 
                     let value_convert = quote!(
-                        #zbus::as_value::to_owned_value(&value)
-                            .map_err(|e| #zbus::fdo::Error::Failed(e.to_string()))
+                        #zbus::as_value::to_owned_value(&value).map_err(|e| {
+                            #zbus::object_server::IntoDBusError::into_dbus_error(
+                                #zbus::fdo::Error::Failed(e.to_string()),
+                            )
+                        })
                     );
                     let inner = if is_fallible_property {
-                        quote!(self.#ident(#args_names) #method_await .and_then(|value| #value_convert))
+                        quote!(
+                            match self.#ident(#args_names)#method_await {
+                                ::std::result::Result::Ok(value) => #value_convert,
+                                ::std::result::Result::Err(e) => ::std::result::Result::Err(
+                                    #zbus::object_server::IntoDBusError::into_dbus_error(e),
+                                ),
+                            }
+                        )
                     } else {
                         quote!({
                             let value = self.#ident(#args_names)#method_await;
@@ -685,46 +718,55 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
 
                     get_all.extend(q);
 
-                    let prop_value_handled = if is_fallible_property {
-                        quote!(self.#ident(#args_names)#method_await?)
+                    let prop_value = if is_fallible_property {
+                        quote!(match self.#ident(#args_names)#method_await {
+                            ::std::result::Result::Ok(value) => ::std::result::Result::Ok(value),
+                            ::std::result::Result::Err(e) => ::std::result::Result::Err(
+                                #zbus::object_server::IntoDBusError::into_dbus_error(e),
+                            ),
+                        })
                     } else {
-                        quote!(self.#ident(#args_names)#method_await)
+                        quote!(::std::result::Result::Ok(self.#ident(#args_names)#method_await))
                     };
 
                     if p.emits_changed_signal == PropertyEmitsChangedSignal::True {
+                        let prop_ty = p.ty.as_ref().unwrap();
                         let changed_doc = format!(
                             "Emit the “PropertiesChanged” signal with the new value for the\n\
                              `{member_name}` property.\n\n\
                              This method should be called if a property value changes outside\n\
                              its setter method."
                         );
+                        // The value is fetched through a hidden method so that the generated
+                        // setter can emit the signal too while keeping the getter's error
+                        // typed. The public helper returns `zbus::Result`, which cannot carry
+                        // an arbitrary `DBusError`, so it reports the getter's failure as
+                        // `Error::Failure` with the error's name and description as its text.
                         let prop_changed_method = quote!(
+                            #[doc(hidden)]
+                            pub async fn #prop_value_method_name(
+                                &self,
+                                __zbus__signal_emitter: &#zbus::object_server::SignalEmitter<'_>,
+                            ) -> ::std::result::Result<#prop_ty, #zbus::BoxDBusError> {
+                                let __zbus__header = ::std::option::Option::None::<&#zbus::message::Header<'_>>;
+                                let __zbus__connection = __zbus__signal_emitter.connection();
+                                let __zbus__object_server = __zbus__connection.object_server();
+                                #args_from_msg
+                                #prop_value
+                            }
+
                             #[doc = #changed_doc]
                             pub async fn #prop_changed_method_name(
                                 &self,
                                 __zbus__signal_emitter: &#zbus::object_server::SignalEmitter<'_>,
                             ) -> #zbus::Result<()> {
-                                let __zbus__header = ::std::option::Option::None::<&#zbus::message::Header<'_>>;
-                                let __zbus__connection = __zbus__signal_emitter.connection();
-                                let __zbus__object_server = __zbus__connection.object_server();
-                                #args_from_msg
-                                let value = #prop_value_handled;
-                                let mut changed = ::std::collections::HashMap::new();
-                                changed.insert(
-                                    #member_name,
-                                    #zbus::as_value::Serialize(&value),
-                                );
-                                __zbus__signal_emitter.emit(
-                                    "org.freedesktop.DBus.Properties",
-                                    "PropertiesChanged",
-                                    &(
-                                        #zbus::names::InterfaceName::from_static_str_unchecked(
-                                            #iface_name,
-                                        ),
-                                        changed,
-                                        ::std::borrow::Cow::<[&str]>::Borrowed(&[]),
-                                    ),
-                                ).await
+                                let value = self
+                                    .#prop_value_method_name(__zbus__signal_emitter)
+                                    .await
+                                    .map_err(|e| #zbus::Error::Failure(
+                                        ::std::string::ToString::to_string(&e),
+                                    ))?;
+                                #emit_changed
                             }
                         );
 
@@ -872,7 +914,9 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                 __zbus__connection: &#zbus::Connection,
                 __zbus__header: Option<&#zbus::message::Header<'_>>,
                 __zbus__signal_emitter: &#zbus::object_server::SignalEmitter<'_>,
-            ) -> ::std::option::Option<#zbus::fdo::Result<#zbus::OwnedValue>> {
+            ) -> ::std::option::Option<
+                ::std::result::Result<#zbus::OwnedValue, #zbus::BoxDBusError>,
+            > {
                 match __zbus__property_name {
                     #get_dispatch
                     _ => ::std::option::Option::None,
@@ -923,7 +967,7 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                 __zbus__connection: &#zbus::Connection,
                 __zbus__header: Option<&#zbus::message::Header<'_>>,
                 __zbus__signal_emitter: &#zbus::object_server::SignalEmitter<'_>,
-            ) -> ::std::option::Option<#zbus::fdo::Result<()>> {
+            ) -> ::std::option::Option<::std::result::Result<(), #zbus::BoxDBusError>> {
                 match __zbus__property_name {
                     #set_mut_dispatch
                     _ => ::std::option::Option::None,


### PR DESCRIPTION
Property getters and setters generated by `#[interface]` may now fail with any type implementing `DBusError`, the same rule methods already follow, so a service can reply with its own error names from a property access (e.g. `org.freedesktop.Secret.Error.IsLocked` from a setter). `fdo::Result` getters and setters, and setters returning `zbus::Result<()>`, keep working.

The `Interface` trait carries property failures as a new `BoxDBusError` alias (`Box<dyn DBusError + Send + Sync>`), so does the `DispatchResult2::Async` future that a `&self` setter reports through. The box is only allocated on the failure path. `Box<E>` implements `DBusError`, `fdo::Error` and `zbus::Error` convert into the box so `?` keeps working, and the macro routes every property failure through a hidden conversion trait since it cannot tell a `DBusError` from a `zbus::Error` syntactically. `Interface::get_all` is unchanged: it leaves out a property whose getter fails.

One observable detail: the generated `<property>_changed` helper returns `zbus::Result<()>` to the service's own code, which cannot carry an arbitrary `DBusError`, so a getter failing there is reported as `Error::Failure` with the error's name and description as its text.

The e2e test gains a getter, a `&self` setter and a `&mut self` setter failing with the custom `MyIfaceError`, checking that the error name reaches the client on all three paths. The book no longer says property errors must be `fdo::Error`.

Fixes #313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLGqZvo2MX7FNACCSAASSM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLGqZvo2MX7FNACCSAASSM)_