### PR TITLE
🚚 zb: Rename Body::deserialize_unchecked

### DIFF
--- a/zbus/src/error.rs
+++ b/zbus/src/error.rs
@@ -377,7 +377,7 @@ impl From<Message> for Error {
 
         if let Some(name) = header.error_name() {
             let name = name.to_owned().into();
-            match message.body().deserialize_unchecked::<&str>() {
+            match message.body().deserialize_ignore_signature::<&str>() {
                 Ok(detail) => Error::MethodError(name, Some(String::from(detail)), message),
                 Err(_) => Error::MethodError(name, None, message),
             }

--- a/zbus/src/match_rule/mod.rs
+++ b/zbus/src/match_rule/mod.rs
@@ -273,7 +273,7 @@ impl<'m> MatchRule<'m> {
 
         // The arg0 namespace.
         if let Some(arg0_ns) = self.arg0ns() {
-            if let Ok(arg0) = msg.body().deserialize_unchecked::<BusName<'_>>() {
+            if let Ok(arg0) = msg.body().deserialize_ignore_signature::<BusName<'_>>() {
                 match arg0.strip_prefix(arg0_ns.as_str()) {
                     None => return Ok(false),
                     Some(s) if !s.is_empty() && !s.starts_with('.') => return Ok(false),

--- a/zbus/src/message/body.rs
+++ b/zbus/src/message/body.rs
@@ -29,8 +29,16 @@ impl Body {
             .map(|b| b.0)
     }
 
-    /// Deserialize the body (without checking signature matching).
-    pub fn deserialize_unchecked<'d, 'm: 'd, B>(&'m self) -> Result<B>
+    /// Deserialize the body, ignoring its signature.
+    ///
+    /// Unlike [`Body::deserialize`], the signature of the body is not used to guide the
+    /// deserialization: `B`'s own signature is assumed instead. This is useful when the body's
+    /// signature is already known to match `B`, or when `B` deserializes from a signature that
+    /// differs from the body's but is compatible with its encoding.
+    ///
+    /// Deserialization still fails with an error if the encoded bytes do not match what `B`
+    /// expects, so this is not an unsafe or unchecked operation.
+    pub fn deserialize_ignore_signature<'d, 'm: 'd, B>(&'m self) -> Result<B>
     where
         B: serde::de::Deserialize<'d> + Type,
     {

--- a/zbus/src/message/mod.rs
+++ b/zbus/src/message/mod.rs
@@ -310,7 +310,7 @@ impl fmt::Display for Message {
                 }
 
                 let body = self.body();
-                let msg = body.deserialize_unchecked::<&str>();
+                let msg = body.deserialize_ignore_signature::<&str>();
                 if let Ok(msg) = msg {
                     write!(f, ": {msg}")?;
                 }


### PR DESCRIPTION
The `_unchecked` suffix conventionally means the caller must uphold safety invariants, or
undefined behaviour follows. Nothing of the sort applies to `Body::deserialize_unchecked`: it
merely skips using the body signature to guide deserialization, and still returns an error if the
bytes do not match the requested type.

Renames it to `Body::deserialize_ignore_signature` and expands its docs to spell out how it
differs from `Body::deserialize`. Since `main` is 6.0 land, this is a plain rename with no
deprecated alias.

Fixes https://github.com/z-galaxy/zbus/issues/1213

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGZsem47eGBd7bBH7nVy9J

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGZsem47eGBd7bBH7nVy9J)_