### PR TITLE
🥅 zb,zm: Carry any D-Bus error in `zbus::Error`

### DIFF
--- a/zbus/src/dbus_error.rs
+++ b/zbus/src/dbus_error.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, sync::Arc};
 
 use crate::{
     Error, Result, fdo,
@@ -40,7 +40,33 @@ impl fmt::Display for dyn DBusError + Send + Sync {
     }
 }
 
+impl fmt::Debug for dyn DBusError + Send + Sync {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DBusError")
+            .field("name", &self.name())
+            .field("description", &self.description())
+            .finish()
+    }
+}
+
 impl<E> DBusError for Box<E>
+where
+    E: DBusError + ?Sized,
+{
+    fn create_reply(&self, msg: &Header<'_>) -> Result<Message> {
+        (**self).create_reply(msg)
+    }
+
+    fn name(&self) -> ErrorName<'_> {
+        (**self).name()
+    }
+
+    fn description(&self) -> Option<&str> {
+        (**self).description()
+    }
+}
+
+impl<E> DBusError for Arc<E>
 where
     E: DBusError + ?Sized,
 {
@@ -63,9 +89,14 @@ impl From<fdo::Error> for BoxDBusError {
     }
 }
 
-/// A plain [`Error`] is not a D-Bus error; it is reported the way [`fdo::Error`] reports it.
+/// A D-Bus error carried by an [`Error`] is boxed as is. Any other [`Error`] is not a D-Bus
+/// error; it is reported the way [`fdo::Error`] reports it.
 impl From<Error> for BoxDBusError {
     fn from(e: Error) -> Self {
-        Box::new(fdo::Error::from(e))
+        match e {
+            Error::FDO(e) => e,
+            Error::DBus(e) => Box::new(e),
+            e => Box::new(fdo::Error::from(e)),
+        }
     }
 }

--- a/zbus/src/error.rs
+++ b/zbus/src/error.rs
@@ -77,6 +77,12 @@ pub enum Error {
     /// A [`fdo::Error`] transformed into [`Error`].
     #[cfg(feature = "comms")]
     FDO(Box<fdo::Error>),
+    /// A [`DBusError`](crate::DBusError) of any other type.
+    ///
+    /// This is how the failure of a property getter reaches the caller of the
+    /// `PropertiesChanged` emission helper that `#[interface]` generates for the property.
+    #[cfg(feature = "comms")]
+    DBus(Arc<dyn crate::DBusError + Send + Sync>),
     /// The requested name was already claimed by another peer.
     NameTaken,
     /// Invalid [match rule][MR] string.
@@ -130,6 +136,10 @@ impl PartialEq for Error {
             (Self::Unsupported, Self::Unsupported) => true,
             #[cfg(feature = "comms")]
             (Self::FDO(s), Self::FDO(o)) => s == o,
+            #[cfg(feature = "comms")]
+            (Self::DBus(s), Self::DBus(o)) => {
+                s.name() == o.name() && s.description() == o.description()
+            }
             (Self::NameTaken, Self::NameTaken) => true,
             (Self::InvalidMatchRule, Self::InvalidMatchRule) => true,
             (Self::InvalidSerial, Self::InvalidSerial) => true,
@@ -150,6 +160,8 @@ impl error::Error for Error {
             Error::Utf8(e) => Some(e),
             #[cfg(feature = "comms")]
             Error::FDO(e) => Some(e),
+            #[cfg(feature = "comms")]
+            Error::DBus(_) => None,
             #[cfg(feature = "comms")]
             Error::Connection(e, _) => Some(e),
             Error::Failure(_) => None,
@@ -230,6 +242,8 @@ impl fmt::Display for Error {
             Error::Unsupported => write!(f, "Connection support is lacking"),
             #[cfg(feature = "comms")]
             Error::FDO(e) => write!(f, "{e}"),
+            #[cfg(feature = "comms")]
+            Error::DBus(e) => write!(f, "{e}"),
             Error::NameTaken => write!(f, "name already taken on the bus"),
             Error::InvalidMatchRule => write!(f, "Invalid match rule string"),
             Error::MissingParameter(p) => {
@@ -284,6 +298,8 @@ impl Error {
             Error::InvalidReply => Some("invalid reply"),
             #[cfg(feature = "comms")]
             Error::MethodError(_, desc, _) => desc.as_deref(),
+            #[cfg(feature = "comms")]
+            Error::DBus(e) => e.description(),
             Error::MissingField => Some("a required field is missing from message headers"),
             Error::InvalidGUID => Some("invalid GUID"),
             Error::Unsupported => Some("connection support is lacking"),

--- a/zbus/src/fdo/mod.rs
+++ b/zbus/src/fdo/mod.rs
@@ -56,6 +56,8 @@ pub use stats::StatsProxy;
 
 #[cfg(all(test, feature = "proxy", feature = "service"))]
 mod tests {
+    use std::sync::Arc;
+
     use crate::{DBusError, Error, fdo, interface, message::Message, names::WellKnownName};
     use futures_util::StreamExt;
     use ntest::timeout;
@@ -81,6 +83,17 @@ mod tests {
         assert_eq!(e, fdo::Error::TimedOut("so long".to_string()),);
         assert_eq!(e.name(), "org.freedesktop.DBus.Error.TimedOut");
         assert_eq!(e.description(), Some("so long"));
+    }
+
+    #[test]
+    fn error_from_dbus_variant() {
+        let e = Error::DBus(Arc::new(fdo::Error::TimedOut("so long".to_string())));
+        assert_eq!(
+            e.to_string(),
+            "org.freedesktop.DBus.Error.TimedOut: so long"
+        );
+        let e: fdo::Error = e.into();
+        assert_eq!(e, fdo::Error::TimedOut("so long".to_string()));
     }
 
     #[test]

--- a/zbus/src/object_server/interface/dispatch_result.rs
+++ b/zbus/src/object_server/interface/dispatch_result.rs
@@ -69,6 +69,7 @@ impl<'a> DispatchResult2<'a> {
 fn handler_error(e: Error) -> BoxDBusError {
     match e {
         Error::FDO(e) => e,
+        Error::DBus(e) => Box::new(e),
         e => Box::new(fdo::Error::Failed(e.to_string())),
     }
 }

--- a/zbus/src/object_server/interface/mod.rs
+++ b/zbus/src/object_server/interface/mod.rs
@@ -177,6 +177,12 @@ pub trait Interface: Any + Send + Sync {
 #[doc(hidden)]
 pub trait IntoDBusError {
     fn into_dbus_error(self) -> BoxDBusError;
+
+    /// The failure as an [`Error`], for a caller that is not replying to a D-Bus call.
+    ///
+    /// A getter's failure reaches the caller of the generated `PropertiesChanged` emission
+    /// helper this way, as [`Error::DBus`].
+    fn into_error(self) -> Error;
 }
 
 impl<E> IntoDBusError for E
@@ -186,11 +192,19 @@ where
     fn into_dbus_error(self) -> BoxDBusError {
         Box::new(self)
     }
+
+    fn into_error(self) -> Error {
+        Error::DBus(Arc::new(self))
+    }
 }
 
 impl IntoDBusError for Error {
     fn into_dbus_error(self) -> BoxDBusError {
         self.into()
+    }
+
+    fn into_error(self) -> Error {
+        self
     }
 }
 

--- a/zbus/tests/e2e.rs
+++ b/zbus/tests/e2e.rs
@@ -20,7 +20,7 @@ use zbus::{block_on, connection, object_server::InterfaceRef};
 use iface_and_proxy::{
     client::my_iface_test,
     iface::{MyIface, MyIfaceSignals},
-    types::NextAction,
+    types::{MyIfaceError, NextAction},
 };
 
 #[test]
@@ -174,6 +174,31 @@ async fn iface_and_proxy_(#[allow(unused)] p2p: bool) {
         .await
         .unwrap();
     debug!("`PropertiesChanged` emitted for `Count` property.");
+
+    // A getter failing inside the `PropertiesChanged` helper hands its error back typed, both
+    // for a standard and for a custom error.
+    let err = iface
+        .get()
+        .await
+        .locked_prop_changed(iface.signal_emitter())
+        .await
+        .expect_err("`LockedProp` getter should fail");
+    assert!(matches!(err, zbus::Error::DBus(_)));
+    assert_eq!(
+        zbus::fdo::Error::from(err),
+        zbus::fdo::Error::AccessDenied("locked".to_string())
+    );
+    let err = iface
+        .get()
+        .await
+        .custom_locked_prop_changed(iface.signal_emitter())
+        .await
+        .expect_err("`CustomLockedProp` getter should fail");
+    assert!(matches!(err, zbus::Error::DBus(_)));
+    assert_eq!(
+        MyIfaceError::from(err),
+        MyIfaceError::SomethingWentWrong("locked".to_string())
+    );
 
     loop {
         iface.alert_count(51).await.unwrap();

--- a/zbus_macros/src/error.rs
+++ b/zbus_macros/src/error.rs
@@ -156,6 +156,10 @@ pub fn expand_derive(input: DeriveInput) -> Result<TokenStream, Error> {
                                 let e = ::std::convert::AsRef::as_ref(e);
                                 (#zbus::DBusError::name(e), #zbus::DBusError::description(e))
                             }
+                            #zbus::Error::DBus(e) => {
+                                let e = ::std::convert::AsRef::as_ref(e);
+                                (#zbus::DBusError::name(e), #zbus::DBusError::description(e))
+                            }
                             _ => return Self::#ident(value),
                         };
                         match name.as_str() {
@@ -240,6 +244,9 @@ fn gen_reply_for_variant(
                     match #error_field {
                         #zbus::Error::MethodError(name, desc, _) => {
                             ::std::clone::Clone::clone(desc)
+                        }
+                        #zbus::Error::DBus(e) => {
+                            #zbus::DBusError::description(e).map(::std::string::ToString::to_string)
                         }
                         _ => None,
                     }

--- a/zbus_macros/src/iface.rs
+++ b/zbus_macros/src/iface.rs
@@ -518,22 +518,6 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                 let sk_member_name = case::snake_or_kebab_case(&member_name, true);
                 let prop_changed_method_name = format_ident!("{sk_member_name}_changed");
                 let prop_invalidate_method_name = format_ident!("{sk_member_name}_invalidate");
-                let prop_value_method_name = format_ident!("__zbus_{sk_member_name}_value");
-                // Emits `PropertiesChanged` for the property, with `value` in scope holding its
-                // current value.
-                let emit_changed = quote!({
-                    let mut changed = ::std::collections::HashMap::new();
-                    changed.insert(#member_name, #zbus::as_value::Serialize(&value));
-                    __zbus__signal_emitter.emit(
-                        "org.freedesktop.DBus.Properties",
-                        "PropertiesChanged",
-                        &(
-                            #zbus::names::InterfaceName::from_static_str_unchecked(#iface_name),
-                            changed,
-                            ::std::borrow::Cow::<[&str]>::Borrowed(&[]),
-                        ),
-                    ).await
-                });
 
                 p.doc_comments.extend(doc_comments);
                 if has_inputs {
@@ -579,19 +563,18 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
                             let #value_param_name = __zbus__value;
                         }
                     };
-                    // Each arm yields `Result<(), BoxDBusError>`. The getter's own error must
-                    // reach the caller unchanged, so the value is fetched through the hidden
-                    // method rather than the public `*_changed` helper, which returns
-                    // `zbus::Result`.
+                    // Each arm yields `Result<(), BoxDBusError>`. A getter's failure inside the
+                    // `*_changed` helper is carried by `Error::DBus`, which the conversion boxes
+                    // as is, so its error name reaches the caller of `Set` unchanged.
                     let prop_changed_method = match p.emits_changed_signal {
                         PropertyEmitsChangedSignal::True => {
                             quote!({
-                                match self.#prop_value_method_name(&__zbus__signal_emitter).await {
-                                    ::std::result::Result::Ok(value) => #emit_changed.map_err(|e| {
+                                self
+                                    .#prop_changed_method_name(&__zbus__signal_emitter)
+                                    .await
+                                    .map_err(|e| {
                                         #zbus::object_server::IntoDBusError::into_dbus_error(e)
-                                    }),
-                                    ::std::result::Result::Err(e) => ::std::result::Result::Err(e),
-                                }
+                                    })
                             })
                         }
                         PropertyEmitsChangedSignal::Invalidates => {
@@ -718,55 +701,53 @@ pub fn expand(args: Punctuated<Meta, Token![,]>, mut input: ItemImpl) -> syn::Re
 
                     get_all.extend(q);
 
-                    let prop_value = if is_fallible_property {
+                    let prop_value_handled = if is_fallible_property {
                         quote!(match self.#ident(#args_names)#method_await {
-                            ::std::result::Result::Ok(value) => ::std::result::Result::Ok(value),
-                            ::std::result::Result::Err(e) => ::std::result::Result::Err(
-                                #zbus::object_server::IntoDBusError::into_dbus_error(e),
-                            ),
+                            ::std::result::Result::Ok(value) => value,
+                            ::std::result::Result::Err(e) => {
+                                return ::std::result::Result::Err(
+                                    #zbus::object_server::IntoDBusError::into_error(e),
+                                );
+                            }
                         })
                     } else {
-                        quote!(::std::result::Result::Ok(self.#ident(#args_names)#method_await))
+                        quote!(self.#ident(#args_names)#method_await)
                     };
 
                     if p.emits_changed_signal == PropertyEmitsChangedSignal::True {
-                        let prop_ty = p.ty.as_ref().unwrap();
                         let changed_doc = format!(
                             "Emit the “PropertiesChanged” signal with the new value for the\n\
                              `{member_name}` property.\n\n\
                              This method should be called if a property value changes outside\n\
                              its setter method."
                         );
-                        // The value is fetched through a hidden method so that the generated
-                        // setter can emit the signal too while keeping the getter's error
-                        // typed. The public helper returns `zbus::Result`, which cannot carry
-                        // an arbitrary `DBusError`, so it reports the getter's failure as
-                        // `Error::Failure` with the error's name and description as its text.
                         let prop_changed_method = quote!(
-                            #[doc(hidden)]
-                            pub async fn #prop_value_method_name(
-                                &self,
-                                __zbus__signal_emitter: &#zbus::object_server::SignalEmitter<'_>,
-                            ) -> ::std::result::Result<#prop_ty, #zbus::BoxDBusError> {
-                                let __zbus__header = ::std::option::Option::None::<&#zbus::message::Header<'_>>;
-                                let __zbus__connection = __zbus__signal_emitter.connection();
-                                let __zbus__object_server = __zbus__connection.object_server();
-                                #args_from_msg
-                                #prop_value
-                            }
-
                             #[doc = #changed_doc]
                             pub async fn #prop_changed_method_name(
                                 &self,
                                 __zbus__signal_emitter: &#zbus::object_server::SignalEmitter<'_>,
                             ) -> #zbus::Result<()> {
-                                let value = self
-                                    .#prop_value_method_name(__zbus__signal_emitter)
-                                    .await
-                                    .map_err(|e| #zbus::Error::Failure(
-                                        ::std::string::ToString::to_string(&e),
-                                    ))?;
-                                #emit_changed
+                                let __zbus__header = ::std::option::Option::None::<&#zbus::message::Header<'_>>;
+                                let __zbus__connection = __zbus__signal_emitter.connection();
+                                let __zbus__object_server = __zbus__connection.object_server();
+                                #args_from_msg
+                                let value = #prop_value_handled;
+                                let mut changed = ::std::collections::HashMap::new();
+                                changed.insert(
+                                    #member_name,
+                                    #zbus::as_value::Serialize(&value),
+                                );
+                                __zbus__signal_emitter.emit(
+                                    "org.freedesktop.DBus.Properties",
+                                    "PropertiesChanged",
+                                    &(
+                                        #zbus::names::InterfaceName::from_static_str_unchecked(
+                                            #iface_name,
+                                        ),
+                                        changed,
+                                        ::std::borrow::Cow::<[&str]>::Borrowed(&[]),
+                                    ),
+                                ).await
                             }
                         );
 


### PR DESCRIPTION
Follow-up to #1950. A property getter may fail with any `DBusError`, but the `<property>_changed` helper that `#[interface]` generates returns `zbus::Result<()>`, and `zbus::Error` could only carry an `fdo::Error`. The helper therefore flattened a getter's failure into `Error::Failure` text, and the generated setter needed a hidden `__zbus_<property>_value` method to keep the getter's error name in its `Set` reply.

This adds `Error::DBus(Arc<dyn DBusError + Send + Sync>)` (an `Arc` because `Error` is `Clone`, like `Error::InputOutput`). The helper reports a failing getter as that variant with name, description and reply body intact, the setter calls the helper again, and the hidden method is gone. The `DBusError` derive maps the new variant by name the way it maps `Error::FDO`, so `fdo::Error::from` and a custom error's `From<zbus::Error>` recover the typed error.

The e2e test calls the helper on the two properties whose getter fails and checks the error converts back to the standard and the custom error; a unit test covers the `fdo::Error` conversion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLGqZvo2MX7FNACCSAASSM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLGqZvo2MX7FNACCSAASSM)_