### PR TITLE
🚸 zb,zm: Defer builder conversion errors to build()

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ impl Greeter {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let greeter = Greeter { count: 0 };
-    let _conn = connection::Builder::session()?
-        .name("org.zbus.MyGreeter")?
-        .serve_at("/org/zbus/MyGreeter", greeter)?
+    let _conn = connection::Builder::session()
+        .name("org.zbus.MyGreeter")
+        .serve_at("/org/zbus/MyGreeter", greeter)
         .build()
         .await?;
 

--- a/book/src/blocking.md
+++ b/book/src/blocking.md
@@ -84,7 +84,6 @@ let args = signal.args().unwrap();
 
 let location = LocationProxyBlocking::builder(&conn)
     .path(args.new())
-    .unwrap()
     .build()
     .unwrap();
 println!(

--- a/book/src/blocking.md
+++ b/book/src/blocking.md
@@ -189,9 +189,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         done: event_listener::Event::new(),
     };
     let done_listener = greeter.done.listen();
-    let _handle = connection::Builder::session()?
-        .name("org.zbus.MyGreeter")?
-        .serve_at("/org/zbus/MyGreeter", greeter)?
+    let _handle = connection::Builder::session()
+        .name("org.zbus.MyGreeter")
+        .serve_at("/org/zbus/MyGreeter", greeter)
         .build()?;
 
     done_listener.wait();

--- a/book/src/client.md
+++ b/book/src/client.md
@@ -257,8 +257,8 @@ async fn main() -> Result<()> {
     client.set_desktop_id("org.freedesktop.zbus").await?;
 
     let props = zbus::fdo::PropertiesProxy::builder(&conn)
-        .destination("org.freedesktop.GeoClue2")?
-        .path(client.inner().path())?
+        .destination("org.freedesktop.GeoClue2")
+        .path(client.inner().path())
         .build()
         .await?;
     let mut props_changed = props.receive_properties_changed().await?;
@@ -283,7 +283,7 @@ async fn main() -> Result<()> {
                 let args = signal.args()?;
 
                 let location = LocationProxy::builder(&conn)
-                    .path(args.new())?
+                    .path(args.new())
                     .build()
                     .await?;
                 println!(

--- a/book/src/connection.md
+++ b/book/src/connection.md
@@ -54,7 +54,7 @@ let (client_conn, server_conn) = futures_util::try_join!(
     // Client
     Builder::async_io_unix_stream(p0).p2p().build(),
     // Server
-    Builder::async_io_unix_stream(p1).server(guid)?.p2p().build(),
+    Builder::async_io_unix_stream(p1).server(guid).p2p().build(),
 )?;
 # }
 #

--- a/book/src/service.md
+++ b/book/src/service.md
@@ -166,9 +166,9 @@ setting up your interfaces and requesting names, and not have to care about this
 #
 # #[tokio::main]
 # async fn main() -> Result<()> {
-    let _connection = connection::Builder::session()?
-        .name("org.zbus.MyGreeter")?
-        .serve_at("/org/zbus/MyGreeter", Greeter)?
+    let _connection = connection::Builder::session()
+        .name("org.zbus.MyGreeter")
+        .serve_at("/org/zbus/MyGreeter", Greeter)
         .build()
         .await?;
 #     loop {
@@ -264,9 +264,9 @@ async fn main() -> Result<()> {
         done: event_listener::Event::new(),
     };
     let done_listener = greeter.done.listen();
-    let connection = Builder::session()?
-        .name("org.zbus.MyGreeter")?
-        .serve_at("/org/zbus/MyGreeter", greeter)?
+    let connection = Builder::session()
+        .name("org.zbus.MyGreeter")
+        .serve_at("/org/zbus/MyGreeter", greeter)
         .build()
         .await?;
 
@@ -416,9 +416,9 @@ impl Greeter {
 # async fn main() -> zbus::Result<()> {
 
 let greeter = Greeter { name: "GreeterName".to_string() };
-let connection = zbus::connection::Builder::session()?
-        .name("org.zbus.MyGreeter.WithProxy")?
-        .serve_at("/org/zbus/MyGreeter/WithProxy", greeter)?
+let connection = zbus::connection::Builder::session()
+        .name("org.zbus.MyGreeter.WithProxy")
+        .serve_at("/org/zbus/MyGreeter/WithProxy", greeter)
         .build()
         .await?;
 let proxy = GreeterProxy::new(&connection).await?;

--- a/book/src/upgrading-to-6.md
+++ b/book/src/upgrading-to-6.md
@@ -318,6 +318,67 @@ The compatibility module is removed in zbus 7.0.
 Seven more things break in 6.0 without being a consequence of the crate merge. They reach code
 that never mentioned `zvariant` or `zbus_names`.
 
+### Builder setters defer their errors to `build()`
+
+Every builder setter generic over `TryInto` (a D-Bus name, an object path, a GUID, an address)
+used to convert its argument on the spot and return `Result<Self>`, forcing a `?` after every
+call in the chain even when the argument was an already-typed value that could not fail to
+convert. Setters now return `Self` and the builder records the first error one of them hits;
+`build()` returns that error, so a whole chain built from string arguments needs exactly one
+`?`, at the end. Nothing clears a recorded error, so calling a setter again with a valid value
+does not rescue a chain that has already passed an invalid one.
+
+Before, this no longer compiles:
+
+```rust,compile_fail,noplayground
+use zbus::Message;
+
+fn make_message() -> zbus::Result<Message> {
+    Message::method_call("/org/zbus/Test", "Test")?
+        .destination("org.zbus.Test")?
+        .build(&())
+}
+```
+
+After:
+
+```rust,noplayground
+use zbus::Message;
+
+fn make_message() -> zbus::Result<Message> {
+    Message::method_call("/org/zbus/Test", "Test")
+        .destination("org.zbus.Test")
+        .build(&())
+}
+```
+
+This covers `message::Builder` and the `Message::method_call`, `Message::signal`,
+`Message::error` and `Message::method_return` constructors that create it; `proxy::Builder`;
+`connection::Builder` and its `session`, `system`, `ibus`, `address` and `authenticated_socket`
+constructors; and the blocking proxy and connection builders. `match_rule::Builder::build()`
+moves the other way: it used to be infallible and now returns `Result<MatchRule<'_>>`, since it
+is the one builder whose fields were already fully validated by the time `build()` ran.
+
+To migrate:
+
+* Remove the `?` (or `.unwrap()`/`.expect(...)`) after every builder setter call.
+* Remove the `?` after `Message::method_call`, `Message::signal`, `Message::error` and
+  `Message::method_return`.
+* Remove the `?` after the `connection::Builder` constructors (`session`, `system`, `ibus`,
+  `address`, `authenticated_socket`) and after `server`, `serve_at`, `name` and `unique_name`.
+* Add a `?` after `MatchRule::builder()...build()`, which is now fallible.
+
+| Before | After |
+| --- | --- |
+| `.path("/org/zbus/Foo")?` | `.path("/org/zbus/Foo")` |
+| `Message::method_call("/", "Ping")?` | `Message::method_call("/", "Ping")` |
+| `MatchRule::builder().build()` | `MatchRule::builder().build()?` |
+
+A stale `?` left after a setter fails to compile with "the `?` operator can only be applied to
+values that implement `Try`", pointing straight at the call site to clean up. A missing `?`
+after `MatchRule::builder()...build()` fails the opposite way, with a type mismatch between
+`MatchRule` and whatever type the rest of the function expected. Both are one-line fixes.
+
 ### Property methods use Serde traits
 
 Property APIs now use the same Serde traits and `Type` bounds as regular methods. Client-side

--- a/docs/superpowers/specs/2026-09-07-infallible-builder-setters-design.md
+++ b/docs/superpowers/specs/2026-09-07-infallible-builder-setters-design.md
@@ -1,0 +1,248 @@
+# Deferred builder errors — design
+
+Resolves z-galaxy/zbus#403 ("Error handling when creating instances via a builder") for the
+zbus 6.0 major release.
+
+## The problem
+
+Every builder method that takes a D-Bus name, object path, GUID or address is generic over
+`TryInto` and returns `Result<Self>`, so a caller writes `?` (or `.expect("cannot fail")`) after
+each call even when the argument is already a validated `ObjectPath`, `BusName` or similar:
+
+```rust
+let proxy = PropertiesProxy::builder(&conn)
+    .destination(proxy.destination())?   // &BusName: cannot fail
+    .path(proxy.path())?                 // &ObjectPath: cannot fail
+    .build()
+    .await?;
+```
+
+Everything that can fail *before* `build()` today:
+
+- `proxy::Builder` (and its `blocking` wrapper): `destination`, `path`, `interface`.
+- `match_rule::Builder`: `sender`, `interface`, `member`, `path`, `path_namespace`,
+  `destination`; also `arg`, `add_arg`, `arg_path`, `add_arg_path` (64-argument limit) and
+  `arg0ns` (namespace rules), which fail for another reason.
+- `message::Builder`: the `Message::method_call`, `Message::signal`, `Message::error` and
+  `Message::method_return` constructors, `sender`, `path`, `interface`, `member`, `destination`;
+  also `with_flags`, which fails for another reason (flag/type mismatch).
+- `connection::Builder` (and its `blocking` wrapper): the `address` and `authenticated_socket`
+  constructors, `server`, `serve_at`, `name`, `unique_name`; also `session`, `system` and
+  `ibus`, which fail for another reason (environment lookup).
+
+The functions outside the builders that take `TryInto` arguments — `Proxy::new`,
+`Connection::call_method`, `ObjectServer::at`, `SignalEmitter::new`, … — fail for other reasons
+too (I/O, missing objects) and are not part of the problem.
+
+## Constraints
+
+- 6.0 is unreleased on `main`, so this is the API-break window the issue was deferred to in
+  2023. The upgrade guide promises a mechanical migration; every change here must be one the
+  compiler points at and a one-token edit fixes.
+- Strings stay accepted. Literals are the majority input (the issue's i3status-rust census: 11 of
+  20 arguments were literals or `String`s) and the `#[proxy]` macro's generated `new()` takes
+  generic `TryInto` arguments.
+- MSRV 1.87, no new dependencies, no type-system machinery that leaks into rustdoc.
+
+## Decision
+
+Every builder setter and constructor keeps its zbus 5 generic signature:
+
+```rust
+pub fn path<P>(mut self, path: P) -> Self
+where
+    P: TryInto<ObjectPath<'a>>,
+    P::Error: Into<Error>,
+```
+
+Only the return type changes, from `Result<Self>` to `Self`. The conversion still happens
+immediately, inside the setter, but its outcome no longer travels back to the caller: a
+converted value goes into the field it belongs to, and a conversion error goes into the one
+`error: Option<Error>` the builder keeps, which only the first error to arrive fills. Nothing
+clears it afterwards — not a later call to the same setter, not the sibling that overrides it
+(`path` and `path_namespace`, `session` and `address`), not a valid value passed to any other
+setter — so whether a setter replaces its field (`path`) or adds to it (`add_arg`, `name`,
+`serve_at`, `with_flags`) makes no difference to the error. `build()` returns the recorded error
+before it does anything else, with the same error value it would have returned eagerly today;
+only the point where the error surfaces moves.
+
+`Message::method_call`, `Message::signal`, `Message::error` and `Message::method_return` return
+the builder directly, no `Result` involved. `match_rule::Builder::build()`
+becomes fallible, returning `Result<MatchRule<'m>>`: it is the one builder whose `build()` was
+previously infallible, because every field was already validated by the time it ran.
+`MatchRule::try_from(&str)` keeps validating each of its components itself (`BusName::try_from`,
+`ObjectPath::try_from`, …) before handing the typed value to the corresponding setter, so a bad
+rule string reports the same parser error it does today. Generic code — `Proxy::new`,
+`Connection::call_method`, the `#[proxy]`-generated `new()` — keeps its `TryInto` bounds
+unchanged and simply drops the `?` after each setter call. There are no `try_`-prefixed twins
+anywhere in this design.
+
+Before, with string arguments:
+
+```rust
+let proxy = PropertiesProxy::builder(&conn)
+    .destination("org.zbus.Foo")?
+    .path("/org/zbus/Foo")?
+    .build()
+    .await?;
+```
+
+After:
+
+```rust
+let proxy = PropertiesProxy::builder(&conn)
+    .destination("org.zbus.Foo")
+    .path("/org/zbus/Foo")
+    .build()
+    .await?;
+```
+
+Before, with already-typed arguments:
+
+```rust
+let proxy = PropertiesProxy::builder(&conn)
+    .destination(proxy.destination())?   // &BusName: cannot fail
+    .path(proxy.path())?                 // &ObjectPath: cannot fail
+    .build()
+    .await?;
+```
+
+After:
+
+```rust
+let proxy = PropertiesProxy::builder(&conn)
+    .destination(proxy.destination())   // &BusName: still cannot fail
+    .path(proxy.path())                 // &ObjectPath: still cannot fail
+    .build()
+    .await?;
+```
+
+Both callers end up with exactly one `?`, at `build()`, regardless of whether their arguments
+were strings or typed values.
+
+## Why
+
+Strings are the majority of real call sites, not the exception. A design that keeps setters
+eager and adds a `try_`-prefixed fallible twin makes the common, string-passing caller rename
+every call to `try_` and keep the `?` it already had, while only the minority typed-argument
+caller gets to drop anything — it optimizes for the minority case and adds typing (a renamed
+method, an extra character) for the majority. Deferring the error instead gives every caller,
+string or typed, exactly one `?`, at `build()`, which is also where three of the four builders
+(`proxy::Builder`, `message::Builder`, `connection::Builder`) already return `Result` today.
+
+The sticky-state objection that the first draft of this spec raised against deferred errors —
+that a corrected later call would not clear an earlier error — is accepted rather than
+engineered away. An error per field, replaced whenever that field is set again, would buy a
+recovery path for a chain no correct program writes: an invalid value reaching a setter is a bug
+in the caller to fix, not a state to recover from at run time. One error per builder is less to
+implement, less to document and less to read, and it is the design the maintainer chose. Parser
+error identity for `MatchRule::try_from(&str)` is preserved for the same reason it always was: the
+parser validates each component itself before it ever touches a setter, so the error a bad rule
+string produces does not depend on which setter deferred errors internally. And the error values
+themselves are unchanged: `build()` returns exactly the error a setter would have returned
+eagerly today, just later; today's eager errors do not carry the name of the setter that
+produced them either, so nothing is lost on that front.
+
+## Costs accepted
+
+- `MatchRule::builder().build()` now returns `Result`, even for a chain built entirely from
+  already-typed arguments that could not have failed.
+- An error surfaces at `build()` — or at the connection builder's `build().await` — instead of
+  at the call site that actually caused it.
+- The setter signature alone no longer shows whether it can fail: `path<P>(self, path: P) -> Self`
+  gives no hint. `build()`'s `# Errors` section documents the deferral once per builder, and each
+  fallible setter's own doc gets one sentence pointing at it.
+- The recorded error is sticky: calling the same setter again with a valid value does not clear
+  it and `build()` still fails. The way out is to fix the invalid value in the chain.
+
+## Migration
+
+The migration is mechanical and compiler-guided:
+
+- Remove the `?` (or `.expect(...)`) after every builder setter call.
+- Remove the `?` after `Message::method_call`, `Message::signal`, `Message::error` and
+  `Message::method_return`.
+- Remove the `?` after the `connection::Builder` constructors (`session`, `system`, `ibus`,
+  `address`, `authenticated_socket`) and after `server`, `serve_at`, `name` and
+  `unique_name`.
+- Add a `?` after `MatchRule::builder()...build()`, which is now fallible.
+
+Nothing else changes: argument types, generic bounds and error values are the same as today.
+
+| Before | After |
+|---|---|
+| `.path("/org/zbus/Foo")?` | `.path("/org/zbus/Foo")` |
+| `.path(object_path)?` or `.path(object_path).unwrap()` | `.path(object_path)` |
+| `Message::method_call("/", "Ping")?` | `Message::method_call("/", "Ping")` |
+| `MatchRule::builder().build()` | `MatchRule::builder().build()?` |
+
+A stale `?` left after a setter fails to compile with `the ? operator can only be applied to
+values that implement Try`, pointing straight at the call site to clean up. A missing `?` after
+`MatchRule::builder().build()` fails the opposite way, with a type mismatch between `MatchRule`
+and the value the rest of the function expects. Both are one-line fixes.
+
+## Alternatives considered
+
+**A. An infallible setter plus a `try_`-prefixed fallible twin.** Every setter would come in two
+forms: an infallible one taking `impl Into<T>` for already-typed values, and a `try_`-prefixed
+twin keeping the zbus 5 `TryInto` signature for strings and anything else needing validation,
+following the `from`/`try_from` convention. This was implemented in full, on all four builders
+and their blocking wrappers, with every in-tree caller, the README and the book migrated and the
+whole CI matrix passing. It was rejected because it optimizes for
+the minority of call sites: strings are the majority input (11 of 20 arguments in the
+i3status-rust census), and this design is the one that forces exactly those callers to rename to
+`try_` and keep their `?`, while adding a second method name and a naming convention that every
+future fallible setter has to follow. Deferred errors reach the same `?`-free result for typed
+arguments without a second method for anyone to learn.
+
+**B. One setter with a conditional return type.** A trait with a generic associated type
+(`type Output<B>`) would make `path(p)` return `Self` for typed input and `Result<Self>` for
+strings, so there would be only one setter name per field. This was prototyped and compiling,
+and it produced the smallest possible migration (only typed call sites would change at all). It
+was rejected because the signature renders as `-> P::Output<Self> where P: Convert<ObjectPath<'a>>`,
+which says nothing about when the call can fail; it needs one blanket impl plus around 55
+concrete impls the crate would commit to forever; generic code cannot use `?` on the projected
+type and would need to learn a `try_convert()`-first rule instead; the blanket `Into` impl stops
+`try_into()` from inferring its target type from the setter that follows it; downstream types
+that only implement `TryFrom<Their> for ObjectPath` would lose the setter entirely; and
+multi-argument constructors such as `Message::method_call(path, member)` cannot use this shape at
+all. No published crate exposes anything like it. The maintainer called this idea "a bit too
+complicated" when the issue was first opened in 2023, and building it did not change that.
+
+**C. Additive infallible setters under another name.** Give the infallible, typed-argument path a
+distinct name instead of overloading the existing one — `raw_path`, `path_typed`, and so on —
+leaving the original fallible setter untouched. This has zero migration cost, since nothing
+existing changes. It was rejected because the convention it relies on runs backwards: an
+ecosystem that marks one of two setters distinguishes the fallible one, not the infallible one,
+so callers who never learn about the second method keep writing `.expect("cannot fail")`
+indefinitely. The issue thread had already rejected the specific `raw_` prefix for the same
+reason.
+
+The first draft of this spec considered deferred errors and rejected them. Each objection it
+raised, revisited against the design above:
+
+- A stale error surviving after a later call fixes the field ("sticky state") is accepted as a
+  cost: the builder records the first error a setter hits and nothing clears it, because a chain
+  that passes an invalid value is a bug to fix rather than a state to recover from.
+- `MatchRule::try_from(&str)` reporting a different error for the same input depending on what
+  follows it in the string is resolved: the parser validates each component itself and calls the
+  typed setter, so parser errors do not depend on setter internals.
+- `MatchRule::builder().build()` becoming fallible for callers who never touched a fallible
+  setter is accepted as a cost.
+- A fully typed chain still ending in a `Result` is accepted as a cost.
+- Error locality dropping to a first-error-only error with no setter name attached does not
+  apply: the reported error carries the same value a setter would have returned eagerly today,
+  and today's eager errors do not carry a setter name either.
+- Needing a `# Errors` note on every `-> Self` setter is accepted, but reduced to one sentence per
+  setter, with the deferral mechanism itself documented once, on `build()`.
+
+## Follow-up, out of scope here
+
+**Compile-time validated literals.** `zbus::object_path!("/org/zbus/Foo")`,
+`zbus::names::interface_name!("org.zbus.Foo")` and siblings, backed by `const fn` validators,
+would make literals infallible too: `.path(object_path!("/org/zbus/Foo"))` with a compile error
+for a typo. The prototype rewrote the object-path and name validators as `const fn` byte loops
+(0 mismatches against the winnow parsers over ~2.2M random and boundary inputs, winnow dropped
+from the wire and names code) and showed `#[proxy]` can emit the macros for its `default_*`
+literals. It is orthogonal to the setter design, has its own review surface, and lands as a
+separate PR.

--- a/zbus/README.md
+++ b/zbus/README.md
@@ -66,9 +66,9 @@ impl Greeter {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let greeter = Greeter { count: 0 };
-    let _conn = connection::Builder::session()?
-        .name("org.zbus.MyGreeter")?
-        .serve_at("/org/zbus/MyGreeter", greeter)?
+    let _conn = connection::Builder::session()
+        .name("org.zbus.MyGreeter")
+        .serve_at("/org/zbus/MyGreeter", greeter)
         .build()
         .await?;
 

--- a/zbus/benches/benchmarks.rs
+++ b/zbus/benches/benchmarks.rs
@@ -56,22 +56,16 @@ fn msg_de(c: &mut Criterion) {
 
 fn empty_message() -> Message {
     Message::method_call("/org/freedesktop/DBus/Something", "Ping")
-        .unwrap()
         .destination("org.freedesktop.DBus.Something")
-        .unwrap()
         .interface("org.freedesktop.DBus.Something")
-        .unwrap()
         .build(&())
         .unwrap()
 }
 
 fn big_boy_message(big_boy: &BigBoy<'_>) -> Message {
     Message::method_call("/org/freedesktop/DBus/Something", "Ping")
-        .unwrap()
         .destination("org.freedesktop.DBus.Something")
-        .unwrap()
         .interface("org.freedesktop.DBus.Something")
-        .unwrap()
         .build(&big_boy)
         .unwrap()
 }

--- a/zbus/benches/concurrent_method_calls.rs
+++ b/zbus/benches/concurrent_method_calls.rs
@@ -21,13 +21,10 @@ async fn create_benchmark_connection_pair() -> (zbus::Connection, zbus::Connecti
     let guid = zbus::Guid::generate();
 
     let server = zbus::connection::Builder::authenticated_socket(server_socket, guid.clone())
-        .unwrap()
         .p2p()
         .serve_at(BENCHMARK_PATH, BenchmarkInterface)
-        .unwrap()
         .build();
     let client = zbus::connection::Builder::authenticated_socket(client_socket, guid)
-        .unwrap()
         .p2p()
         .method_timeout(std::time::Duration::from_secs(30))
         .build();

--- a/zbus/src/address/transport/ibus.rs
+++ b/zbus/src/address/transport/ibus.rs
@@ -56,7 +56,7 @@ impl Ibus {
     /// #
     /// # block_on(async {
     /// // This method is used internally by the connection builder
-    /// let _conn = Builder::ibus()?.build().await?;
+    /// let _conn = Builder::ibus().build().await?;
     /// # Ok::<(), zbus::Error>(())
     /// # }).unwrap();
     /// ```

--- a/zbus/src/blocking/connection/builder.rs
+++ b/zbus/src/blocking/connection/builder.rs
@@ -16,19 +16,27 @@ use crate::{
 use crate::{ObjectPath, object_server::Interface};
 
 /// A builder for [`zbus::blocking::Connection`].
+///
+/// The constructors and setters take the same loosely typed values as the rest of the API and
+/// convert them right away, but they never fail: the first error one hits is recorded — a later
+/// call doesn't clear it — and reported by [`Builder::build`].
 #[derive(Debug)]
 #[must_use]
 pub struct Builder<'a>(crate::connection::Builder<'a>);
 
 impl<'a> Builder<'a> {
     /// Create a builder for the session/user message bus connection.
-    pub fn session() -> Result<Self> {
-        crate::connection::Builder::session().map(Self)
+    ///
+    /// A failure to find the session bus address is reported by [`Builder::build`].
+    pub fn session() -> Self {
+        Self(crate::connection::Builder::session())
     }
 
     /// Create a builder for the system-wide message bus connection.
-    pub fn system() -> Result<Self> {
-        crate::connection::Builder::system().map(Self)
+    ///
+    /// A failure to find the system bus address is reported by [`Builder::build`].
+    pub fn system() -> Self {
+        Self(crate::connection::Builder::system())
     }
 
     /// Create a builder for an IBus connection.
@@ -42,7 +50,7 @@ impl<'a> Builder<'a> {
     ///
     /// # Errors
     ///
-    /// Returns an error if:
+    /// [`Builder::build`] returns an error if:
     /// - The `ibus` command is not found or fails to execute
     /// - The IBus daemon is not running
     /// - The command output cannot be parsed as a valid D-Bus address
@@ -53,26 +61,28 @@ impl<'a> Builder<'a> {
     /// # use std::error::Error;
     /// # use zbus::blocking::connection;
     /// #
-    /// let _conn = connection::Builder::ibus()?
+    /// let _conn = connection::Builder::ibus()
     ///     .build()?;
     ///
     /// // Use the connection to interact with IBus services.
     /// # Ok::<_, Box<dyn Error + Send + Sync>>(())
     /// ```
     #[cfg(all(unix, feature = "ibus"))]
-    pub fn ibus() -> Result<Self> {
-        crate::connection::Builder::ibus().map(Self)
+    pub fn ibus() -> Self {
+        Self(crate::connection::Builder::ibus())
     }
 
     /// Create a builder for a connection that will use the given [D-Bus bus address].
     ///
+    /// An invalid address is reported by [`Builder::build`].
+    ///
     /// [D-Bus bus address]: https://dbus.freedesktop.org/doc/dbus-specification.html#addresses
-    pub fn address<A>(address: A) -> Result<Self>
+    pub fn address<A>(address: A) -> Self
     where
         A: TryInto<Address>,
         A::Error: Into<Error>,
     {
-        crate::connection::Builder::address(address).map(Self)
+        Self(crate::connection::Builder::address(address))
     }
 
     /// Create a builder for a connection that will use the given unix stream with `async-io`.
@@ -131,13 +141,17 @@ impl<'a> Builder<'a> {
     ///
     /// This is similar to [`Builder::socket`], except that the socket is either already
     /// authenticated or does not require authentication.
-    pub fn authenticated_socket<S, G>(socket: S, guid: G) -> Result<Self>
+    ///
+    /// An invalid GUID is reported by [`Builder::build`].
+    pub fn authenticated_socket<S, G>(socket: S, guid: G) -> Self
     where
         S: Into<BoxedSplit>,
         G: TryInto<crate::Guid<'a>>,
         G::Error: Into<Error>,
     {
-        crate::connection::Builder::authenticated_socket(socket, guid).map(Self)
+        Self(crate::connection::Builder::authenticated_socket(
+            socket, guid,
+        ))
     }
 
     /// Create a builder for a connection that will use the given socket.
@@ -178,13 +192,15 @@ impl<'a> Builder<'a> {
     /// **NOTE:** This method is redundant when using [`Builder::authenticated_socket`] since the
     /// latter already sets the GUID for the connection and zbus doesn't differentiate between a
     /// server and a client connection, except for authentication.
+    ///
+    /// An invalid GUID is reported by [`Builder::build`].
     #[cfg(feature = "p2p")]
-    pub fn server<G>(self, guid: G) -> Result<Self>
+    pub fn server<G>(self, guid: G) -> Self
     where
         G: TryInto<Guid<'a>>,
         G::Error: Into<Error>,
     {
-        self.0.server(guid).map(Self)
+        Self(self.0.server(guid))
     }
 
     /// Set the capacity of the main (unfiltered) queue.
@@ -198,7 +214,7 @@ impl<'a> Builder<'a> {
     /// # use std::error::Error;
     /// # use zbus::blocking::connection;
     /// #
-    /// let conn = connection::Builder::session()?
+    /// let conn = connection::Builder::session()
     ///     .max_queued(30)
     ///     .build()?;
     /// assert_eq!(conn.max_queued(), 30);
@@ -216,14 +232,16 @@ impl<'a> Builder<'a> {
     /// your interfaces available immediately after the connection is established. Typically, this
     /// is exactly what you'd want. Also in contrast to [`zbus::blocking::ObjectServer::at`], this
     /// method will replace any previously added interface with the same name at the same path.
+    ///
+    /// An invalid path is reported by [`Builder::build`].
     #[cfg(feature = "service")]
-    pub fn serve_at<P, I>(self, path: P, iface: I) -> Result<Self>
+    pub fn serve_at<P, I>(self, path: P, iface: I) -> Self
     where
         I: Interface,
         P: TryInto<ObjectPath<'a>>,
         P::Error: Into<Error>,
     {
-        self.0.serve_at(path, iface).map(Self)
+        Self(self.0.serve_at(path, iface))
     }
 
     /// Register a well-known name for this connection on the bus.
@@ -240,12 +258,14 @@ impl<'a> Builder<'a> {
         doc = "feature) are advertised. Typically"
     )]
     /// this is exactly what you want.
-    pub fn name<W>(self, well_known_name: W) -> Result<Self>
+    ///
+    /// An invalid name is reported by [`Builder::build`].
+    pub fn name<W>(self, well_known_name: W) -> Self
     where
         W: TryInto<WellKnownName<'a>>,
         W::Error: Into<Error>,
     {
-        self.0.name(well_known_name).map(Self)
+        Self(self.0.name(well_known_name))
     }
 
     /// Whether the [`zbus::fdo::RequestNameFlags::AllowReplacement`] flag will be set when
@@ -270,13 +290,15 @@ impl<'a> Builder<'a> {
     /// It will always panic if the connection is to a message bus as it's the bus that assigns
     /// peers their unique names. This is mainly provided for bus implementations. All other users
     /// should not need to use this method.
+    ///
+    /// An invalid name is reported by [`Builder::build`].
     #[cfg(feature = "bus-impl")]
-    pub fn unique_name<U>(self, unique_name: U) -> Result<Self>
+    pub fn unique_name<U>(self, unique_name: U) -> Self
     where
         U: TryInto<crate::names::UniqueName<'a>>,
         U::Error: Into<Error>,
     {
-        self.0.unique_name(unique_name).map(Self)
+        Self(self.0.unique_name(unique_name))
     }
 
     /// Set a timeout for method calls.
@@ -291,6 +313,9 @@ impl<'a> Builder<'a> {
     /// Build the connection, consuming the builder.
     ///
     /// # Errors
+    ///
+    /// Returns the first error recorded by a constructor or setter, then any error from
+    /// connecting, authenticating or setting the connection up.
     ///
     /// Until server-side bus connection is supported, attempting to build such a connection will
     /// result in a [`Error::Unsupported`] error.

--- a/zbus/src/blocking/connection/mod.rs
+++ b/zbus/src/blocking/connection/mod.rs
@@ -345,7 +345,7 @@ mod tests {
             let builder = Builder::async_io_unix_stream(p0);
             #[cfg(feature = "tokio")]
             let builder = Builder::tokio_unix_stream(p0);
-            let c = builder.server(guid).unwrap().p2p().build().unwrap();
+            let c = builder.server(guid).p2p().build().unwrap();
             rx.recv().unwrap();
             let reply = c
                 .call_method(None::<()>, "/", Some("org.zbus.p2p"), "Test", &())

--- a/zbus/src/blocking/message_iterator.rs
+++ b/zbus/src/blocking/message_iterator.rs
@@ -48,11 +48,11 @@ impl MessageIterator {
     /// let conn = Connection::session()?;
     /// let rule = MatchRule::builder()
     ///     .msg_type(zbus::message::Type::Signal)
-    ///     .sender("org.freedesktop.DBus")?
-    ///     .interface("org.freedesktop.DBus")?
-    ///     .member("NameOwnerChanged")?
-    ///     .add_arg("org.freedesktop.zbus.MatchRuleIteratorTest42")?
-    ///     .build();
+    ///     .sender("org.freedesktop.DBus")
+    ///     .interface("org.freedesktop.DBus")
+    ///     .member("NameOwnerChanged")
+    ///     .add_arg("org.freedesktop.zbus.MatchRuleIteratorTest42")
+    ///     .build()?;
     /// let mut iter = MessageIterator::for_match_rule(
     ///     rule,
     ///     &conn,

--- a/zbus/src/blocking/proxy/builder.rs
+++ b/zbus/src/blocking/proxy/builder.rs
@@ -21,6 +21,7 @@ impl<'a, T> Builder<'a, T> {
     /// Set the proxy destination address.
     ///
     /// An invalid destination is reported by [`Builder::build`].
+    #[must_use]
     pub fn destination<D>(self, destination: D) -> Self
     where
         D: TryInto<BusName<'a>>,
@@ -32,6 +33,7 @@ impl<'a, T> Builder<'a, T> {
     /// Set the proxy path.
     ///
     /// An invalid path is reported by [`Builder::build`].
+    #[must_use]
     pub fn path<P>(self, path: P) -> Self
     where
         P: TryInto<ObjectPath<'a>>,
@@ -43,6 +45,7 @@ impl<'a, T> Builder<'a, T> {
     /// Set the proxy interface.
     ///
     /// An invalid interface name is reported by [`Builder::build`].
+    #[must_use]
     pub fn interface<I>(self, interface: I) -> Self
     where
         I: TryInto<InterfaceName<'a>>,

--- a/zbus/src/blocking/proxy/builder.rs
+++ b/zbus/src/blocking/proxy/builder.rs
@@ -9,35 +9,46 @@ use crate::{
 pub use crate::proxy::Defaults;
 
 /// Builder for proxies.
+///
+/// Each setter takes the value it is given, whether that's an already parsed name or a string
+/// that still needs parsing, and converts it right away, but it never fails: the first error a
+/// setter hits is recorded — a later call doesn't clear it — and reported by [`Builder::build`],
+/// so a chain of setters never needs a `?` in between.
 #[derive(Debug, Clone)]
 pub struct Builder<'a, T = ()>(crate::proxy::Builder<'a, T>);
 
 impl<'a, T> Builder<'a, T> {
     /// Set the proxy destination address.
-    pub fn destination<D>(self, destination: D) -> Result<Self>
+    ///
+    /// An invalid destination is reported by [`Builder::build`].
+    pub fn destination<D>(self, destination: D) -> Self
     where
         D: TryInto<BusName<'a>>,
         D::Error: Into<Error>,
     {
-        crate::proxy::Builder::destination(self.0, destination).map(Self)
+        Self(crate::proxy::Builder::destination(self.0, destination))
     }
 
     /// Set the proxy path.
-    pub fn path<P>(self, path: P) -> Result<Self>
+    ///
+    /// An invalid path is reported by [`Builder::build`].
+    pub fn path<P>(self, path: P) -> Self
     where
         P: TryInto<ObjectPath<'a>>,
         P::Error: Into<Error>,
     {
-        crate::proxy::Builder::path(self.0, path).map(Self)
+        Self(crate::proxy::Builder::path(self.0, path))
     }
 
     /// Set the proxy interface.
-    pub fn interface<I>(self, interface: I) -> Result<Self>
+    ///
+    /// An invalid interface name is reported by [`Builder::build`].
+    pub fn interface<I>(self, interface: I) -> Self
     where
         I: TryInto<InterfaceName<'a>>,
         I::Error: Into<Error>,
     {
-        crate::proxy::Builder::interface(self.0, interface).map(Self)
+        Self(crate::proxy::Builder::interface(self.0, interface))
     }
 
     /// Set whether to cache properties.
@@ -54,9 +65,10 @@ impl<'a, T> Builder<'a, T> {
 
     /// Build a proxy from the builder.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the builder is lacking the necessary details to build a proxy.
+    /// The first error recorded by a setter, then [`Error::MissingParameter`] if the builder is
+    /// lacking the necessary parameters to build a proxy.
     pub fn build(self) -> Result<T>
     where
         T: From<crate::Proxy<'a>> + crate::proxy::Defaults,

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -82,9 +82,14 @@ type Interfaces<'a> = HashMap<ObjectPath<'a>, HashMap<InterfaceName<'static>, Ar
     doc = "   `fdo::NameAcquiredStream` (requires the `proxy` feature) is constructed. As a result",
     doc = "   the service can miss the `NameAcquired` signal."
 )]
+///
+/// The constructors and setters take the same loosely typed values as the rest of the API and
+/// convert them right away, but they never fail: the first error one hits is recorded — a later
+/// call doesn't clear it — and reported by [`Builder::build`].
 #[derive(Debug)]
 #[must_use]
 pub struct Builder<'a> {
+    // `None` only when a constructor recorded an error instead of working out a target.
     target: Option<Target>,
     max_queued: Option<usize>,
     // This is only set for p2p server case or pre-authenticated sockets.
@@ -101,17 +106,28 @@ pub struct Builder<'a> {
     request_name_flags: BitFlags<RequestNameFlags>,
     method_timeout: Option<std::time::Duration>,
     user_id: Option<u32>,
+    error: Option<Error>,
 }
 
 impl<'a> Builder<'a> {
     /// Create a builder for the session/user message bus connection.
-    pub fn session() -> Result<Self> {
-        Ok(Self::new(Target::Address(Address::session()?)))
+    ///
+    /// A failure to find the session bus address is reported by [`Builder::build`].
+    pub fn session() -> Self {
+        match Address::session() {
+            Ok(address) => Self::new(Target::Address(address)),
+            Err(e) => Self::with_error(e),
+        }
     }
 
     /// Create a builder for the system-wide message bus connection.
-    pub fn system() -> Result<Self> {
-        Ok(Self::new(Target::Address(Address::system()?)))
+    ///
+    /// A failure to find the system bus address is reported by [`Builder::build`].
+    pub fn system() -> Self {
+        match Address::system() {
+            Ok(address) => Self::new(Target::Address(address)),
+            Err(e) => Self::with_error(e),
+        }
     }
 
     /// Create a builder for an IBus connection.
@@ -125,7 +141,7 @@ impl<'a> Builder<'a> {
     ///
     /// # Errors
     ///
-    /// Returns an error if:
+    /// [`Builder::build`] returns an error if:
     /// - The `ibus` command is not found or fails to execute
     /// - The IBus daemon is not running
     /// - The command output cannot be parsed as a valid D-Bus address
@@ -138,7 +154,7 @@ impl<'a> Builder<'a> {
     /// # use zbus::block_on;
     /// #
     /// # block_on(async {
-    /// let conn = Builder::ibus()?
+    /// let conn = Builder::ibus()
     ///     .build()
     ///     .await?;
     ///
@@ -150,11 +166,10 @@ impl<'a> Builder<'a> {
     /// # Ok::<_, Box<dyn Error + Send + Sync>>(())
     /// ```
     #[cfg(all(unix, feature = "ibus"))]
-    pub fn ibus() -> Result<Self> {
+    pub fn ibus() -> Self {
         use crate::address::transport::{Ibus, Transport};
-        Ok(Self::new(Target::Address(Address::from(Transport::Ibus(
-            Ibus::new(),
-        )))))
+
+        Self::new(Target::Address(Address::from(Transport::Ibus(Ibus::new()))))
     }
 
     /// Create a builder for a connection that will use the given [D-Bus bus address].
@@ -172,7 +187,7 @@ impl<'a> Builder<'a> {
     /// let addr = "unix:\
     ///     path=/home/zeenix/.cache/ibus/dbus-ET0Xzrk9,\
     ///     guid=fdd08e811a6c7ebe1fef0d9e647230da";
-    /// let conn = Builder::address(addr)?
+    /// let conn = Builder::address(addr)
     ///     .build()
     ///     .await?;
     ///
@@ -188,15 +203,18 @@ impl<'a> Builder<'a> {
     /// current session using `ibus address` command. For a more convenient way to connect to IBus,
     /// see `Builder::ibus`, available with the `ibus` feature.
     ///
+    /// An invalid address is reported by [`Builder::build`].
+    ///
     /// [D-Bus bus address]: https://dbus.freedesktop.org/doc/dbus-specification.html#addresses
-    pub fn address<A>(address: A) -> Result<Self>
+    pub fn address<A>(address: A) -> Self
     where
         A: TryInto<Address>,
         A::Error: Into<Error>,
     {
-        Ok(Self::new(Target::Address(
-            address.try_into().map_err(Into::into)?,
-        )))
+        match address.try_into() {
+            Ok(address) => Self::new(Target::Address(address)),
+            Err(e) => Self::with_error(e.into()),
+        }
     }
 
     /// Create a builder for a connection that will use the given unix stream with `async-io`.
@@ -285,16 +303,21 @@ impl<'a> Builder<'a> {
     ///
     /// This is similar to [`Builder::socket`], except that the socket is either already
     /// authenticated or does not require authentication.
-    pub fn authenticated_socket<S, G>(socket: S, guid: G) -> Result<Self>
+    ///
+    /// An invalid GUID is reported by [`Builder::build`].
+    pub fn authenticated_socket<S, G>(socket: S, guid: G) -> Self
     where
         S: Into<BoxedSplit>,
         G: TryInto<Guid<'a>>,
         G::Error: Into<Error>,
     {
         let mut builder = Self::new(Target::AuthenticatedSocket(socket.into()));
-        builder.guid = Some(guid.try_into().map_err(Into::into)?);
+        match guid.try_into() {
+            Ok(guid) => builder.guid = Some(guid),
+            Err(e) => builder.record(e.into()),
+        }
 
-        Ok(builder)
+        builder
     }
 
     /// Specify the mechanism to use during authentication.
@@ -336,15 +359,20 @@ impl<'a> Builder<'a> {
     /// **NOTE:** This method is redundant when using [`Builder::authenticated_socket`] since the
     /// latter already sets the GUID for the connection and zbus doesn't differentiate between a
     /// server and a client connection, except for authentication.
+    ///
+    /// An invalid GUID is reported by [`Builder::build`].
     #[cfg(feature = "p2p")]
-    pub fn server<G>(mut self, guid: G) -> Result<Self>
+    pub fn server<G>(mut self, guid: G) -> Self
     where
         G: TryInto<Guid<'a>>,
         G::Error: Into<Error>,
     {
-        self.guid = Some(guid.try_into().map_err(Into::into)?);
+        match guid.try_into() {
+            Ok(guid) => self.guid = Some(guid),
+            Err(e) => self.record(e.into()),
+        }
 
-        Ok(self)
+        self
     }
 
     /// Set the capacity of the main (unfiltered) queue.
@@ -360,7 +388,7 @@ impl<'a> Builder<'a> {
     /// # use zbus::block_on;
     /// #
     /// # block_on(async {
-    /// let conn = Builder::session()?
+    /// let conn = Builder::session()
     ///     .max_queued(30)
     ///     .build()
     ///     .await?;
@@ -398,17 +426,26 @@ impl<'a> Builder<'a> {
     ///
     /// Standard interfaces (Peer, Introspectable, Properties) are added on your behalf. If you
     /// attempt to add yours, [`Builder::build()`] will fail.
+    ///
+    /// An invalid path is reported by [`Builder::build`].
     #[cfg(feature = "service")]
-    pub fn serve_at<P, I>(mut self, path: P, iface: I) -> Result<Self>
+    pub fn serve_at<P, I>(mut self, path: P, iface: I) -> Self
     where
         I: Interface,
         P: TryInto<ObjectPath<'a>>,
         P::Error: Into<Error>,
     {
-        let path = path.try_into().map_err(Into::into)?;
-        let entry = self.interfaces.entry(path).or_default();
-        entry.insert(I::name(), ArcInterface::new(iface));
-        Ok(self)
+        match path.try_into() {
+            Ok(path) => {
+                self.interfaces
+                    .entry(path)
+                    .or_default()
+                    .insert(I::name(), ArcInterface::new(iface));
+            }
+            Err(e) => self.record(e.into()),
+        }
+
+        self
     }
 
     /// Register a well-known name for this connection on the bus.
@@ -428,15 +465,21 @@ impl<'a> Builder<'a> {
     ///
     /// The methods [`Builder::allow_name_replacements`] and [`Builder::replace_existing_names`]
     /// allow to set the [`zbus::fdo::RequestNameFlags`] used to request the name.
-    pub fn name<W>(mut self, well_known_name: W) -> Result<Self>
+    ///
+    /// An invalid name is reported by [`Builder::build`].
+    pub fn name<W>(mut self, well_known_name: W) -> Self
     where
         W: TryInto<WellKnownName<'a>>,
         W::Error: Into<Error>,
     {
-        let well_known_name = well_known_name.try_into().map_err(Into::into)?;
-        self.names.insert(well_known_name);
+        match well_known_name.try_into() {
+            Ok(well_known_name) => {
+                self.names.insert(well_known_name);
+            }
+            Err(e) => self.record(e.into()),
+        }
 
-        Ok(self)
+        self
     }
 
     /// Whether the [`zbus::fdo::RequestNameFlags::AllowReplacement`] flag will be set when
@@ -464,8 +507,10 @@ impl<'a> Builder<'a> {
     ///
     /// It will panic if the connection is to a message bus as it's the bus that assigns
     /// peers their unique names.
+    ///
+    /// An invalid name is reported by [`Builder::build`].
     #[cfg(feature = "bus-impl")]
-    pub fn unique_name<U>(mut self, unique_name: U) -> Result<Self>
+    pub fn unique_name<U>(mut self, unique_name: U) -> Self
     where
         U: TryInto<crate::names::UniqueName<'a>>,
         U::Error: Into<Error>,
@@ -473,10 +518,12 @@ impl<'a> Builder<'a> {
         if !self.p2p {
             panic!("unique name can only be set for peer-to-peer connections");
         }
-        let name = unique_name.try_into().map_err(Into::into)?;
-        self.unique_name = Some(name);
+        match unique_name.try_into() {
+            Ok(unique_name) => self.unique_name = Some(unique_name),
+            Err(e) => self.record(e.into()),
+        }
 
-        Ok(self)
+        self
     }
 
     /// Set a timeout for method calls.
@@ -493,6 +540,9 @@ impl<'a> Builder<'a> {
     /// Build the connection, consuming the builder.
     ///
     /// # Errors
+    ///
+    /// Returns the first error recorded by a constructor or setter, then any error from
+    /// connecting, authenticating or setting the connection up.
     ///
     /// Until server-side bus connection is supported, attempting to build such a connection will
     /// result in a [`Error::Unsupported`] error.
@@ -514,6 +564,10 @@ impl<'a> Builder<'a> {
     ///
     /// This method is only available when the `bus-impl` feature is enabled.
     ///
+    /// # Errors
+    ///
+    /// The same errors as [`Builder::build`].
+    ///
     /// # Example
     ///
     /// ```
@@ -530,7 +584,6 @@ impl<'a> Builder<'a> {
     ///
     /// // Bus client sends a method call right away (simulates pipelining after auth).
     /// let client = Builder::authenticated_socket(c1, guid.clone())
-    ///     .unwrap()
     ///     .build()
     ///     .await
     ///     .unwrap();
@@ -542,7 +595,6 @@ impl<'a> Builder<'a> {
     ///
     /// // Server builds *after* the client has already sent.
     /// let mut stream = Builder::authenticated_socket(c2, guid)
-    ///     .unwrap()
     ///     .p2p()
     ///     .build_message_stream()
     ///     .await
@@ -567,9 +619,13 @@ impl<'a> Builder<'a> {
     }
 
     async fn build_inner(
-        self,
+        mut self,
         activate_msg_stream: bool,
     ) -> Result<(Connection, Option<ActiveReceiver<Result<Message>>>)> {
+        if let Some(error) = self.error.take() {
+            return Err(error);
+        }
+
         let executor = Executor::new();
         #[cfg(feature = "async-io")]
         let internal_executor = self.internal_executor;
@@ -646,8 +702,18 @@ impl<'a> Builder<'a> {
     }
 
     fn new(target: Target) -> Self {
+        Self::from_parts(Some(target), None)
+    }
+
+    /// Create a builder that has no target to connect to, only the error that kept a constructor
+    /// from working one out.
+    fn with_error(error: Error) -> Self {
+        Self::from_parts(None, Some(error))
+    }
+
+    fn from_parts(target: Option<Target>, error: Option<Error>) -> Self {
         Self {
-            target: Some(target),
+            target,
             #[cfg(feature = "p2p")]
             p2p: false,
             max_queued: None,
@@ -662,6 +728,14 @@ impl<'a> Builder<'a> {
             request_name_flags: BitFlags::default(),
             method_timeout: None,
             user_id: None,
+            error,
+        }
+    }
+
+    /// Record `error`, unless an earlier constructor or setter already recorded one.
+    fn record(&mut self, error: Error) {
+        if self.error.is_none() {
+            self.error = Some(error);
         }
     }
 
@@ -741,8 +815,8 @@ impl<'a> Builder<'a> {
     async fn target_connect(&mut self) -> Result<(BoxedSplit, Option<OwnedGuid>, bool)> {
         let mut authenticated = false;
         let mut guid = None;
-        // SAFETY: `self.target` is always `Some` from the beginning and this method is only called
-        // once.
+        // SAFETY: `self.target` is `None` only when a constructor recorded an error, which
+        // `build` returns before it gets here, and this method is only called once.
         let split = match self.target.take().unwrap() {
             #[cfg(all(unix, feature = "tokio"))]
             Target::TokioUnixStream(stream) => stream.into(),
@@ -804,4 +878,48 @@ fn start_internal_executor(executor: &Executor<'static>, internal_executor: bool
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use test_log::test;
+
+    use super::{Address, Builder};
+    use crate::{Error, names::WellKnownName, utils::block_on};
+
+    // Syntactically valid, so that the builder records no error for the target itself.
+    const ADDRESS: &str = "unix:path=/tmp/zbus-connection-builder-tests";
+
+    #[test]
+    fn strings() {
+        // An invalid string is only reported by `build`.
+        let error = block_on(Builder::address("not an address").build()).unwrap_err();
+        assert_eq!(error, Address::try_from("not an address").unwrap_err());
+
+        let error = block_on(Builder::address(ADDRESS).name("not a name").build()).unwrap_err();
+        assert_eq!(error, WellKnownName::try_from("not a name").unwrap_err());
+    }
+
+    #[test]
+    fn typed_values() {
+        // No `Result` anywhere before `build`.
+        let address = Address::try_from(ADDRESS).unwrap();
+        let name = WellKnownName::try_from("org.zbus.Test").unwrap();
+        let error = block_on(Builder::address(address).name(name).build()).unwrap_err();
+        // No setter recorded an error, so the build got as far as connecting.
+        assert!(matches!(error, Error::Connection(..)));
+    }
+
+    #[test]
+    fn a_later_valid_call_keeps_the_first_error() {
+        // Calling the setter again, even with a valid name, doesn't clear the error it recorded.
+        let error = block_on(
+            Builder::address(ADDRESS)
+                .name("not a name")
+                .name("org.zbus.Test")
+                .build(),
+        )
+        .unwrap_err();
+        assert_eq!(error, WellKnownName::try_from("not a name").unwrap_err());
+    }
 }

--- a/zbus/src/connection/builder.rs
+++ b/zbus/src/connection/builder.rs
@@ -535,9 +535,7 @@ impl<'a> Builder<'a> {
     ///     .await
     ///     .unwrap();
     /// let hello = Message::method_call("/org/freedesktop/DBus", "Hello")
-    ///     .unwrap()
     ///     .destination("org.freedesktop.DBus")
-    ///     .unwrap()
     ///     .build(&())
     ///     .unwrap();
     /// client.send(&hello).await.unwrap();

--- a/zbus/src/connection/handshake/client.rs
+++ b/zbus/src/connection/handshake/client.rs
@@ -229,11 +229,8 @@ impl Handshake for Client {
 
 fn create_hello_method_call() -> Message {
     Message::method_call("/org/freedesktop/DBus", "Hello")
-        .unwrap()
         .destination("org.freedesktop.DBus")
-        .unwrap()
         .interface("org.freedesktop.DBus")
-        .unwrap()
         .build(&())
         .unwrap()
 }

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -343,7 +343,7 @@ impl Connection {
             .map_err(Into::into)?;
         let method_name = method_name.try_into().map_err(Into::into)?;
         let msg = self
-            .method_call_builder(destination, path, interface, method_name, flags)?
+            .method_call_builder(destination, path, interface, method_name, flags)
             .build(body)?;
 
         self.send_method_call(msg, flags).await
@@ -360,22 +360,22 @@ impl Connection {
         interface: Option<InterfaceName<'b>>,
         method_name: MemberName<'b>,
         flags: BitFlags<Flags>,
-    ) -> Result<message::Builder<'b>> {
-        let mut builder = Message::method_call(path, method_name)?;
+    ) -> message::Builder<'b> {
+        let mut builder = Message::method_call(path, method_name);
         if let Some(sender) = self.unique_name() {
-            builder = builder.sender(sender)?
+            builder = builder.sender(sender)
         }
         if let Some(destination) = destination {
-            builder = builder.destination(destination)?
+            builder = builder.destination(destination)
         }
         if let Some(interface) = interface {
-            builder = builder.interface(interface)?
+            builder = builder.interface(interface)
         }
         for flag in flags {
-            builder = builder.with_flags(flag)?;
+            builder = builder.with_flags(flag);
         }
 
-        Ok(builder)
+        builder
     }
 
     /// Send a method call message and register for its reply, unless none is expected.
@@ -429,7 +429,7 @@ impl Connection {
         let interface = interface.try_into().map_err(Into::into)?;
         let signal_name = signal_name.try_into().map_err(Into::into)?;
         let m = self
-            .signal_builder(destination, path, interface, signal_name)?
+            .signal_builder(destination, path, interface, signal_name)
             .build(body)?;
 
         self.send(&m).await
@@ -444,16 +444,16 @@ impl Connection {
         path: ObjectPath<'b>,
         interface: InterfaceName<'b>,
         signal_name: MemberName<'b>,
-    ) -> Result<message::Builder<'b>> {
-        let mut builder = Message::signal(path, interface, signal_name)?;
+    ) -> message::Builder<'b> {
+        let mut builder = Message::signal(path, interface, signal_name);
         if let Some(sender) = self.unique_name() {
-            builder = builder.sender(sender)?;
+            builder = builder.sender(sender);
         }
         if let Some(destination) = destination {
-            builder = builder.destination(destination)?;
+            builder = builder.destination(destination);
         }
 
-        Ok(builder)
+        builder
     }
 
     /// Reply to a message.
@@ -495,14 +495,13 @@ impl Connection {
     ///
     /// The body is written through a trait object so that this is compiled once rather than once
     /// per body type.
-    fn reply_message(
-        &self,
-        builder: Result<message::Builder<'_>>,
+    fn reply_message<'b>(
+        &'b self,
+        mut builder: message::Builder<'b>,
         build: &mut dyn FnMut(message::Builder<'_>) -> Result<Message>,
     ) -> Result<Message> {
-        let mut builder = builder?;
         if let Some(sender) = self.unique_name() {
-            builder = builder.sender(sender)?;
+            builder = builder.sender(sender);
         }
         build(builder)
     }
@@ -1752,8 +1751,8 @@ mod p2p_tests {
                 Endian::Little => Endian::Big,
                 Endian::Big => Endian::Little,
             };
-            let method = Message::method_call("/", "Test")?
-                .interface("org.zbus.p2p")?
+            let method = Message::method_call("/", "Test")
+                .interface("org.zbus.p2p")
                 .endian(endian)
                 .build(&64u64)?;
             client1.send(&method).await?;

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -949,10 +949,10 @@ impl Connection {
     /// #
     /// #[tokio::main]
     /// async fn main() {
-    ///     let builder = Builder::session().unwrap().internal_executor(false);
+    ///     let builder = Builder::session().internal_executor(false);
     /// #   // This is only for testing a deadlock that used to happen with this combo.
     /// #   #[cfg(feature = "service")]
-    /// #   let builder = builder.serve_at("/some/iface", SomeIface).unwrap();
+    /// #   let builder = builder.serve_at("/some/iface", SomeIface);
     ///     let conn = builder.build().await.unwrap();
     ///     {
     ///        let conn = conn.clone();
@@ -1265,12 +1265,12 @@ impl Connection {
 
     /// Create a `Connection` to the session/user message bus.
     pub async fn session() -> Result<Self> {
-        Builder::session()?.build().await
+        Builder::session().build().await
     }
 
     /// Create a `Connection` to the system-wide message bus.
     pub async fn system() -> Result<Self> {
-        Builder::system()?.build().await
+        Builder::system().build().await
     }
 
     /// Return a listener, notified on various connection activity.
@@ -1393,9 +1393,9 @@ impl Connection {
     /// # #[cfg(feature = "service")]
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn Error>> {
-    /// let conn = Builder::session()?
-    ///     .name("foo.bar.baz")?
-    ///     .serve_at("/foo/bar/baz", MyInterface)?
+    /// let conn = Builder::session()
+    ///     .name("foo.bar.baz")
+    ///     .serve_at("/foo/bar/baz", MyInterface)
     ///     .build()
     ///     .await?;
     ///
@@ -1551,11 +1551,8 @@ mod tests {
         }
         let name = "dev.peelz.foobar";
         let connection = Builder::session()
-            .unwrap()
             .name(name)
-            .unwrap()
             .serve_at("/dev/peelz/FooBar", MyInterface::default())
-            .unwrap()
             .build()
             .await
             .unwrap();
@@ -1633,11 +1630,8 @@ mod tests {
         let name = "dev.peelz.TestGracefulShutdown";
         let obj = "/dev/peelz/TestGracefulShutdown";
         let connection = Builder::session()
-            .unwrap()
             .name(name)
-            .unwrap()
             .serve_at(obj, interface)
-            .unwrap()
             .build()
             .await
             .unwrap();
@@ -1799,7 +1793,6 @@ mod p2p_tests {
             (
                 Builder::async_io_tcp_stream(p0)
                     .server(guid)
-                    .unwrap()
                     .p2p()
                     .auth_mechanism(AuthMechanism::Anonymous),
                 Builder::async_io_tcp_stream(p1).p2p(),
@@ -1816,7 +1809,6 @@ mod p2p_tests {
             (
                 Builder::tokio_tcp_stream(p0)
                     .server(guid)
-                    .unwrap()
                     .p2p()
                     .auth_mechanism(AuthMechanism::Anonymous),
                 Builder::tokio_tcp_stream(p1).p2p(),
@@ -1865,7 +1857,7 @@ mod p2p_tests {
             Builder::tokio_unix_stream(p0),
         );
 
-        futures_util::try_join!(b1.p2p().build(), b0.server(guid).unwrap().p2p().build(),)
+        futures_util::try_join!(b1.p2p().build(), b0.server(guid).p2p().build(),)
     }
 
     // With both backends compiled in, exercise the async-io one end to end. `utils::block_on`
@@ -1917,11 +1909,7 @@ mod p2p_tests {
 
         futures_util::try_join!(
             Builder::async_io_unix_stream(p1).p2p().build(),
-            Builder::async_io_unix_stream(p0)
-                .server(guid)
-                .unwrap()
-                .p2p()
-                .build(),
+            Builder::async_io_unix_stream(p0).server(guid).p2p().build(),
         )
     }
 
@@ -1958,14 +1946,14 @@ mod p2p_tests {
             #[cfg(feature = "tokio-vsock")]
             let builder = Builder::tokio_vsock_stream(server.unwrap()?);
             builder
-                .server(guid)?
+                .server(guid)
                 .p2p()
                 .auth_mechanism(AuthMechanism::Anonymous)
                 .build()
                 .await
         };
 
-        let client = crate::connection::Builder::address(addr.as_str())?
+        let client = crate::connection::Builder::address(addr.as_str())
             .p2p()
             .build();
 
@@ -2000,7 +1988,6 @@ mod p2p_tests {
         futures_util::try_join!(
             Builder::async_io_vsock_stream(server)
                 .server(guid)
-                .unwrap()
                 .p2p()
                 .auth_mechanism(AuthMechanism::Anonymous)
                 .build(),
@@ -2023,7 +2010,6 @@ mod p2p_tests {
         futures_util::try_join!(
             Builder::tokio_vsock_stream(server)
                 .server(guid)
-                .unwrap()
                 .p2p()
                 .auth_mechanism(AuthMechanism::Anonymous)
                 .build(),
@@ -2049,13 +2035,11 @@ mod p2p_tests {
 
         let guid = crate::Guid::generate();
         let conn1 = Builder::authenticated_socket(a, guid.clone())
-            .unwrap()
             .p2p()
             .build()
             .await
             .unwrap();
         let conn2 = Builder::authenticated_socket(b, guid)
-            .unwrap()
             .p2p()
             .build()
             .await

--- a/zbus/src/connection/mod.rs
+++ b/zbus/src/connection/mod.rs
@@ -701,13 +701,11 @@ impl Connection {
 
         let acquired_match_rule = MatchRule::fdo_signal_builder("NameAcquired")
             .arg(0, well_known_name.as_ref())
-            .unwrap()
-            .build();
+            .build()?;
         let mut acquired_stream = self.add_match(acquired_match_rule.into(), None).await?;
         let lost_match_rule = MatchRule::fdo_signal_builder("NameLost")
             .arg(0, well_known_name.as_ref())
-            .unwrap()
-            .build();
+            .build()?;
         let mut lost_stream = self.add_match(lost_match_rule.into(), None).await?;
         let reply = self
             .call_method(
@@ -1022,9 +1020,11 @@ impl Connection {
                         Some(conn) => {
                             let mut builder = MatchRule::builder().msg_type(Type::MethodCall);
                             if let Some(unique_name) = conn.unique_name() {
-                                builder = builder.destination(&**unique_name).expect("unique name");
+                                builder = builder.destination(&**unique_name);
                             }
-                            let rule = builder.build();
+                            let rule = builder
+                                .build()
+                                .expect("a unique name is a valid destination");
                             match conn.add_match(rule.into(), None).await {
                                 Ok(stream) => stream,
                                 Err(e) => {

--- a/zbus/src/fdo/mod.rs
+++ b/zbus/src/fdo/mod.rs
@@ -185,10 +185,9 @@ mod tests {
             zbus::MatchRule::builder()
                 .msg_type(zbus::message::Type::Signal)
                 .interface("org.freedesktop.DBus.ObjectManager")
-                .unwrap()
                 .path("/org/zbus/NoObjectManagerSignalsBeforeHello")
-                .unwrap()
-                .build(),
+                .build()
+                .unwrap(),
             &conn,
             None,
         )

--- a/zbus/src/fdo/mod.rs
+++ b/zbus/src/fdo/mod.rs
@@ -69,13 +69,10 @@ mod tests {
     #[test]
     fn error_from_zerror() {
         let m = Message::method_call("/", "foo")
-            .unwrap()
             .destination(":1.2")
-            .unwrap()
             .build(&())
             .unwrap();
         let m = Message::error(&m.header(), "org.freedesktop.DBus.Error.TimedOut")
-            .unwrap()
             .build(&("so long"))
             .unwrap();
         let e: Error = m.into();

--- a/zbus/src/fdo/mod.rs
+++ b/zbus/src/fdo/mod.rs
@@ -201,16 +201,12 @@ mod tests {
             }
         }
         let _conn = zbus::conn::Builder::session()
-            .unwrap()
             .name("org.zbus.NoObjectManagerSignalsBeforeHello")
-            .unwrap()
             .serve_at("/org/zbus/NoObjectManagerSignalsBeforeHello/Obj", TestObj)
-            .unwrap()
             .serve_at(
                 "/org/zbus/NoObjectManagerSignalsBeforeHello",
                 super::ObjectManager,
             )
-            .unwrap()
             .build()
             .await
             .unwrap();
@@ -253,11 +249,8 @@ mod tests {
         impl TestObj {}
 
         let _service_conn = zbus::conn::Builder::session()
-            .unwrap()
             .name("org.zbus.PeerArbitraryPathTest")
-            .unwrap()
             .serve_at("/registered", TestObj)
-            .unwrap()
             .build()
             .await
             .unwrap();

--- a/zbus/src/guid.rs
+++ b/zbus/src/guid.rs
@@ -197,6 +197,12 @@ impl<'unowned, 'owned: 'unowned> From<&'owned OwnedGuid> for Guid<'unowned> {
     }
 }
 
+impl<'g> From<&Guid<'g>> for Guid<'g> {
+    fn from(guid: &Guid<'g>) -> Self {
+        guid.clone()
+    }
+}
+
 impl From<Guid<'_>> for OwnedGuid {
     fn from(guid: Guid<'_>) -> Self {
         OwnedGuid(guid.to_owned())

--- a/zbus/src/match_rule/builder.rs
+++ b/zbus/src/match_rule/builder.rs
@@ -15,6 +15,7 @@ const MAX_ARGS: u8 = 64;
 /// clear it — and reported by [`Builder::build`], so a chain of setters never needs a `?` in
 /// between.
 #[derive(Debug)]
+#[must_use]
 pub struct Builder<'m> {
     rule: MatchRule<'m>,
     error: Option<Error>,

--- a/zbus/src/match_rule/builder.rs
+++ b/zbus/src/match_rule/builder.rs
@@ -9,190 +9,209 @@ const MAX_ARGS: u8 = 64;
 
 /// Builder for [`MatchRule`].
 ///
-/// This is created by [`MatchRule::builder`].
+/// This is created by [`MatchRule::builder`]. Each setter takes the value it is given, whether
+/// that's an already parsed name or a string that still needs parsing, and converts it right
+/// away, but it never fails: the first error a setter hits is recorded — a later call doesn't
+/// clear it — and reported by [`Builder::build`], so a chain of setters never needs a `?` in
+/// between.
 #[derive(Debug)]
-pub struct Builder<'m>(MatchRule<'m>);
+pub struct Builder<'m> {
+    rule: MatchRule<'m>,
+    error: Option<Error>,
+}
 
 impl<'m> Builder<'m> {
     /// Build the `MatchRule`.
-    pub fn build(self) -> MatchRule<'m> {
-        self.0
+    ///
+    /// # Errors
+    ///
+    /// The first error recorded by a setter.
+    pub fn build(self) -> Result<MatchRule<'m>> {
+        match self.error {
+            Some(error) => Err(error),
+            None => Ok(self.rule),
+        }
     }
 
     /// Set the sender.
-    pub fn sender<B>(mut self, sender: B) -> Result<Self>
+    ///
+    /// An invalid sender is reported by [`Builder::build`].
+    pub fn sender<B>(mut self, sender: B) -> Self
     where
         B: TryInto<BusName<'m>>,
         B::Error: Into<Error>,
     {
-        self.0.sender = Some(sender.try_into().map_err(Into::into)?);
+        match sender.try_into() {
+            Ok(sender) => self.rule.sender = Some(sender),
+            Err(e) => self.record(e.into()),
+        }
 
-        Ok(self)
+        self
     }
 
     /// Set the message type.
     pub fn msg_type(mut self, msg_type: Type) -> Self {
-        self.0.msg_type = Some(msg_type);
+        self.rule.msg_type = Some(msg_type);
 
         self
     }
 
     /// Set the interface.
-    pub fn interface<I>(mut self, interface: I) -> Result<Self>
+    ///
+    /// An invalid interface name is reported by [`Builder::build`].
+    pub fn interface<I>(mut self, interface: I) -> Self
     where
         I: TryInto<InterfaceName<'m>>,
         I::Error: Into<Error>,
     {
-        self.0.interface = Some(interface.try_into().map_err(Into::into)?);
+        match interface.try_into() {
+            Ok(interface) => self.rule.interface = Some(interface),
+            Err(e) => self.record(e.into()),
+        }
 
-        Ok(self)
+        self
     }
 
     /// Set the member.
-    pub fn member<M>(mut self, member: M) -> Result<Self>
+    ///
+    /// An invalid member name is reported by [`Builder::build`].
+    pub fn member<M>(mut self, member: M) -> Self
     where
         M: TryInto<MemberName<'m>>,
         M::Error: Into<Error>,
     {
-        self.0.member = Some(member.try_into().map_err(Into::into)?);
+        match member.try_into() {
+            Ok(member) => self.rule.member = Some(member),
+            Err(e) => self.record(e.into()),
+        }
 
-        Ok(self)
+        self
     }
 
     /// Set the path.
     ///
     /// Note: Since both a path and a path namespace are not allowed to appear in a match rule at
     /// the same time, this overrides any path namespace previously set.
-    pub fn path<P>(mut self, path: P) -> Result<Self>
+    ///
+    /// An invalid path is reported by [`Builder::build`].
+    pub fn path<P>(mut self, path: P) -> Self
     where
         P: TryInto<ObjectPath<'m>>,
         P::Error: Into<Error>,
     {
-        self.0.path_spec = path
-            .try_into()
-            .map(PathSpec::Path)
-            .map(Some)
-            .map_err(Into::into)?;
+        match path.try_into() {
+            Ok(path) => self.rule.path_spec = Some(PathSpec::Path(path)),
+            Err(e) => self.record(e.into()),
+        }
 
-        Ok(self)
+        self
     }
 
     /// Set the path namespace.
     ///
     /// Note: Since both a path and a path namespace are not allowed to appear in a match rule at
     /// the same time, this overrides any path previously set.
-    pub fn path_namespace<P>(mut self, path_namespace: P) -> Result<Self>
+    ///
+    /// An invalid path namespace is reported by [`Builder::build`].
+    pub fn path_namespace<P>(mut self, path_namespace: P) -> Self
     where
         P: TryInto<ObjectPath<'m>>,
         P::Error: Into<Error>,
     {
-        self.0.path_spec = path_namespace
-            .try_into()
-            .map(PathSpec::PathNamespace)
-            .map(Some)
-            .map_err(Into::into)?;
+        match path_namespace.try_into() {
+            Ok(namespace) => self.rule.path_spec = Some(PathSpec::PathNamespace(namespace)),
+            Err(e) => self.record(e.into()),
+        }
 
-        Ok(self)
+        self
     }
 
     /// Set the destination.
-    pub fn destination<B>(mut self, destination: B) -> Result<Self>
+    ///
+    /// An invalid destination is reported by [`Builder::build`].
+    pub fn destination<B>(mut self, destination: B) -> Self
     where
         B: TryInto<UniqueName<'m>>,
         B::Error: Into<Error>,
     {
-        self.0.destination = Some(destination.try_into().map_err(Into::into)?);
+        match destination.try_into() {
+            Ok(destination) => self.rule.destination = Some(destination),
+            Err(e) => self.record(e.into()),
+        }
 
-        Ok(self)
+        self
     }
 
     /// Append an argument.
     ///
     /// Use this in instead of [`Builder::arg`] if you want to sequentially add args.
     ///
-    /// # Errors
-    ///
-    /// [`Error::InvalidMatchRule`] on attempt to add the 65th argument.
-    pub fn add_arg<S>(self, arg: S) -> Result<Self>
+    /// An attempt to add the 65th argument is reported by [`Builder::build`].
+    pub fn add_arg<S>(self, arg: S) -> Self
     where
         S: Into<Str<'m>>,
     {
-        let idx = self.0.args.len() as u8;
+        let idx = self.rule.args.len() as u8;
 
         self.arg(idx, arg)
     }
 
     /// Add an argument of a specified index.
     ///
-    /// # Errors
+    /// This replaces any argument previously added at `idx`.
     ///
-    /// [`Error::InvalidMatchRule`] if `idx` is greater than 64.
-    pub fn arg<S>(mut self, idx: u8, arg: S) -> Result<Self>
+    /// An `idx` of 64 or greater is reported by [`Builder::build`].
+    pub fn arg<S>(mut self, idx: u8, arg: S) -> Self
     where
         S: Into<Str<'m>>,
     {
         if idx >= MAX_ARGS {
-            return Err(Error::InvalidMatchRule);
+            self.record(Error::InvalidMatchRule);
+
+            return self;
         }
-        let value = (idx, arg.into());
-        let vec_idx = match self.0.args().binary_search_by(|(i, _)| i.cmp(&idx)) {
-            Ok(i) => {
-                // If the argument is already present, replace it.
-                self.0.args.remove(i);
+        insert_indexed(&mut self.rule.args, idx, arg.into());
 
-                i
-            }
-            Err(i) => i,
-        };
-        self.0.args.insert(vec_idx, value);
-
-        Ok(self)
+        self
     }
 
     /// Append a path argument.
     ///
     /// Use this in instead of [`Builder::arg_path`] if you want to sequentially add args.
     ///
-    /// # Errors
-    ///
-    /// [`Error::InvalidMatchRule`] on attempt to add the 65th path argument.
-    pub fn add_arg_path<P>(self, arg_path: P) -> Result<Self>
+    /// An invalid path, or an attempt to add the 65th path argument, is reported by
+    /// [`Builder::build`].
+    pub fn add_arg_path<P>(self, arg_path: P) -> Self
     where
         P: TryInto<ObjectPath<'m>>,
         P::Error: Into<Error>,
     {
-        let idx = self.0.arg_paths.len() as u8;
+        let idx = self.rule.arg_paths.len() as u8;
 
         self.arg_path(idx, arg_path)
     }
 
     /// Add a path argument of a specified index.
     ///
-    /// # Errors
+    /// This replaces any path argument previously added at `idx`.
     ///
-    /// [`Error::InvalidMatchRule`] if `idx` is greater than 64.
-    pub fn arg_path<P>(mut self, idx: u8, arg_path: P) -> Result<Self>
+    /// An invalid path, or an `idx` of 64 or greater, is reported by [`Builder::build`].
+    pub fn arg_path<P>(mut self, idx: u8, arg_path: P) -> Self
     where
         P: TryInto<ObjectPath<'m>>,
         P::Error: Into<Error>,
     {
         if idx >= MAX_ARGS {
-            return Err(Error::InvalidMatchRule);
+            self.record(Error::InvalidMatchRule);
+
+            return self;
+        }
+        match arg_path.try_into() {
+            Ok(arg_path) => insert_indexed(&mut self.rule.arg_paths, idx, arg_path),
+            Err(e) => self.record(e.into()),
         }
 
-        let value = (idx, arg_path.try_into().map_err(Into::into)?);
-        let vec_idx = match self.0.arg_paths().binary_search_by(|(i, _)| i.cmp(&idx)) {
-            Ok(i) => {
-                // If the argument is already present, replace it.
-                self.0.arg_paths.remove(i);
-
-                i
-            }
-            Err(i) => i,
-        };
-        self.0.arg_paths.insert(vec_idx, value);
-
-        Ok(self)
+        self
     }
 
     /// Set 0th argument's namespace.
@@ -200,73 +219,206 @@ impl<'m> Builder<'m> {
     /// The namespace must be a valid bus name or a valid element of a bus name. For more
     /// information, see [the spec](https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names-bus).
     ///
+    /// An invalid namespace is reported by [`Builder::build`].
+    ///
     /// # Examples
     ///
     /// ```
     /// # use zbus::MatchRule;
     /// // Valid namespaces
-    /// MatchRule::builder().arg0ns("org.mpris.MediaPlayer2").unwrap();
-    /// MatchRule::builder().arg0ns("org").unwrap();
-    /// MatchRule::builder().arg0ns(":org").unwrap();
-    /// MatchRule::builder().arg0ns(":1org").unwrap();
+    /// MatchRule::builder().arg0ns("org.mpris.MediaPlayer2").build().unwrap();
+    /// MatchRule::builder().arg0ns("org").build().unwrap();
+    /// MatchRule::builder().arg0ns(":org").build().unwrap();
+    /// MatchRule::builder().arg0ns(":1org").build().unwrap();
     ///
     /// // Invalid namespaces
-    /// MatchRule::builder().arg0ns("org.").unwrap_err();
-    /// MatchRule::builder().arg0ns(".org").unwrap_err();
-    /// MatchRule::builder().arg0ns("1org").unwrap_err();
-    /// MatchRule::builder().arg0ns(".").unwrap_err();
-    /// MatchRule::builder().arg0ns("org..freedesktop").unwrap_err();
+    /// MatchRule::builder().arg0ns("org.").build().unwrap_err();
+    /// MatchRule::builder().arg0ns(".org").build().unwrap_err();
+    /// MatchRule::builder().arg0ns("1org").build().unwrap_err();
+    /// MatchRule::builder().arg0ns(".").build().unwrap_err();
+    /// MatchRule::builder().arg0ns("org..freedesktop").build().unwrap_err();
     /// ````
-    pub fn arg0ns<S>(mut self, namespace: S) -> Result<Self>
+    pub fn arg0ns<S>(mut self, namespace: S) -> Self
     where
         S: Into<Str<'m>>,
     {
-        let namespace: Str<'m> = namespace.into();
-
-        // Rules: https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names-bus
-        // minus the requirement to have more than one element.
-
-        if namespace.is_empty() || namespace.len() > 255 {
-            return Err(Error::InvalidMatchRule);
+        match validate_arg0ns(namespace.into()) {
+            Ok(namespace) => self.rule.arg0ns = Some(namespace),
+            Err(e) => self.record(e),
         }
 
-        let (is_unique, namespace_str) = match namespace.strip_prefix(':') {
-            Some(s) => (true, s),
-            None => (false, namespace.as_str()),
-        };
-
-        let valid_first_char = |s: &str| match s.chars().next() {
-            None | Some('.') => false,
-            Some('0'..='9') if !is_unique => false,
-            _ => true,
-        };
-
-        if !valid_first_char(namespace_str)
-            || !namespace_str.split('.').all(valid_first_char)
-            || !namespace_str
-                .chars()
-                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
-        {
-            return Err(Error::InvalidMatchRule);
-        }
-
-        self.0.arg0ns = Some(namespace);
-
-        Ok(self)
+        self
     }
 
     /// Create a builder for `MatchRule`.
     pub(crate) fn new() -> Self {
-        Self(MatchRule {
-            msg_type: None,
-            sender: None,
-            interface: None,
-            member: None,
-            path_spec: None,
-            destination: None,
-            args: Vec::with_capacity(MAX_ARGS as usize),
-            arg_paths: Vec::with_capacity(MAX_ARGS as usize),
-            arg0ns: None,
-        })
+        Self {
+            rule: MatchRule {
+                msg_type: None,
+                sender: None,
+                interface: None,
+                member: None,
+                path_spec: None,
+                destination: None,
+                args: Vec::with_capacity(MAX_ARGS as usize),
+                arg_paths: Vec::with_capacity(MAX_ARGS as usize),
+                arg0ns: None,
+            },
+            error: None,
+        }
+    }
+
+    /// Record `error`, unless an earlier setter already recorded one.
+    fn record(&mut self, error: Error) {
+        if self.error.is_none() {
+            self.error = Some(error);
+        }
+    }
+}
+
+/// Add `value` at `idx`, replacing the value already recorded at that index, if any.
+fn insert_indexed<T>(entries: &mut Vec<(u8, T)>, idx: u8, value: T) {
+    match entries.binary_search_by(|(i, _)| i.cmp(&idx)) {
+        Ok(i) => entries[i] = (idx, value),
+        Err(i) => entries.insert(i, (idx, value)),
+    }
+}
+
+/// Check that `namespace` is a valid bus name or a valid element of a bus name.
+pub(crate) fn validate_arg0ns(namespace: Str<'_>) -> Result<Str<'_>> {
+    // Rules: https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names-bus
+    // minus the requirement to have more than one element.
+
+    if namespace.is_empty() || namespace.len() > 255 {
+        return Err(Error::InvalidMatchRule);
+    }
+
+    let (is_unique, namespace_str) = match namespace.strip_prefix(':') {
+        Some(s) => (true, s),
+        None => (false, namespace.as_str()),
+    };
+
+    let valid_first_char = |s: &str| match s.chars().next() {
+        None | Some('.') => false,
+        Some('0'..='9') if !is_unique => false,
+        _ => true,
+    };
+
+    if !valid_first_char(namespace_str)
+        || !namespace_str.split('.').all(valid_first_char)
+        || !namespace_str
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+    {
+        return Err(Error::InvalidMatchRule);
+    }
+
+    Ok(namespace)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::names::OwnedBusName;
+    use test_log::test;
+
+    #[test]
+    fn strings_are_converted() {
+        let rule = MatchRule::builder()
+            .msg_type(Type::Signal)
+            .sender("org.freedesktop.DBus")
+            .interface("org.freedesktop.DBus.Properties")
+            .member("PropertiesChanged")
+            .path("/org/zbus")
+            .destination(":1.11")
+            .add_arg("org.zbus")
+            .add_arg_path("/org/zbus/Arg")
+            .arg0ns("org.zbus")
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            rule.to_string(),
+            "type='signal',\
+             sender='org.freedesktop.DBus',\
+             interface='org.freedesktop.DBus.Properties',\
+             member='PropertiesChanged',\
+             destination=':1.11',\
+             path='/org/zbus',\
+             arg0='org.zbus',\
+             arg0path='/org/zbus/Arg',\
+             arg0namespace='org.zbus'",
+        );
+    }
+
+    #[test]
+    fn invalid_string_is_reported_by_build() {
+        let err = MatchRule::builder()
+            .sender("not a bus name")
+            .member("Whatever")
+            .build()
+            .unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            BusName::try_from("not a bus name").unwrap_err().to_string(),
+        );
+    }
+
+    #[test]
+    fn typed_values_need_no_error_handling() {
+        let sender = BusName::try_from("org.zbus.Sender").unwrap();
+        let path = ObjectPath::try_from("/org/zbus").unwrap();
+        let rule = MatchRule::builder()
+            .sender(&sender)
+            .path(path.clone())
+            .build()
+            .unwrap();
+
+        assert_eq!(rule.sender(), Some(&sender));
+        assert_eq!(rule.path_spec(), Some(&PathSpec::Path(path)));
+
+        let rule = MatchRule::builder()
+            .sender(OwnedBusName::from(sender.clone()))
+            .build()
+            .unwrap();
+
+        assert_eq!(rule.sender(), Some(&sender));
+    }
+
+    #[test]
+    fn a_later_valid_call_keeps_the_first_error() {
+        // Setting the field again, even to a valid value, doesn't clear the error it recorded.
+        let err = MatchRule::builder()
+            .path("bad")
+            .path("/good")
+            .build()
+            .unwrap_err();
+
+        assert_eq!(err, ObjectPath::try_from("bad").unwrap_err());
+
+        let mut builder = MatchRule::builder();
+        for i in 0..MAX_ARGS {
+            builder = builder.add_arg(i.to_string());
+        }
+
+        // The 65th argument doesn't fit and the later valid argument doesn't undo that.
+        let err = builder
+            .add_arg("one too many")
+            .arg(0, "replaced")
+            .build()
+            .unwrap_err();
+
+        assert_eq!(err, Error::InvalidMatchRule);
+    }
+
+    #[test]
+    fn rule_string_rejects_an_invalid_namespace_even_if_repeated() {
+        // The parser validates each component itself, so a later valid `arg0namespace` must not
+        // hide an earlier invalid one.
+        let err = MatchRule::try_from("arg0namespace='org.',arg0namespace='org'").unwrap_err();
+
+        assert_eq!(err, Error::InvalidMatchRule);
+        MatchRule::try_from("arg0namespace='org'").unwrap();
     }
 }

--- a/zbus/src/match_rule/mod.rs
+++ b/zbus/src/match_rule/mod.rs
@@ -33,13 +33,13 @@ pub use builder::Builder;
 /// // Let's take the most typical example of match rule to subscribe to properties' changes:
 /// let rule = MatchRule::builder()
 ///     .msg_type(zbus::message::Type::Signal)
-///     .sender("org.freedesktop.DBus")?
-///     .interface("org.freedesktop.DBus.Properties")?
-///     .member("PropertiesChanged")?
-///     .add_arg("org.zbus")?
+///     .sender("org.freedesktop.DBus")
+///     .interface("org.freedesktop.DBus.Properties")
+///     .member("PropertiesChanged")
+///     .add_arg("org.zbus")
 ///     // Sometimes it's useful to match empty strings (null check).
-///     .add_arg("")?
-///     .build();
+///     .add_arg("")
+///     .build()?;
 /// let rule_str = rule.to_string();
 /// assert_eq!(
 ///     rule_str,
@@ -58,11 +58,11 @@ pub use builder::Builder;
 /// // Now for the `ObjectManager::InterfacesAdded` signal.
 /// let rule = MatchRule::builder()
 ///     .msg_type(zbus::message::Type::Signal)
-///     .sender("org.zbus")?
-///     .interface("org.freedesktop.DBus.ObjectManager")?
-///     .member("InterfacesAdded")?
-///     .arg_path(0, "/org/zbus/NewPath")?
-///     .build();
+///     .sender("org.zbus")
+///     .interface("org.freedesktop.DBus.ObjectManager")
+///     .member("InterfacesAdded")
+///     .arg_path(0, "/org/zbus/NewPath")
+///     .build()?;
 /// let rule_str = rule.to_string();
 /// assert_eq!(
 ///     rule_str,
@@ -329,11 +329,8 @@ impl<'m> MatchRule<'m> {
         Builder::new()
             .msg_type(Type::Signal)
             .sender("org.freedesktop.DBus")
-            .unwrap()
             .interface("org.freedesktop.DBus")
-            .unwrap()
             .member(signal_name)
-            .unwrap()
     }
 }
 
@@ -440,31 +437,33 @@ impl<'m> TryFrom<&'m str> for MatchRule<'m> {
                     };
                     builder.msg_type(msg_type)
                 }
-                "sender" => builder.sender(value)?,
-                "interface" => builder.interface(value)?,
-                "member" => builder.member(value)?,
-                "path" => builder.path(value)?,
-                "path_namespace" => builder.path_namespace(value)?,
-                "destination" => builder.destination(value)?,
-                "arg0namespace" => builder.arg0ns(value)?,
+                // Each component is converted here, rather than left to the builder, so that an
+                // invalid rule string is reported by the component that's actually at fault.
+                "sender" => builder.sender(BusName::try_from(value)?),
+                "interface" => builder.interface(InterfaceName::try_from(value)?),
+                "member" => builder.member(MemberName::try_from(value)?),
+                "path" => builder.path(ObjectPath::try_from(value)?),
+                "path_namespace" => builder.path_namespace(ObjectPath::try_from(value)?),
+                "destination" => builder.destination(UniqueName::try_from(value)?),
+                "arg0namespace" => builder.arg0ns(builder::validate_arg0ns(value.into())?),
                 key if key.starts_with("arg") => {
                     if let Some(trailing_idx) = key.find("path") {
                         let idx = key[3..trailing_idx]
                             .parse::<u8>()
                             .map_err(|_| Error::InvalidMatchRule)?;
-                        builder.arg_path(idx, value)?
+                        builder.arg_path(idx, ObjectPath::try_from(value)?)
                     } else {
                         let idx = key[3..]
                             .parse::<u8>()
                             .map_err(|_| Error::InvalidMatchRule)?;
-                        builder.arg(idx, value)?
+                        builder.arg(idx, value)
                     }
                 }
                 _ => return Err(Error::InvalidMatchRule),
             };
         }
 
-        Ok(builder.build())
+        builder.build()
     }
 }
 

--- a/zbus/src/message/builder.rs
+++ b/zbus/src/message/builder.rs
@@ -20,10 +20,27 @@ macro_rules! dbus_context {
     };
 }
 
+/// Convert `$value` into the header field `$field`, recording a failure to convert it.
+macro_rules! set_field {
+    ($self:ident, $field:ident, $value:expr) => {{
+        match $value.try_into() {
+            Ok(value) => $self.header.fields_mut().$field = Some(value),
+            Err(e) => $self.record(e.into()),
+        }
+
+        $self
+    }};
+}
+
 /// A builder for a [`Message`].
+///
+/// The setters take the same loosely typed values as the rest of the API and convert them right
+/// away, but they never fail: the first error a setter hits is recorded — a later call doesn't
+/// clear it — and reported by [`Builder::build`].
 #[derive(Debug, Clone)]
 pub struct Builder<'a> {
     header: Header<'a>,
+    error: Option<Error>,
 }
 
 impl<'a> Builder<'a> {
@@ -31,82 +48,95 @@ impl<'a> Builder<'a> {
         let primary = PrimaryHeader::new(msg_type, 0);
         let fields = Fields::new();
         let header = Header::new(primary, fields);
-        Self { header }
+        Self {
+            header,
+            error: None,
+        }
     }
 
     /// Add flags to the message.
     ///
     /// See [`Flags`] documentation for the meaning of the flags.
     ///
-    /// The function will return an error if invalid flags are given for the message type.
-    pub fn with_flags(mut self, flag: Flags) -> Result<Self> {
+    /// Flags that are invalid for the message type are reported by [`Builder::build`].
+    pub fn with_flags(mut self, flag: Flags) -> Self {
         if self.header.message_type() != Type::MethodCall
             && BitFlags::from_flag(flag).contains(Flags::NoReplyExpected)
         {
-            return Err(Error::InvalidField);
+            self.record(Error::InvalidField);
+
+            return self;
         }
         let flags = self.header.primary().flags() | flag;
         self.header.primary_mut().set_flags(flags);
-        Ok(self)
+
+        self
     }
 
     /// Set the unique name of the sending connection.
-    pub fn sender<'s: 'a, S>(mut self, sender: S) -> Result<Self>
+    ///
+    /// An invalid sender name is reported by [`Builder::build`].
+    pub fn sender<'s: 'a, S>(mut self, sender: S) -> Self
     where
         S: TryInto<UniqueName<'s>>,
         S::Error: Into<Error>,
     {
-        self.header.fields_mut().sender = Some(sender.try_into().map_err(Into::into)?);
-        Ok(self)
+        set_field!(self, sender, sender)
     }
 
     /// Set the object to send a call to, or the object a signal is emitted from.
-    pub fn path<'p: 'a, P>(mut self, path: P) -> Result<Self>
+    ///
+    /// An invalid path is reported by [`Builder::build`].
+    pub fn path<'p: 'a, P>(mut self, path: P) -> Self
     where
         P: TryInto<ObjectPath<'p>>,
         P::Error: Into<Error>,
     {
-        self.header.fields_mut().path = Some(path.try_into().map_err(Into::into)?);
-        Ok(self)
+        set_field!(self, path, path)
     }
 
     /// Set the interface to invoke a method call on, or that a signal is emitted from.
-    pub fn interface<'i: 'a, I>(mut self, interface: I) -> Result<Self>
+    ///
+    /// An invalid interface name is reported by [`Builder::build`].
+    pub fn interface<'i: 'a, I>(mut self, interface: I) -> Self
     where
         I: TryInto<InterfaceName<'i>>,
         I::Error: Into<Error>,
     {
-        self.header.fields_mut().interface = Some(interface.try_into().map_err(Into::into)?);
-        Ok(self)
+        set_field!(self, interface, interface)
     }
 
     /// Set the member, either the method name or signal name.
-    pub fn member<'m: 'a, M>(mut self, member: M) -> Result<Self>
+    ///
+    /// An invalid member name is reported by [`Builder::build`].
+    pub fn member<'m: 'a, M>(mut self, member: M) -> Self
     where
         M: TryInto<MemberName<'m>>,
         M::Error: Into<Error>,
     {
-        self.header.fields_mut().member = Some(member.try_into().map_err(Into::into)?);
-        Ok(self)
+        set_field!(self, member, member)
     }
 
-    pub(super) fn error_name<'e: 'a, E>(mut self, error: E) -> Result<Self>
+    /// Set the name of the error this message reports.
+    ///
+    /// An invalid error name is reported by [`Builder::build`].
+    pub(super) fn error_name<'e: 'a, E>(mut self, error: E) -> Self
     where
         E: TryInto<ErrorName<'e>>,
         E::Error: Into<Error>,
     {
-        self.header.fields_mut().error_name = Some(error.try_into().map_err(Into::into)?);
-        Ok(self)
+        set_field!(self, error_name, error)
     }
 
     /// Set the name of the connection this message is intended for.
-    pub fn destination<'d: 'a, D>(mut self, destination: D) -> Result<Self>
+    ///
+    /// An invalid destination name is reported by [`Builder::build`].
+    pub fn destination<'d: 'a, D>(mut self, destination: D) -> Self
     where
         D: TryInto<BusName<'d>>,
         D::Error: Into<Error>,
     {
-        self.header.fields_mut().destination = Some(destination.try_into().map_err(Into::into)?);
-        Ok(self)
+        set_field!(self, destination, destination)
     }
 
     /// Override the generated or inherited serial.  This is a low level modification,
@@ -123,15 +153,14 @@ impl<'a> Builder<'a> {
         self
     }
 
-    pub(super) fn reply_to(mut self, reply_to: &Header<'_>) -> Result<Self> {
+    pub(super) fn reply_to(mut self, reply_to: &Header<'_>) -> Self {
         let serial = reply_to.primary().serial_num();
         self.header.fields_mut().reply_serial = Some(serial);
         self = self.endian(reply_to.primary().endian_sig().into());
 
-        if let Some(sender) = reply_to.sender() {
-            self.destination(sender.to_owned())
-        } else {
-            Ok(self)
+        match reply_to.sender() {
+            Some(sender) => self.destination(sender.to_owned()),
+            None => self,
         }
     }
 
@@ -155,10 +184,19 @@ impl<'a> Builder<'a> {
     ///
     /// [specification]:
     /// https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-header-fields
-    pub fn build<B>(self, body: &B) -> Result<Message>
+    ///
+    /// # Errors
+    ///
+    /// Returns the first error recorded by a setter, then any error from serializing the body or
+    /// from the message exceeding the maximum message size.
+    pub fn build<B>(mut self, body: &B) -> Result<Message>
     where
         B: serde::ser::Serialize + DynamicType,
     {
+        if let Some(error) = self.error.take() {
+            return Err(error);
+        }
+
         let ctxt = dbus_context!(self, 0);
         let signature = body.signature();
 
@@ -187,11 +225,16 @@ impl<'a> Builder<'a> {
     /// Create a new message from a raw slice of bytes to populate the body with, rather than by
     /// serializing a value. The message body will be the exact bytes.
     ///
+    /// # Errors
+    ///
+    /// The same errors as [`Builder::build`], except that the body is taken as is instead of
+    /// being serialized, and an invalid `signature` is reported here.
+    ///
     /// # Safety
     ///
     /// This method is unsafe because it can be used to build an invalid message.
     pub unsafe fn build_raw_body<S>(
-        self,
+        mut self,
         body_bytes: &[u8],
         signature: S,
         #[cfg(unix)] fds: Vec<OwnedFd>,
@@ -200,6 +243,10 @@ impl<'a> Builder<'a> {
         S: TryInto<Signature>,
         S::Error: Into<Error>,
     {
+        if let Some(error) = self.error.take() {
+            return Err(error);
+        }
+
         let signature = signature.try_into().map_err(Into::into)?;
 
         self.build_from_bytes(
@@ -264,6 +311,13 @@ impl<'a> Builder<'a> {
             }),
         })
     }
+
+    /// Record `error`, unless an earlier setter already recorded one.
+    fn record(&mut self, error: Error) {
+        if self.error.is_none() {
+            self.error = Some(error);
+        }
+    }
 }
 
 impl<'m> From<Header<'m>> for Builder<'m> {
@@ -273,20 +327,78 @@ impl<'m> From<Header<'m>> for Builder<'m> {
         fields.signature = Cow::Owned(Signature::Unit);
         fields.unix_fds = None;
 
-        Self { header }
+        Self {
+            header,
+            error: None,
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{Endian, Message};
-    use crate::Error;
+    use crate::{
+        Error, ObjectPath,
+        message::Flags,
+        names::{BusName, InterfaceName},
+    };
     use test_log::test;
 
     #[test]
-    fn test_raw() -> Result<(), Error> {
+    fn strings() {
+        let message = Message::method_call("/org/zbus/Test", "Test")
+            .destination("org.zbus.Test")
+            .interface("org.zbus.Test")
+            .build(&())
+            .unwrap();
+        assert_eq!(message.header().path().unwrap().as_str(), "/org/zbus/Test");
+
+        // An invalid string is only reported by `build`.
+        let error = Message::method_call("not a path", "Test")
+            .build(&())
+            .unwrap_err();
+        assert_eq!(error, ObjectPath::try_from("not a path").unwrap_err());
+
+        let error = Message::method_call("/org/zbus/Test", "Test")
+            .destination("not a bus name")
+            .build(&())
+            .unwrap_err();
+        assert_eq!(error, BusName::try_from("not a bus name").unwrap_err());
+    }
+
+    #[test]
+    fn typed_values() {
+        // No `Result` anywhere before `build`.
+        let path = ObjectPath::try_from("/org/zbus/Test").unwrap();
+        let interface = InterfaceName::try_from("org.zbus.Test").unwrap();
+        let builder = Message::signal(&path, &interface, "Test").sender(":1.72");
+        let message = builder.build(&()).unwrap();
+        assert_eq!(message.header().interface().unwrap(), &interface);
+    }
+
+    #[test]
+    fn a_later_valid_call_keeps_the_first_error() {
+        // Setting the field again, even to a valid value, doesn't clear the error it recorded.
+        let error = Message::method_call("/", "Test")
+            .path("not a path")
+            .path("/org/zbus/Test")
+            .build(&())
+            .unwrap_err();
+        assert_eq!(error, ObjectPath::try_from("not a path").unwrap_err());
+
+        // Same for a valid flag after an invalid one.
+        let error = Message::signal("/", "org.zbus.Test", "Test")
+            .with_flags(Flags::NoReplyExpected)
+            .with_flags(Flags::NoAutoStart)
+            .build(&())
+            .unwrap_err();
+        assert_eq!(error, Error::InvalidField);
+    }
+
+    #[test]
+    fn raw() -> Result<(), Error> {
         let raw_body: &[u8] = &[16, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0];
-        let message_builder = Message::signal("/", "test.test", "test")?;
+        let message_builder = Message::signal("/", "test.test", "test");
         let message_builder = message_builder.endian(Endian::Little);
         let message = unsafe {
             message_builder.build_raw_body(

--- a/zbus/src/message/builder.rs
+++ b/zbus/src/message/builder.rs
@@ -59,6 +59,7 @@ impl<'a> Builder<'a> {
     /// See [`Flags`] documentation for the meaning of the flags.
     ///
     /// Flags that are invalid for the message type are reported by [`Builder::build`].
+    #[must_use]
     pub fn with_flags(mut self, flag: Flags) -> Self {
         if self.header.message_type() != Type::MethodCall
             && BitFlags::from_flag(flag).contains(Flags::NoReplyExpected)
@@ -76,6 +77,7 @@ impl<'a> Builder<'a> {
     /// Set the unique name of the sending connection.
     ///
     /// An invalid sender name is reported by [`Builder::build`].
+    #[must_use]
     pub fn sender<'s: 'a, S>(mut self, sender: S) -> Self
     where
         S: TryInto<UniqueName<'s>>,
@@ -87,6 +89,7 @@ impl<'a> Builder<'a> {
     /// Set the object to send a call to, or the object a signal is emitted from.
     ///
     /// An invalid path is reported by [`Builder::build`].
+    #[must_use]
     pub fn path<'p: 'a, P>(mut self, path: P) -> Self
     where
         P: TryInto<ObjectPath<'p>>,
@@ -98,6 +101,7 @@ impl<'a> Builder<'a> {
     /// Set the interface to invoke a method call on, or that a signal is emitted from.
     ///
     /// An invalid interface name is reported by [`Builder::build`].
+    #[must_use]
     pub fn interface<'i: 'a, I>(mut self, interface: I) -> Self
     where
         I: TryInto<InterfaceName<'i>>,
@@ -109,6 +113,7 @@ impl<'a> Builder<'a> {
     /// Set the member, either the method name or signal name.
     ///
     /// An invalid member name is reported by [`Builder::build`].
+    #[must_use]
     pub fn member<'m: 'a, M>(mut self, member: M) -> Self
     where
         M: TryInto<MemberName<'m>>,
@@ -120,6 +125,7 @@ impl<'a> Builder<'a> {
     /// Set the name of the error this message reports.
     ///
     /// An invalid error name is reported by [`Builder::build`].
+    #[must_use]
     pub(super) fn error_name<'e: 'a, E>(mut self, error: E) -> Self
     where
         E: TryInto<ErrorName<'e>>,
@@ -131,6 +137,7 @@ impl<'a> Builder<'a> {
     /// Set the name of the connection this message is intended for.
     ///
     /// An invalid destination name is reported by [`Builder::build`].
+    #[must_use]
     pub fn destination<'d: 'a, D>(mut self, destination: D) -> Self
     where
         D: TryInto<BusName<'d>>,
@@ -153,6 +160,7 @@ impl<'a> Builder<'a> {
         self
     }
 
+    #[must_use]
     pub(super) fn reply_to(mut self, reply_to: &Header<'_>) -> Self {
         let serial = reply_to.primary().serial_num();
         self.header.fields_mut().reply_serial = Some(serial);

--- a/zbus/src/message/mod.rs
+++ b/zbus/src/message/mod.rs
@@ -68,7 +68,9 @@ pub(super) struct Inner {
 
 impl Message {
     /// Create a builder for a message of type [`Type::MethodCall`].
-    pub fn method_call<'b, 'p: 'b, 'm: 'b, P, M>(path: P, method_name: M) -> Result<Builder<'b>>
+    ///
+    /// An invalid path or method name is reported by [`Builder::build`].
+    pub fn method_call<'b, 'p: 'b, 'm: 'b, P, M>(path: P, method_name: M) -> Builder<'b>
     where
         P: TryInto<ObjectPath<'p>>,
         M: TryInto<MemberName<'m>>,
@@ -76,16 +78,18 @@ impl Message {
         M::Error: Into<Error>,
     {
         Builder::new(Type::MethodCall)
-            .path(path)?
+            .path(path)
             .member(method_name)
     }
 
     /// Create a builder for a message of type [`Type::Signal`].
+    ///
+    /// An invalid path, interface name or signal name is reported by [`Builder::build`].
     pub fn signal<'b, 'p: 'b, 'i: 'b, 'm: 'b, P, I, M>(
         path: P,
         iface: I,
         signal_name: M,
-    ) -> Result<Builder<'b>>
+    ) -> Builder<'b>
     where
         P: TryInto<ObjectPath<'p>>,
         I: TryInto<InterfaceName<'i>>,
@@ -95,24 +99,26 @@ impl Message {
         M::Error: Into<Error>,
     {
         Builder::new(Type::Signal)
-            .path(path)?
-            .interface(iface)?
+            .path(path)
+            .interface(iface)
             .member(signal_name)
     }
 
     /// Create a builder for a message of type [`Type::MethodReturn`].
-    pub fn method_return(reply_to: &Header<'_>) -> Result<Builder<'static>> {
+    pub fn method_return(reply_to: &Header<'_>) -> Builder<'static> {
         Builder::new(Type::MethodReturn).reply_to(reply_to)
     }
 
     /// Create a builder for a message of type [`Type::Error`].
-    pub fn error<'b, 'e: 'b, E>(reply_to: &Header<'_>, name: E) -> Result<Builder<'b>>
+    ///
+    /// An invalid error name is reported by [`Builder::build`].
+    pub fn error<'b, 'e: 'b, E>(reply_to: &Header<'_>, name: E) -> Builder<'b>
     where
         E: TryInto<ErrorName<'e>>,
         E::Error: Into<Error>,
     {
         Builder::new(Type::Error)
-            .reply_to(reply_to)?
+            .reply_to(reply_to)
             .error_name(name)
     }
 
@@ -194,9 +200,9 @@ impl Message {
     /// # use zbus::message::Message;
     /// # (|| -> zbus::Result<()> {
     /// let send_body = (7i32, (2i32, "foo"), vec!["bar"]);
-    /// let message = Message::method_call("/", "ping")?
-    ///     .destination("zbus.test")?
-    ///     .interface("zbus.test")?
+    /// let message = Message::method_call("/", "ping")
+    ///     .destination("zbus.test")
+    ///     .interface("zbus.test")
     ///     .build(&send_body)?;
     /// let header = message.header();
     /// let body = message.body();
@@ -206,7 +212,7 @@ impl Message {
     /// assert!(matches!(fields[1], zbus::Value::Structure(_)));
     /// assert!(matches!(fields[2], zbus::Value::Array(_)));
     ///
-    /// let reply_body = Message::method_return(&header)?.build(&body)?.body();
+    /// let reply_body = Message::method_return(&header).build(&body)?.body();
     /// let reply_value : (i32, (i32, &str), Vec<String>) = reply_body.deserialize()?;
     ///
     /// assert_eq!(reply_value.0, 7);
@@ -348,9 +354,7 @@ mod tests {
         #[cfg(unix)]
         let stdout = std::io::stdout();
         let m = Message::method_call("/", "do")
-            .unwrap()
             .sender(":1.72")
-            .unwrap()
             .build(&(
                 #[cfg(unix)]
                 Fd::from(&stdout),
@@ -377,12 +381,10 @@ mod tests {
 
         assert_eq!(m.to_string(), "Method call do from :1.72");
         let r = Message::method_return(&m.header())
-            .unwrap()
             .build(&("all fine!"))
             .unwrap();
         assert_eq!(r.to_string(), "Method return");
         let e = Message::error(&m.header(), "org.freedesktop.zbus.Error")
-            .unwrap()
             .build(&("kaboom!", 32))
             .unwrap();
         assert_eq!(e.to_string(), "Error org.freedesktop.zbus.Error: kaboom!");

--- a/zbus/src/message/mod.rs
+++ b/zbus/src/message/mod.rs
@@ -70,6 +70,7 @@ impl Message {
     /// Create a builder for a message of type [`Type::MethodCall`].
     ///
     /// An invalid path or method name is reported by [`Builder::build`].
+    #[must_use]
     pub fn method_call<'b, 'p: 'b, 'm: 'b, P, M>(path: P, method_name: M) -> Builder<'b>
     where
         P: TryInto<ObjectPath<'p>>,
@@ -85,6 +86,7 @@ impl Message {
     /// Create a builder for a message of type [`Type::Signal`].
     ///
     /// An invalid path, interface name or signal name is reported by [`Builder::build`].
+    #[must_use]
     pub fn signal<'b, 'p: 'b, 'i: 'b, 'm: 'b, P, I, M>(
         path: P,
         iface: I,
@@ -105,6 +107,7 @@ impl Message {
     }
 
     /// Create a builder for a message of type [`Type::MethodReturn`].
+    #[must_use]
     pub fn method_return(reply_to: &Header<'_>) -> Builder<'static> {
         Builder::new(Type::MethodReturn).reply_to(reply_to)
     }
@@ -112,6 +115,7 @@ impl Message {
     /// Create a builder for a message of type [`Type::Error`].
     ///
     /// An invalid error name is reported by [`Builder::build`].
+    #[must_use]
     pub fn error<'b, 'e: 'b, E>(reply_to: &Header<'_>, name: E) -> Builder<'b>
     where
         E: TryInto<ErrorName<'e>>,

--- a/zbus/src/message_stream.rs
+++ b/zbus/src/message_stream.rs
@@ -66,11 +66,11 @@ impl MessageStream {
     /// let conn = Connection::session().await?;
     /// let rule = MatchRule::builder()
     ///     .msg_type(zbus::message::Type::Signal)
-    ///     .sender("org.freedesktop.DBus")?
-    ///     .interface("org.freedesktop.DBus")?
-    ///     .member("NameOwnerChanged")?
-    ///     .add_arg("org.freedesktop.zbus.MatchRuleStreamTest42")?
-    ///     .build();
+    ///     .sender("org.freedesktop.DBus")
+    ///     .interface("org.freedesktop.DBus")
+    ///     .member("NameOwnerChanged")
+    ///     .add_arg("org.freedesktop.zbus.MatchRuleStreamTest42")
+    ///     .build()?;
     /// let mut stream = MessageStream::for_match_rule(
     ///     rule,
     ///     &conn,

--- a/zbus/src/names/bus_name.rs
+++ b/zbus/src/names/bus_name.rs
@@ -209,6 +209,18 @@ impl<'name> From<WellKnownName<'name>> for BusName<'name> {
     }
 }
 
+impl<'name> From<&UniqueName<'name>> for BusName<'name> {
+    fn from(name: &UniqueName<'name>) -> Self {
+        BusName::Unique(name.clone())
+    }
+}
+
+impl<'name> From<&WellKnownName<'name>> for BusName<'name> {
+    fn from(name: &WellKnownName<'name>) -> Self {
+        BusName::WellKnown(name.clone())
+    }
+}
+
 impl<'s> TryFrom<Str<'s>> for BusName<'s> {
     type Error = Error;
 

--- a/zbus/src/proxy/builder.rs
+++ b/zbus/src/proxy/builder.rs
@@ -22,6 +22,11 @@ pub enum CacheProperties {
 }
 
 /// Builder for proxies.
+///
+/// Each setter takes the value it is given, whether that's an already parsed name or a string
+/// that still needs parsing, and converts it right away, but it never fails: the first error a
+/// setter hits is recorded — a later call doesn't clear it — and reported by [`Builder::build`],
+/// so a chain of setters never needs a `?` in between.
 #[derive(Debug)]
 pub struct Builder<'a, T = ()> {
     conn: Connection,
@@ -31,6 +36,7 @@ pub struct Builder<'a, T = ()> {
     proxy_type: PhantomData<T>,
     cache: CacheProperties,
     uncached_properties: Option<HashSet<Str<'a>>>,
+    error: Option<Error>,
 }
 
 impl<T> Clone for Builder<'_, T> {
@@ -43,39 +49,58 @@ impl<T> Clone for Builder<'_, T> {
             cache: self.cache,
             uncached_properties: self.uncached_properties.clone(),
             proxy_type: PhantomData,
+            error: self.error.clone(),
         }
     }
 }
 
 impl<'a, T> Builder<'a, T> {
     /// Set the proxy destination address.
-    pub fn destination<D>(mut self, destination: D) -> Result<Self>
+    ///
+    /// An invalid destination is reported by [`Builder::build`].
+    pub fn destination<D>(mut self, destination: D) -> Self
     where
         D: TryInto<BusName<'a>>,
         D::Error: Into<Error>,
     {
-        self.destination = Some(destination.try_into().map_err(Into::into)?);
-        Ok(self)
+        match destination.try_into() {
+            Ok(destination) => self.destination = Some(destination),
+            Err(e) => self.record(e.into()),
+        }
+
+        self
     }
 
     /// Set the proxy path.
-    pub fn path<P>(mut self, path: P) -> Result<Self>
+    ///
+    /// An invalid path is reported by [`Builder::build`].
+    pub fn path<P>(mut self, path: P) -> Self
     where
         P: TryInto<ObjectPath<'a>>,
         P::Error: Into<Error>,
     {
-        self.path = Some(path.try_into().map_err(Into::into)?);
-        Ok(self)
+        match path.try_into() {
+            Ok(path) => self.path = Some(path),
+            Err(e) => self.record(e.into()),
+        }
+
+        self
     }
 
     /// Set the proxy interface.
-    pub fn interface<I>(mut self, interface: I) -> Result<Self>
+    ///
+    /// An invalid interface name is reported by [`Builder::build`].
+    pub fn interface<I>(mut self, interface: I) -> Self
     where
         I: TryInto<InterfaceName<'a>>,
         I::Error: Into<Error>,
     {
-        self.interface = Some(interface.try_into().map_err(Into::into)?);
-        Ok(self)
+        match interface.try_into() {
+            Ok(interface) => self.interface = Some(interface),
+            Err(e) => self.record(e.into()),
+        }
+
+        self
     }
 
     /// Set the properties caching mode.
@@ -95,6 +120,11 @@ impl<'a, T> Builder<'a, T> {
     }
 
     pub(crate) fn build_internal(self) -> Result<Proxy<'a>> {
+        // The error a setter recorded comes first, then the missing pieces.
+        if let Some(error) = self.error {
+            return Err(error);
+        }
+
         let conn = self.conn;
         let destination = self
             .destination
@@ -120,8 +150,8 @@ impl<'a, T> Builder<'a, T> {
     ///
     /// # Errors
     ///
-    /// If the builder is lacking the necessary parameters to build a proxy,
-    /// [`Error::MissingParameter`] is returned.
+    /// The first error recorded by a setter, then [`Error::MissingParameter`] if the builder is
+    /// lacking the necessary parameters to build a proxy.
     pub async fn build(self) -> Result<T>
     where
         T: From<Proxy<'a>> + super::Defaults,
@@ -141,6 +171,13 @@ impl<'a, T> Builder<'a, T> {
 
         Ok(proxy.into())
     }
+
+    /// Record `error`, unless an earlier setter already recorded one.
+    fn record(&mut self, error: Error) {
+        if self.error.is_none() {
+            self.error = Some(error);
+        }
+    }
 }
 
 impl<T> Builder<'_, T>
@@ -158,6 +195,7 @@ where
             cache: CacheProperties::default(),
             uncached_properties: None,
             proxy_type: PhantomData,
+            error: None,
         }
     }
 }
@@ -176,13 +214,11 @@ mod tests {
     async fn builder_async() {
         let conn = Connection::session().await.unwrap();
 
+        // Strings are converted for us.
         let builder = Builder::<Proxy<'_>>::new(&conn)
             .destination("org.freedesktop.DBus")
-            .unwrap()
             .path("/some/path")
-            .unwrap()
             .interface("org.freedesktop.Interface")
-            .unwrap()
             .cache_properties(CacheProperties::No);
         assert!(matches!(
             builder.clone().destination.unwrap(),
@@ -190,5 +226,46 @@ mod tests {
         ));
         let proxy = builder.build().await.unwrap();
         assert!(matches!(proxy.inner.destination, BusName::Unique(_)));
+
+        // As are already parsed values, without any error handling on the way.
+        let destination = BusName::try_from("org.freedesktop.DBus").unwrap();
+        let path = ObjectPath::try_from("/some/path").unwrap();
+        let interface = InterfaceName::try_from("org.freedesktop.Interface").unwrap();
+        let proxy = Builder::<Proxy<'_>>::new(&conn)
+            .destination(&destination)
+            .path(path.clone())
+            .interface(interface.clone())
+            .build()
+            .await
+            .unwrap();
+        assert_eq!(proxy.inner.path, path);
+        assert_eq!(proxy.inner.interface, interface);
+
+        // An invalid value is only reported by `build`.
+        let err = Builder::<Proxy<'_>>::new(&conn)
+            .destination("not a bus name")
+            .path("/some/path")
+            .interface("org.freedesktop.Interface")
+            .build()
+            .await
+            .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            BusName::try_from("not a bus name").unwrap_err().to_string(),
+        );
+
+        // Setting the field again, even to a valid value, doesn't clear the error it recorded.
+        let err = Builder::<Proxy<'_>>::new(&conn)
+            .destination("not a bus name")
+            .destination("org.freedesktop.DBus")
+            .path("/some/path")
+            .interface("org.freedesktop.Interface")
+            .build()
+            .await
+            .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            BusName::try_from("not a bus name").unwrap_err().to_string(),
+        );
     }
 }

--- a/zbus/src/proxy/builder.rs
+++ b/zbus/src/proxy/builder.rs
@@ -58,6 +58,7 @@ impl<'a, T> Builder<'a, T> {
     /// Set the proxy destination address.
     ///
     /// An invalid destination is reported by [`Builder::build`].
+    #[must_use]
     pub fn destination<D>(mut self, destination: D) -> Self
     where
         D: TryInto<BusName<'a>>,
@@ -74,6 +75,7 @@ impl<'a, T> Builder<'a, T> {
     /// Set the proxy path.
     ///
     /// An invalid path is reported by [`Builder::build`].
+    #[must_use]
     pub fn path<P>(mut self, path: P) -> Self
     where
         P: TryInto<ObjectPath<'a>>,
@@ -90,6 +92,7 @@ impl<'a, T> Builder<'a, T> {
     /// Set the proxy interface.
     ///
     /// An invalid interface name is reported by [`Builder::build`].
+    #[must_use]
     pub fn interface<I>(mut self, interface: I) -> Self
     where
         I: TryInto<InterfaceName<'a>>,

--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -536,12 +536,12 @@ impl<'a> ProxyInner<'a> {
         let conn = &self.inner_without_borrows.conn;
         let signal_rule: OwnedMatchRule = MatchRule::builder()
             .msg_type(Type::Signal)
-            .sender("org.freedesktop.DBus")?
-            .path("/org/freedesktop/DBus")?
-            .interface("org.freedesktop.DBus")?
-            .member("NameOwnerChanged")?
-            .add_arg(well_known_name.as_str())?
-            .build()
+            .sender("org.freedesktop.DBus")
+            .path("/org/freedesktop/DBus")
+            .interface("org.freedesktop.DBus")
+            .member("NameOwnerChanged")
+            .add_arg(well_known_name.as_str())
+            .build()?
             .to_owned()
             .into();
 
@@ -1142,16 +1142,16 @@ impl<'a> SignalStream<'a> {
     ) -> Result<SignalStream<'a>> {
         let mut rule_builder = MatchRule::builder()
             .msg_type(Type::Signal)
-            .sender(proxy.destination())?
-            .path(proxy.path())?
-            .interface(proxy.interface())?;
+            .sender(proxy.destination())
+            .path(proxy.path())
+            .interface(proxy.interface());
         if let Some(name) = &signal_name {
-            rule_builder = rule_builder.member(name)?;
+            rule_builder = rule_builder.member(name);
         }
         for (i, arg) in args {
-            rule_builder = rule_builder.arg(*i, *arg)?;
+            rule_builder = rule_builder.arg(*i, *arg);
         }
-        let signal_rule: OwnedMatchRule = rule_builder.build().to_owned().into();
+        let signal_rule: OwnedMatchRule = rule_builder.build()?.to_owned().into();
         let conn = proxy.connection();
 
         let (src_unique_name, stream) = match proxy.destination().to_owned() {
@@ -1167,12 +1167,12 @@ impl<'a> SignalStream<'a> {
 
                 let name_owner_changed_rule = MatchRule::builder()
                     .msg_type(Type::Signal)
-                    .sender("org.freedesktop.DBus")?
-                    .path("/org/freedesktop/DBus")?
-                    .interface("org.freedesktop.DBus")?
-                    .member("NameOwnerChanged")?
-                    .add_arg(name.as_str())?
-                    .build();
+                    .sender("org.freedesktop.DBus")
+                    .path("/org/freedesktop/DBus")
+                    .interface("org.freedesktop.DBus")
+                    .member("NameOwnerChanged")
+                    .add_arg(name.as_str())
+                    .build()?;
                 let name_owner_changed_stream = MessageStream::for_match_rule(
                     name_owner_changed_rule,
                     conn,

--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -584,9 +584,9 @@ impl<'a> Proxy<'a> {
         I::Error: Into<Error>,
     {
         Builder::new(conn)
-            .destination(destination)?
-            .path(path)?
-            .interface(interface)?
+            .destination(destination)
+            .path(path)
+            .interface(interface)
             .build()
             .await
     }
@@ -608,9 +608,9 @@ impl<'a> Proxy<'a> {
         I::Error: Into<Error>,
     {
         Builder::new(&conn)
-            .destination(destination)?
-            .path(path)?
-            .interface(interface)?
+            .destination(destination)
+            .path(path)
+            .interface(interface)
             .build()
             .await
     }
@@ -641,8 +641,8 @@ impl<'a> Proxy<'a> {
     /// result.
     pub async fn introspect(&self) -> fdo::Result<String> {
         let proxy = IntrospectableProxy::builder(&self.inner.inner_without_borrows.conn)
-            .destination(&self.inner.destination)?
-            .path(&self.inner.path)?
+            .destination(&self.inner.destination)
+            .path(&self.inner.path)
             .build()
             .await?;
 
@@ -651,31 +651,25 @@ impl<'a> Proxy<'a> {
 
     fn properties_proxy(&self) -> PropertiesProxy<'_> {
         PropertiesProxy::builder(&self.inner.inner_without_borrows.conn)
-            // Safe because already checked earlier
             .destination(self.inner.destination.as_ref())
-            .unwrap()
-            // Safe because already checked earlier
             .path(self.inner.path.as_ref())
-            .unwrap()
             // does not have properties
             .cache_properties(CacheProperties::No)
             .build_internal()
-            .unwrap()
+            // Safe because the destination and path were already checked.
+            .expect("invalid properties proxy")
             .into()
     }
 
     fn owned_properties_proxy(&self) -> PropertiesProxy<'static> {
         PropertiesProxy::builder(&self.inner.inner_without_borrows.conn)
-            // Safe because already checked earlier
             .destination(self.inner.destination.to_owned())
-            .unwrap()
-            // Safe because already checked earlier
             .path(self.inner.path.to_owned())
-            .unwrap()
             // does not have properties
             .cache_properties(CacheProperties::No)
             .build_internal()
-            .unwrap()
+            // Safe because the destination and path were already checked.
+            .expect("invalid properties proxy")
             .into()
     }
 
@@ -1403,9 +1397,9 @@ mod tests {
 
         let well_known = "org.freedesktop.zbus.async.ProxySignalStreamTest";
         let proxy: Proxy<'_> = Builder::new(&conn)
-            .destination(well_known)?
-            .path("/does/not/matter")?
-            .interface("does.not.matter")?
+            .destination(well_known)
+            .path("/does/not/matter")
+            .interface("does.not.matter")
             .build()
             .await?;
         let mut owner_changed_stream = proxy.receive_owner_changed().await?;
@@ -1503,8 +1497,8 @@ mod tests {
 
         let test_proxy = TestProxy::new(&client_conn).await?;
         let test_prop_proxy = PropertiesProxy::builder(&client_conn)
-            .destination("org.zbus.Test.MR501")?
-            .path("/org/zbus/Test")?
+            .destination("org.zbus.Test.MR501")
+            .path("/org/zbus/Test")
             .build()
             .await?;
 

--- a/zbus/src/proxy/mod.rs
+++ b/zbus/src/proxy/mod.rs
@@ -1484,16 +1484,13 @@ mod tests {
         }
 
         let test_iface = TestIface;
-        let server_conn = connection::Builder::session()?
-            .name("org.zbus.Test.MR501")?
-            .serve_at("/org/zbus/Test", test_iface)?
+        let server_conn = connection::Builder::session()
+            .name("org.zbus.Test.MR501")
+            .serve_at("/org/zbus/Test", test_iface)
             .build()
             .await?;
 
-        let client_conn = connection::Builder::session()?
-            .max_queued(1)
-            .build()
-            .await?;
+        let client_conn = connection::Builder::session().max_queued(1).build().await?;
 
         let test_proxy = TestProxy::new(&client_conn).await?;
         let test_prop_proxy = PropertiesProxy::builder(&client_conn)

--- a/zbus/src/wire/object_path.rs
+++ b/zbus/src/wire/object_path.rs
@@ -282,7 +282,7 @@ impl<'a> Borrow<ObjectPath<'a>> for OwnedObjectPath {
     }
 }
 
-impl std::convert::From<OwnedObjectPath> for ObjectPath<'static> {
+impl std::convert::From<OwnedObjectPath> for ObjectPath<'_> {
     fn from(o: OwnedObjectPath) -> Self {
         o.into_inner()
     }

--- a/zbus/tests/basic.rs
+++ b/zbus/tests/basic.rs
@@ -424,7 +424,7 @@ async fn ibus_connection() {
 
 #[cfg(all(unix, feature = "ibus"))]
 async fn test_ibus_connection() -> Result<()> {
-    let connection = zbus::connection::Builder::ibus()?.build().await?;
+    let connection = zbus::connection::Builder::ibus().build().await?;
 
     // Just verify we can get a unique name.
     assert!(connection.unique_name().is_some());

--- a/zbus/tests/basic.rs
+++ b/zbus/tests/basic.rs
@@ -19,11 +19,8 @@ use zbus::{
 #[test]
 fn msg() {
     let m = Message::method_call("/org/freedesktop/DBus", "GetMachineId")
-        .unwrap()
         .destination("org.freedesktop.DBus")
-        .unwrap()
         .interface("org.freedesktop.DBus.Peer")
-        .unwrap()
         .build(&())
         .unwrap();
     let hdr = m.header();

--- a/zbus/tests/builder_message_stream.rs
+++ b/zbus/tests/builder_message_stream.rs
@@ -25,10 +25,7 @@ fn build_message_stream_does_not_drop_pipelined_hello_async_io() {
         let guid = Guid::generate();
 
         build_message_stream_does_not_drop_pipelined_hello(
-            Builder::async_io_unix_stream(s0)
-                .server(guid)
-                .unwrap()
-                .p2p(),
+            Builder::async_io_unix_stream(s0).server(guid).p2p(),
             Builder::async_io_unix_stream(s1),
         )
         .await;
@@ -44,7 +41,7 @@ fn build_message_stream_does_not_drop_pipelined_hello_tokio() {
         let guid = Guid::generate();
 
         build_message_stream_does_not_drop_pipelined_hello(
-            Builder::tokio_unix_stream(s0).server(guid).unwrap().p2p(),
+            Builder::tokio_unix_stream(s0).server(guid).p2p(),
             Builder::tokio_unix_stream(s1),
         )
         .await;

--- a/zbus/tests/connection_closed.rs
+++ b/zbus/tests/connection_closed.rs
@@ -14,10 +14,7 @@ fn closed_resolves_when_peer_disconnects() {
         let (s0, s1) = UnixStream::pair().unwrap();
         let guid = Guid::generate();
 
-        let server_builder = Builder::async_io_unix_stream(s0)
-            .server(guid)
-            .unwrap()
-            .p2p();
+        let server_builder = Builder::async_io_unix_stream(s0).server(guid).p2p();
         let client_builder = Builder::async_io_unix_stream(s1).p2p();
 
         let (server, client) = futures_util::join!(server_builder.build(), client_builder.build());
@@ -42,10 +39,7 @@ fn closed_resolves_on_explicit_close() {
         let (s0, s1) = UnixStream::pair().unwrap();
         let guid = Guid::generate();
 
-        let server_builder = Builder::async_io_unix_stream(s0)
-            .server(guid)
-            .unwrap()
-            .p2p();
+        let server_builder = Builder::async_io_unix_stream(s0).server(guid).p2p();
         let client_builder = Builder::async_io_unix_stream(s1).p2p();
 
         let (server, client) = futures_util::join!(server_builder.build(), client_builder.build());
@@ -69,10 +63,7 @@ fn closed_resolves_immediately_if_already_closed() {
         let (s0, s1) = UnixStream::pair().unwrap();
         let guid = Guid::generate();
 
-        let server_builder = Builder::async_io_unix_stream(s0)
-            .server(guid)
-            .unwrap()
-            .p2p();
+        let server_builder = Builder::async_io_unix_stream(s0).server(guid).p2p();
         let client_builder = Builder::async_io_unix_stream(s1).p2p();
 
         let (server, client) = futures_util::join!(server_builder.build(), client_builder.build());

--- a/zbus/tests/e2e.rs
+++ b/zbus/tests/e2e.rs
@@ -45,16 +45,11 @@ async fn iface_and_proxy_(#[allow(unused)] p2p: bool) {
 
     let session_conns_build = || {
         let service_conn_builder = connection::Builder::session()
-            .unwrap()
             .name("org.freedesktop.MyService")
-            .unwrap()
             .name("org.freedesktop.MyService.foo")
-            .unwrap()
             .name("org.freedesktop.MyService.bar")
-            .unwrap()
-            .name("org.freedesktop.MyEmitsChangedSignalIface")
-            .unwrap();
-        let client_conn_builder = connection::Builder::session().unwrap();
+            .name("org.freedesktop.MyEmitsChangedSignalIface");
+        let client_conn_builder = connection::Builder::session();
 
         (service_conn_builder, client_conn_builder)
     };
@@ -68,7 +63,6 @@ async fn iface_and_proxy_(#[allow(unused)] p2p: bool) {
             let builders = (
                 connection::Builder::async_io_unix_stream(p0)
                     .server(guid)
-                    .unwrap()
                     .p2p(),
                 connection::Builder::async_io_unix_stream(p1).p2p(),
             );
@@ -76,7 +70,6 @@ async fn iface_and_proxy_(#[allow(unused)] p2p: bool) {
             let builders = (
                 connection::Builder::tokio_unix_stream(p0)
                     .server(guid)
-                    .unwrap()
                     .p2p(),
                 connection::Builder::tokio_unix_stream(p1).p2p(),
             );
@@ -96,7 +89,6 @@ async fn iface_and_proxy_(#[allow(unused)] p2p: bool) {
                 (
                     connection::Builder::async_io_tcp_stream(p0)
                         .server(guid)
-                        .unwrap()
                         .p2p(),
                     connection::Builder::async_io_tcp_stream(p1).p2p(),
                 )
@@ -110,10 +102,7 @@ async fn iface_and_proxy_(#[allow(unused)] p2p: bool) {
                 let p0 = listener.accept().await.unwrap().0;
 
                 (
-                    connection::Builder::tokio_tcp_stream(p0)
-                        .server(guid)
-                        .unwrap()
-                        .p2p(),
+                    connection::Builder::tokio_tcp_stream(p0).server(guid).p2p(),
                     connection::Builder::tokio_tcp_stream(p1).p2p(),
                 )
             }
@@ -134,13 +123,9 @@ async fn iface_and_proxy_(#[allow(unused)] p2p: bool) {
     );
     let (next_tx, mut next_rx) = channel(64);
     let iface = MyIface::new(next_tx.clone());
-    let service_conn_builder = service_conn_builder
-        .serve_at("/org/freedesktop/MyService", iface)
-        .unwrap();
+    let service_conn_builder = service_conn_builder.serve_at("/org/freedesktop/MyService", iface);
     #[cfg(feature = "object-manager")]
-    let service_conn_builder = service_conn_builder
-        .serve_at("/zbus/test", ObjectManager)
-        .unwrap();
+    let service_conn_builder = service_conn_builder.serve_at("/zbus/test", ObjectManager);
     debug!("ObjectServer set-up.");
 
     let (service_conn, client_conn) = futures_util::try_join!(

--- a/zbus/tests/iface_and_proxy/client.rs
+++ b/zbus/tests/iface_and_proxy/client.rs
@@ -47,8 +47,8 @@ pub async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> 
     drop(stream);
 
     let root_introspect_proxy = zbus::fdo::IntrospectableProxy::builder(&conn)
-        .destination("org.freedesktop.MyService")?
-        .path("/")?
+        .destination("org.freedesktop.MyService")
+        .path("/")
         .build()
         .await?;
     debug!("Created: {:?}", root_introspect_proxy);
@@ -89,8 +89,8 @@ pub async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> 
     );
 
     let proxy = MyIfaceProxy::builder(&conn)
-        .destination("org.freedesktop.MyService")?
-        .path("/org/freedesktop/MyService")?
+        .destination("org.freedesktop.MyService")
+        .path("/org/freedesktop/MyService")
         // the server isn't yet running
         .cache_properties(CacheProperties::No)
         .build()
@@ -109,8 +109,8 @@ pub async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> 
     );
 
     let props_proxy = PropertiesProxy::builder(&conn)
-        .destination("org.freedesktop.MyService")?
-        .path("/org/freedesktop/MyService")?
+        .destination("org.freedesktop.MyService")
+        .path("/org/freedesktop/MyService")
         .build()
         .await?;
     debug!("Created: {:?}", props_proxy);
@@ -331,8 +331,8 @@ pub async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> 
 
     #[cfg(feature = "object-manager")]
     let obj_manager_proxy = ObjectManagerProxy::builder(&conn)
-        .destination("org.freedesktop.MyService")?
-        .path("/zbus/test")?
+        .destination("org.freedesktop.MyService")
+        .path("/zbus/test")
         .build()
         .await?;
     #[cfg(feature = "object-manager")]
@@ -382,8 +382,8 @@ pub async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> 
     assert!(proxy.inner().call_method("CreateObj", &()).await.is_err());
 
     let my_obj_proxy = MyIfaceProxy::builder(&conn)
-        .destination("org.freedesktop.MyService")?
-        .path("/zbus/test/MyObj")?
+        .destination("org.freedesktop.MyService")
+        .path("/zbus/test/MyObj")
         .build()
         .await?;
     debug!("Created: {:?}", my_obj_proxy);
@@ -444,8 +444,8 @@ pub async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> 
         .call_method("CreateObjInside", &("CreatedInside"))
         .await?;
     let created_inside_proxy = MyIfaceProxy::builder(&conn)
-        .destination("org.freedesktop.MyService")?
-        .path("/zbus/test/CreatedInside")?
+        .destination("org.freedesktop.MyService")
+        .path("/zbus/test/CreatedInside")
         .build()
         .await?;
     created_inside_proxy.ping().await?;
@@ -458,8 +458,8 @@ pub async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> 
         .call_method("CreateObjInsideMut", &("CreatedInsideMut"))
         .await?;
     let created_inside_mut_proxy = MyIfaceProxy::builder(&conn)
-        .destination("org.freedesktop.MyService")?
-        .path("/zbus/test/CreatedInsideMut")?
+        .destination("org.freedesktop.MyService")
+        .path("/zbus/test/CreatedInsideMut")
         .build()
         .await?;
     created_inside_mut_proxy.ping().await?;

--- a/zbus/tests/iface_and_proxy/client.rs
+++ b/zbus/tests/iface_and_proxy/client.rs
@@ -21,9 +21,9 @@ pub async fn my_iface_test(conn: Connection, event: Event) -> zbus::Result<u32> 
     // Use low-level API for `TestResponseNotify` because we need to ensure that the signal is
     // always received after the response.
     let mut stream = MessageStream::from(&conn);
-    let method = Message::method_call("/org/freedesktop/MyService", "TestResponseNotify")?
-        .interface("org.freedesktop.MyIface")?
-        .destination("org.freedesktop.MyService")?
+    let method = Message::method_call("/org/freedesktop/MyService", "TestResponseNotify")
+        .interface("org.freedesktop.MyIface")
+        .destination("org.freedesktop.MyService")
         .build(&())?;
     let serial = method.primary_header().serial_num();
     conn.send(&method).await?;

--- a/zbus/tests/issue/issue_1003.rs
+++ b/zbus/tests/issue/issue_1003.rs
@@ -41,7 +41,6 @@ fn issue_1003() {
         let service_conn_builder = service_conn_builder
             .auth_mechanism(AuthMechanism::External)
             .server(guid)
-            .unwrap()
             .p2p()
             .user_id(UID);
         let client_conn_builder = client_conn_builder.p2p().user_id(UID);

--- a/zbus/tests/issue/issue_1015.rs
+++ b/zbus/tests/issue/issue_1015.rs
@@ -35,11 +35,8 @@ fn issue_1015() {
 
 async fn issue_1015_async() {
     let conn = Builder::session()
-        .unwrap()
         .serve_at(IfaceProxy::PATH.as_ref().unwrap(), Iface)
-        .unwrap()
         .name(IfaceProxy::DESTINATION.clone().unwrap())
-        .unwrap()
         .build()
         .await
         .unwrap();

--- a/zbus/tests/issue/issue_104.rs
+++ b/zbus/tests/issue/issue_104.rs
@@ -43,9 +43,7 @@ async fn issue104_async() {
 
     let secret = Secret;
     let conn = conn::Builder::session()
-        .unwrap()
         .serve_at("/org/freedesktop/secrets", secret)
-        .unwrap()
         .build()
         .await
         .unwrap();

--- a/zbus/tests/issue/issue_104.rs
+++ b/zbus/tests/issue/issue_104.rs
@@ -64,9 +64,7 @@ async fn issue104_async() {
 
         let proxy = SecretProxy::builder(&conn)
             .destination(UniqueName::from(service_name))
-            .unwrap()
             .path("/org/freedesktop/secrets")
-            .unwrap()
             .build()
             .await
             .unwrap();

--- a/zbus/tests/issue/issue_122.rs
+++ b/zbus/tests/issue/issue_122.rs
@@ -49,9 +49,7 @@ fn issue_122() {
 
     let destination = conn.unique_name().map(UniqueName::<'_>::from).unwrap();
     let msg = Message::method_call("/does/not/matter", "ZBusIssue122")
-        .unwrap()
         .destination(destination)
-        .unwrap()
         .build(&())
         .unwrap();
     conn.send(&msg).unwrap();

--- a/zbus/tests/issue/issue_1478.rs
+++ b/zbus/tests/issue/issue_1478.rs
@@ -33,7 +33,7 @@ async fn connection_error_async() {
     addresses.push(VSOCK_ADDRESS);
 
     for addr in addresses {
-        let res = connection::Builder::address(addr).unwrap().build().await;
+        let res = connection::Builder::address(addr).build().await;
 
         let Err(Error::Connection(_, error_addr)) = res else {
             panic!("expected a connection error, got {res:?}");

--- a/zbus/tests/issue/issue_173.rs
+++ b/zbus/tests/issue/issue_173.rs
@@ -56,11 +56,8 @@ async fn issue_173_async(mut rx: Receiver<()>) {
     rx.recv().await.unwrap();
     for _ in 0..2 {
         let conn = zbus::connection::Builder::session()
-            .unwrap()
             .serve_at("/org/freedesktop/zbus/ComeAndGo", ComeAndGo)
-            .unwrap()
             .name("org.freedesktop.zbus.ComeAndGo")
-            .unwrap()
             .build()
             .await
             .unwrap();

--- a/zbus/tests/issue/issue_1916.rs
+++ b/zbus/tests/issue/issue_1916.rs
@@ -28,9 +28,7 @@ fn issue_1916() {
 async fn issue_1916_async() {
     let leaf = "/org/zbus/issue1916/sub/leaf";
     let server_conn = Builder::session()
-        .unwrap()
         .serve_at(leaf, Iface)
-        .unwrap()
         .build()
         .await
         .unwrap();

--- a/zbus/tests/issue/issue_1916.rs
+++ b/zbus/tests/issue/issue_1916.rs
@@ -41,9 +41,7 @@ async fn issue_1916_async() {
         async move {
             zbus::fdo::IntrospectableProxy::builder(&client_conn)
                 .destination(dest)
-                .unwrap()
                 .path(path)
-                .unwrap()
                 .build()
                 .await
                 .unwrap()

--- a/zbus/tests/issue/issue_279.rs
+++ b/zbus/tests/issue/issue_279.rs
@@ -15,11 +15,7 @@ async fn issue_279() {
     let guid = zbus::Guid::generate();
     let (p0, p1) = UnixStream::pair().unwrap();
 
-    let server = Builder::tokio_unix_stream(p0)
-        .server(guid)
-        .unwrap()
-        .p2p()
-        .build();
+    let server = Builder::tokio_unix_stream(p0).server(guid).p2p().build();
     let client = Builder::tokio_unix_stream(p1).p2p().build();
     let (client, server) = try_join!(client, server).unwrap();
     let mut stream = MessageStream::from(client);

--- a/zbus/tests/issue/issue_310.rs
+++ b/zbus/tests/issue/issue_310.rs
@@ -36,11 +36,8 @@ async fn issue_310() {
         fn connected_network(&self) -> zbus::Result<OwnedObjectPath>;
     }
     let connection = Builder::session()
-        .unwrap()
         .serve_at("/net/connman/iwd/0/33", Station(0))
-        .unwrap()
         .name("net.connman.iwd")
-        .unwrap()
         .build()
         .await
         .unwrap();

--- a/zbus/tests/issue/issue_310.rs
+++ b/zbus/tests/issue/issue_310.rs
@@ -70,7 +70,6 @@ async fn issue_310() {
 
     let station = StationProxy::builder(&connection)
         .path("/net/connman/iwd/0/33")
-        .unwrap()
         .build()
         .await
         .unwrap();

--- a/zbus/tests/issue/issue_356.rs
+++ b/zbus/tests/issue/issue_356.rs
@@ -63,9 +63,7 @@ async fn issue_356() {
     // Create a proxy for the Device interface using the auto-generated DeviceProxy
     let device_proxy = DeviceProxy::builder(&connection)
         .destination("org.test.Issue356")
-        .unwrap()
         .path(&device_path)
-        .unwrap()
         .build()
         .await
         .unwrap();

--- a/zbus/tests/issue/issue_356.rs
+++ b/zbus/tests/issue/issue_356.rs
@@ -39,23 +39,19 @@ async fn issue_356() {
 
     // Create the service connection with both interfaces registered
     let connection = Builder::session()
-        .unwrap()
         .serve_at(
             &adapter_path,
             Adapter {
                 name: "TestAdapter".to_string(),
             },
         )
-        .unwrap()
         .serve_at(
             &device_path,
             Device {
                 adapter_path: adapter_path.clone(),
             },
         )
-        .unwrap()
         .name("org.test.Issue356")
-        .unwrap()
         .build()
         .await
         .unwrap();

--- a/zbus/tests/issue/issue_68.rs
+++ b/zbus/tests/issue/issue_68.rs
@@ -23,11 +23,8 @@ async fn issue_68_async() {
     let client_conn = Connection::session().await.unwrap();
     let destination = conn.unique_name().map(UniqueName::<'_>::from).unwrap();
     let msg = Message::method_call("/org/freedesktop/Issue68", "Ping")
-        .unwrap()
         .destination(destination)
-        .unwrap()
         .interface("org.freedesktop.Issue68")
-        .unwrap()
         .build(&())
         .unwrap();
     let serial = msg.primary_header().serial_num();

--- a/zbus/tests/issue/issue_799.rs
+++ b/zbus/tests/issue/issue_799.rs
@@ -27,11 +27,8 @@ fn concurrent_interface_methods() {
         let listener = event.listen();
         let iface = Iface(event);
         let conn = zbus::connection::Builder::session()
-            .unwrap()
             .name("org.zbus.test.issue799")
-            .unwrap()
             .serve_at("/org/zbus/test/issue799", iface)
-            .unwrap()
             .build()
             .await
             .unwrap();

--- a/zbus/tests/issue/issue_813.rs
+++ b/zbus/tests/issue/issue_813.rs
@@ -63,7 +63,7 @@ fn issue_813() {
             #[cfg(feature = "tokio")]
             let builder = Builder::tokio_unix_stream(p0);
             let _conn = builder
-                .server(guid)?
+                .server(guid)
                 .p2p()
                 .serve_at(
                     "/org/zbus/Issue813",
@@ -71,8 +71,8 @@ fn issue_813() {
                         event: server_event,
                         call_count: 0,
                     },
-                )?
-                .name("org.zbus.Issue813")?
+                )
+                .name("org.zbus.Issue813")
                 .build()
                 .await?;
             client_listener.await;

--- a/zbus/tests/issue/issue_813.rs
+++ b/zbus/tests/issue/issue_813.rs
@@ -86,9 +86,9 @@ fn issue_813() {
             );
             let mut bytes: Vec<u8> = commands.bytes().collect();
             let fd = std::io::stdin();
-            let msg = zbus::message::Message::method_call("/org/zbus/Issue813", "PassFd")?
-                .destination("org.zbus.Issue813")?
-                .interface("org.zbus.Issue813")?
+            let msg = zbus::message::Message::method_call("/org/zbus/Issue813", "PassFd")
+                .destination("org.zbus.Issue813")
+                .interface("org.zbus.Issue813")
                 .build(&(Fd::from(fd.as_fd())))?;
             let msg_data = msg.data();
             let mut fds = vec![];

--- a/zbus/tests/uncached_propert.rs
+++ b/zbus/tests/uncached_propert.rs
@@ -50,12 +50,10 @@ async fn test_uncached_property() -> Result<()> {
     }
 
     let service = zbus::connection::Builder::session()
-        .unwrap()
         .serve_at(
             "/org/freedesktop/zbus/UncachedPropertyTest",
             ServiceUncachedPropertyTest(false),
         )
-        .unwrap()
         .build()
         .await
         .unwrap();
@@ -162,11 +160,11 @@ async fn test_serde_property() -> Result<()> {
         fn dynamic_dict(&self) -> zbus::Result<HashMap<String, String>>;
     }
 
-    let service = zbus::connection::Builder::session()?
+    let service = zbus::connection::Builder::session()
         .serve_at(
             "/org/freedesktop/zbus/SerdePropertyTest",
             Service("before".to_string()),
-        )?
+        )
         .build()
         .await?;
     let client_conn = zbus::Connection::session().await?;

--- a/zbus/tests/uncached_propert.rs
+++ b/zbus/tests/uncached_propert.rs
@@ -65,7 +65,6 @@ async fn test_uncached_property() -> Result<()> {
     let client_conn = zbus::Connection::session().await.unwrap();
     let client = UncachedPropertyTestProxy::builder(&client_conn)
         .destination(dest)
-        .unwrap()
         .build()
         .await
         .unwrap();
@@ -172,7 +171,7 @@ async fn test_serde_property() -> Result<()> {
         .await?;
     let client_conn = zbus::Connection::session().await?;
     let client = SerdePropertyTestProxy::builder(&client_conn)
-        .destination(service.unique_name().unwrap())?
+        .destination(service.unique_name().unwrap())
         .build()
         .await?;
 

--- a/zbus/tests/unixexec.rs
+++ b/zbus/tests/unixexec.rs
@@ -12,7 +12,7 @@ fn unixexec_connection_async() {
 }
 
 async fn test_unixexec_connection() -> Result<()> {
-    let connection = Builder::address("unixexec:path=systemd-stdio-bridge")?
+    let connection = Builder::address("unixexec:path=systemd-stdio-bridge")
         .build()
         .await?;
 

--- a/zbus_macros/src/error.rs
+++ b/zbus_macros/src/error.rs
@@ -202,7 +202,7 @@ pub fn expand_derive(input: DeriveInput) -> Result<TokenStream, Error> {
 
             fn create_reply(&self, call: &#zbus::message::Header) -> #zbus::Result<#zbus::message::Message> {
                 let name = self.name();
-                let #builder = #zbus::message::Message::error(call, name)?;
+                let #builder = #zbus::message::Message::error(call, name);
                 match self {
                     #replies
                 }

--- a/zbus_macros/src/lib.rs
+++ b/zbus_macros/src/lib.rs
@@ -178,7 +178,7 @@ mod utils;
 /// let connection = Connection::session()?;
 /// // Use `builder` to override the default arguments, `new` otherwise.
 /// let proxy = SomeIfaceProxyBlocking::builder(&connection)
-///                .destination("org.another.Service")?
+///                .destination("org.another.Service")
 ///                .cache_properties(zbus::proxy::CacheProperties::No)
 ///                .build()?;
 /// let _ = proxy.do_this("foo", 32, &Value::new(true));

--- a/zbus_macros/src/proxy.rs
+++ b/zbus_macros/src/proxy.rs
@@ -328,8 +328,8 @@ pub fn create_proxy(
                     let obj_path = path.try_into().map_err(::std::convert::Into::into)?;
                     let obj_destination = destination.try_into().map_err(::std::convert::Into::into)?;
                     Self::builder(conn)
-                        .path(obj_path)?
-                        .destination(obj_destination)?
+                        .path(obj_path)
+                        .destination(obj_destination)
                         .build()#wait
                 }
             }
@@ -344,7 +344,7 @@ pub fn create_proxy(
                 {
                     let obj_dest = destination.try_into().map_err(::std::convert::Into::into)?;
                     Self::builder(conn)
-                        .destination(obj_dest)?
+                        .destination(obj_dest)
                         .build()#wait
                 }
             }
@@ -359,7 +359,7 @@ pub fn create_proxy(
                 {
                     let obj_path = path.try_into().map_err(::std::convert::Into::into)?;
                     Self::builder(conn)
-                        .path(obj_path)?
+                        .path(obj_path)
                         .build()#wait
                 }
             }
@@ -628,7 +628,7 @@ fn gen_proxy_method_call(
 
         let proxy_build = quote! {
             #proxy_path::builder(&self.0.connection())
-                .path(object_path)?
+                .path(object_path)
                 .build()
                 #wait
         };
@@ -802,8 +802,8 @@ fn gen_proxy_property(
             };
             let proxy_build = quote! {
                 #proxy_path::builder(&self.0.connection())
-                    .destination(self.0.destination().to_owned())?
-                    .path(object_path)?
+                    .destination(self.0.destination().to_owned())
+                    .path(object_path)
                     .build()
                     #wait
             };

--- a/zbus_macros/tests/tests.rs
+++ b/zbus_macros/tests/tests.rs
@@ -469,9 +469,7 @@ fn test_proxy_object_list() {
     }
 
     let connection = zbus::blocking::connection::Builder::session()
-        .unwrap()
         .serve_at(OBJECT_LIST.paths[1].as_ref(), OBJECT_LIST.clone())
-        .unwrap()
         .build()
         .unwrap();
     let destination = connection.unique_name().unwrap().clone();

--- a/zbus_macros/tests/tests.rs
+++ b/zbus_macros/tests/tests.rs
@@ -72,7 +72,6 @@ fn test_proxy() {
         let connection = zbus::Connection::session().await.unwrap();
         let proxy = test::TestProxy::builder(&connection)
             .path("/org/freedesktop/zbus_macros/test")
-            .unwrap()
             .cache_properties(CacheProperties::No)
             .build()
             .await
@@ -483,9 +482,7 @@ fn test_proxy_object_list() {
 
     let proxy = ObjectListProxyBlocking::builder(&connection)
         .path(OBJECT_LIST.paths[1].as_ref())
-        .unwrap()
         .destination(&destination)
-        .unwrap()
         .build()
         .unwrap();
 

--- a/zbus_macros/tests/tests.rs
+++ b/zbus_macros/tests/tests.rs
@@ -303,7 +303,6 @@ fn test_interface() {
             let c = zbus::Connection::session().await.unwrap();
             let s = c.object_server();
             let m = zbus::message::Message::method_call("/", "StrU32")
-                .unwrap()
                 .build(&(42,))
                 .unwrap();
             let _ = t.call(s, &c, &m, "StrU32".try_into().unwrap());
@@ -379,7 +378,6 @@ mod signal_from_message {
             "org.freedesktop.zbus_macros.Test",
             "SignalU8",
         )
-        .expect("Failed to create signal message builder")
         .build(&(1u8,))
         .expect("Failed to build signal message");
 
@@ -400,7 +398,6 @@ mod signal_from_message {
             "org.freedesktop.zbus_macros.Test",
             "SignalString",
         )
-        .expect("Failed to create signal message builder")
         .build(&(String::from("test"),))
         .expect("Failed to build signal message");
 
@@ -421,7 +418,6 @@ mod signal_from_message {
             "org.freedesktop.zbus_macros.Test",
             "SignalU8",
         )
-        .expect("Failed to create signal message builder")
         .build(&(String::from("test"),))
         .expect("Failed to build signal message");
 

--- a/zbus_xmlgen/src/main.rs
+++ b/zbus_xmlgen/src/main.rs
@@ -146,9 +146,7 @@ impl DBusInfo<'_> {
 
         let xml = IntrospectableProxy::builder(&connection)
             .destination(service.clone())
-            .expect("invalid destination")
             .path(path.clone())
-            .expect("invalid path")
             .build()
             .unwrap()
             .introspect()?;

--- a/zbus_xmlgen/src/main.rs
+++ b/zbus_xmlgen/src/main.rs
@@ -43,7 +43,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             service,
             object_path,
         } => DBusInfo::new(
-            connection::Builder::address(&*address)?.build()?,
+            connection::Builder::address(&*address).build()?,
             service,
             object_path,
         )?,


### PR DESCRIPTION
Every builder method that takes a D-Bus name, object path, GUID or address is generic over
`TryInto` and returns `Result<Self>`, so callers write `?` (or `.expect("cannot fail")`) after
every call, even when the argument is already a validated `ObjectPath` or `BusName`, and even
though three of the four builders return a `Result` from `build()` anyway. This PR resolves that
for 6.0 by deferring the errors, the way `http::request::Builder` does:

* Every setter keeps its zbus 5 generic signature and returns the builder. The conversion still
  happens immediately; a failure is recorded in the builder's single error slot, first error
  wins, and later calls never clear it.
* `build()` returns that recorded error before doing anything else, with the same error value
  the setter used to return. `match_rule::Builder::build()` becomes fallible for that reason;
  the other three already were.
* `Message::method_call`, `signal`, `error` and `method_return` return the builder directly,
  and the connection builder constructors (`session()`, `system()`, `address(..)`, ...) return
  the builder with a bad address recorded in it.
* `MatchRule::try_from(&str)` validates each component itself, so parse errors are unchanged.
* Generic code (`Proxy::new`, the `#[proxy]`-generated `new()`, `Connection::call_method`)
  keeps its `TryInto` bounds and just drops the `?` after each setter. Nothing changes for
  generated proxies.

```rust
// Before
let props = PropertiesProxy::builder(&conn)
    .destination("org.freedesktop.DBus")?
    .path("/org/freedesktop/DBus")?
    .build()
    .await?;

// After: strings or typed values, no `?` until `build()`
let props = PropertiesProxy::builder(&conn)
    .destination("org.freedesktop.DBus")
    .path(proxy.path())
    .build()
    .await?;
```

Migration is mechanical and compiler-guided: delete the `?` after each setter and after the
constructors above, add one after `MatchRule::builder()...build()`. The 6.0 upgrade guide gets a
section with the details.

The design spec (`docs/superpowers/specs/2026-09-07-infallible-builder-setters-design.md`)
records the alternatives and why they lost: an infallible `impl Into` setter plus a `try_` twin
(strings are the majority input, so most callers would rename and keep their `?`), a trait with
a conditional return type (opaque signatures, dozens of impls, unusable from generic code), and
additive setters under another name. Compile-time validated literal macros
(`object_path!("/org/zbus/Foo")`) are an orthogonal follow-up.

Fixes #403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAoA1GwLD68owkUkUS9fSB