### PR TITLE
👷 ci: Run each test feature set as its own job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -110,6 +110,18 @@ jobs:
   linux_test:
     runs-on: ubuntu-latest
     needs: [fmt, clippy]
+    strategy:
+      fail-fast: false
+      matrix:
+        # Every suite builds the workspace with a different feature set, so they run as
+        # separate jobs, in parallel, each with a dependency cache of its own.
+        suite:
+          - all-features
+          - default
+          - async-io
+          - tokio
+          - tokio-async-io
+          - wire
     env:
       RUSTFLAGS: -D warnings
       RUST_BACKTRACE: full
@@ -123,52 +135,41 @@ jobs:
           sed -e s/UID/$UID/ -e s/PATH/abstract/ CI/dbus-session.conf > /tmp/dbus-session-abstract.conf
           sudo apt-get update
           sudo apt-get install -y dbus ibus
+          # Start IBus daemon for IBus test.
+          ibus-daemon -d --xim
+          sleep 2
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
-      - name: Test zbus with zbus_utils/gvariant enabled (zgvariant coexistence)
+        with:
+          # The dependencies are compiled with a different feature set in every suite, so a
+          # shared cache would only ever hold the set of the suite that saved it.
+          key: ${{ matrix.suite }}
+          cache-on-failure: true
+      - name: Test all workspace features together
+        if: matrix.suite == 'all-features'
         run: |
-          # Simulates the graph a zgvariant 2.0 dependency creates: it turns the shared crate's
-          # `gvariant` feature on, and Cargo unification hands zbus the extra signature and
-          # format variants it must keep rejecting.
-          cargo --locked test -p zbus --no-default-features --features zbus_utils/gvariant
-          # The same graph with the D-Bus API on: the message header carries a body signature
-          # that must be rejected too.
-          cargo --locked test -p zbus --no-default-features --features zbus_utils/gvariant,async-io
-      - name: Build and Test
-        run: |
-          dbus-run-session --config-file /tmp/dbus-session-abstract.conf -- cargo --locked test --release --verbose -- basic_connection
-          # Start IBus daemon for IBus test.
-          ibus-daemon -d --xim
-          sleep 2
-          # Test all workspace features together.
           dbus-run-session --config-file /tmp/dbus-session.conf -- \
             cargo --locked test --release --verbose --all-features \
               -- --skip fdpass_systemd
-          # Test the full zbus suite with async-io but without Tokio.
+      - name: Test the default features over an abstract socket
+        if: matrix.suite == 'default'
+        run: |
+          dbus-run-session --config-file /tmp/dbus-session-abstract.conf -- \
+            cargo --locked test --release --verbose -- basic_connection
+      - name: Test the full zbus suite with async-io but without Tokio
+        if: matrix.suite == 'async-io'
+        run: |
           dbus-run-session --config-file /tmp/dbus-session.conf -- \
             cargo --locked test --release --verbose -p zbus \
               --features uuid,url,time,chrono,option-as-array,vsock,bus-impl \
               -- --skip fdpass_systemd
-          # Test tokio support.
-          dbus-run-session --config-file /tmp/dbus-session.conf -- \
-            cargo --locked test --release --verbose --tests -p zbus --no-default-features \
-              --features tokio-vsock,proxy,service -- --skip fdpass_systemd
-          # Test tokio and async-io enabled together (additive features): the backend is then
-          # chosen at run time. `vsock` is included as it pulls in `async-io` alongside `tokio`.
-          dbus-run-session --config-file /tmp/dbus-session.conf -- \
-            cargo --locked test --release --verbose -p zbus --features tokio,p2p,vsock \
-              -- --skip fdpass_systemd
-          # The executor doctest drives the connection from tokio's scheduler, so it has to build
-          # without the default async-io runtime. `-p zbus` is load-bearing: a workspace-wide
-          # `--no-default-features` is undone by zbus_xmlgen's default-featured zbus dependency.
-          dbus-run-session --config-file /tmp/dbus-session.conf -- \
-            cargo --locked test --release --verbose --doc -p zbus --no-default-features \
-              --features tokio,service connection::Connection::executor
-          # The doc examples with the proxy or service API disabled, with and without the blocking
-          # API.
+      - name: Test the doc examples with the proxy or service API disabled
+        if: matrix.suite == 'async-io'
+        run: |
+          # With and without the blocking API.
           dbus-run-session --config-file /tmp/dbus-session.conf -- \
             cargo --locked test --release --verbose --doc -p zbus --no-default-features \
               --features async-io,proxy
@@ -181,15 +182,57 @@ jobs:
           dbus-run-session --config-file /tmp/dbus-session.conf -- \
             cargo --locked test --release --verbose --doc -p zbus --no-default-features \
               --features async-io,blocking-api,service
-          # The wire-format-only build. No D-Bus API, so no session bus is needed.
+      - name: Test tokio support
+        if: matrix.suite == 'tokio'
+        run: |
+          dbus-run-session --config-file /tmp/dbus-session.conf -- \
+            cargo --locked test --release --verbose --tests -p zbus --no-default-features \
+              --features tokio-vsock,proxy,service -- --skip fdpass_systemd
+          # The executor doctest drives the connection from tokio's scheduler, so it has to build
+          # without the default async-io runtime. `-p zbus` is load-bearing: a workspace-wide
+          # `--no-default-features` is undone by zbus_xmlgen's default-featured zbus dependency.
+          dbus-run-session --config-file /tmp/dbus-session.conf -- \
+            cargo --locked test --release --verbose --doc -p zbus --no-default-features \
+              --features tokio,service connection::Connection::executor
+      - name: Test tokio and async-io enabled together
+        if: matrix.suite == 'tokio-async-io'
+        run: |
+          # The features are additive, so the backend is then chosen at run time. `vsock` is
+          # included as it pulls in `async-io` alongside `tokio`.
+          dbus-run-session --config-file /tmp/dbus-session.conf -- \
+            cargo --locked test --release --verbose -p zbus --features tokio,p2p,vsock \
+              -- --skip fdpass_systemd
+      - name: Test the wire-format-only build
+        if: matrix.suite == 'wire'
+        run: |
+          # No D-Bus API, so no session bus is needed.
           cargo --locked test --release --verbose -p zbus --no-default-features
           cargo --locked test --release --verbose -p zbus --no-default-features \
             --features arrayvec,camino,chrono,enumflags2,heapless \
             --features option-as-array,serde_bytes,time,url,uuid
+      - name: Test zbus with zbus_utils/gvariant enabled (zgvariant coexistence)
+        if: matrix.suite == 'wire'
+        run: |
+          # Simulates the graph a zgvariant 2.0 dependency creates: it turns the shared crate's
+          # `gvariant` feature on, and Cargo unification hands zbus the extra signature and
+          # format variants it must keep rejecting.
+          cargo --locked test -p zbus --no-default-features --features zbus_utils/gvariant
+          # The same graph with the D-Bus API on: the message header carries a body signature
+          # that must be rejected too.
+          dbus-run-session --config-file /tmp/dbus-session.conf -- \
+            cargo --locked test -p zbus --no-default-features --features zbus_utils/gvariant,async-io
 
   windows_test:
     runs-on: windows-latest
     needs: [fmt, clippy]
+    strategy:
+      fail-fast: false
+      matrix:
+        # The two suites build zbus with different feature sets, so they run as separate jobs,
+        # in parallel, each with a dependency cache of its own.
+        suite:
+          - default
+          - no-default-features
     env:
       RUSTFLAGS: -D warnings
       RUST_BACKTRACE: full
@@ -228,11 +271,22 @@ jobs:
           toolchain: stable
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
-      - name: Test
+        with:
+          # The dependencies are compiled with a different feature set in every suite, so a
+          # shared cache would only ever hold the set of the suite that saved it.
+          key: ${{ matrix.suite }}
+          cache-on-failure: true
+      - name: Test the default features
+        if: matrix.suite == 'default'
         run: |
           $PSNativeCommandUseErrorActionPreference = $true
           Start-Process C:\vcpkg\installed\x64-windows\tools\dbus\dbus-daemon.exe '--config-file=CI/win32-session.conf --address=autolaunch:'
           cargo --locked test
+      - name: Test the tokio-only and wire-format-only builds
+        if: matrix.suite == 'no-default-features'
+        run: |
+          $PSNativeCommandUseErrorActionPreference = $true
+          Start-Process C:\vcpkg\installed\x64-windows\tools\dbus\dbus-daemon.exe '--config-file=CI/win32-session.conf --address=autolaunch:'
           # The tokio-only build. `-p zbus` is load-bearing: a workspace-wide
           # `--no-default-features` is undone by zbus_xmlgen's default-featured zbus dependency.
           # `--tests` because the doc examples assume the async-io runtime.


### PR DESCRIPTION
The Linux test job runs the suite eleven times in sequence, once per feature set, and every run recompiles the workspace crates in release mode. Dependency caching already works (the logs show only workspace crates compiling), so the ~12 minutes are pure serialized workspace builds. The whole workflow takes ~15 minutes while every other job finishes within three.

This turns `linux_test` and `windows_test` into matrices, one suite per feature set (the cheap doc-test and wire-format-only runs are grouped with a related suite), so the builds run in parallel:

| Linux suite | What it runs | Build time on `main` |
|---|---|---|
| `all-features` | workspace `--all-features` | 2:36 |
| `default` | `basic_connection` over an abstract socket | 1:54 |
| `async-io` | zbus without tokio, plus the four proxy/service doc-test variants | 1:47 + 0:52 |
| `tokio` | `tokio-vsock,proxy,service`, plus the executor doctest | 1:14 + 0:13 |
| `tokio-async-io` | `tokio,p2p,vsock` | 2:04 |
| `wire` | wire-format-only builds and the zgvariant coexistence runs | 0:47 + 0:22 |

Windows splits into `default` and `no-default-features` (tokio-only and wire-format-only).

Each suite gets its own `rust-cache` entry via `key: ${{ matrix.suite }}`. Without that, all matrix jobs share one key and only the first to save wins, so the other feature sets' dependencies are never cached. `cache-on-failure` is on since a failing test does not invalidate compiled dependencies, and `fail-fast` is off so one failing suite does not cancel the others.

The zgvariant coexistence run with `async-io` used to rely on the runner's own user session bus; it now runs under `dbus-run-session` like the other bus-using runs.

## Measured on this PR

Two attempts of [the same run](https://github.com/z-galaxy/zbus/actions/runs/34162889114): attempt 1 with cold caches (every suite logged `No cache found` under its new key, then saved), attempt 2 after a re-run, where every suite logged `Restored from cache key "v0-rust-<suite>-…" full match: true`.

| | Before (`main`) | Attempt 1 (cold) | Attempt 2 (warm) |
|---|---|---|---|
| Whole workflow | 15:28 | 6:40 | 5:39 |
| Longest Linux job | 12:42 | 4:18 (`all-features`) | 3:25 (`all-features`) |
| Longest Windows job | 4:48 | 4:39 (`no-default-features`) | 3:16 (`no-default-features`) |

Warm per-job times: Linux `all-features` 3:25, `async-io` 2:50, `tokio-async-io` 2:41, `default` 2:30, `tokio` 1:57, `wire` 1:52; Windows `no-default-features` 3:16, `default` 2:46. The remaining gate is `needs: [fmt, clippy]` (~2 minutes on the critical path), which I left in place since it saves runner time on PRs that fail lint.

The workflow passes `actionlint`, and the `wire`, `tokio` and `default` suite commands pass locally under `dbus-run-session` (except `fdpass_systemd`, which needs a system bus this container lacks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNpakxPg7pnvYxxfGentyT