### PR TITLE
🔒️ zb: Make FilePath to std conversions sound & lossless

### DIFF
--- a/book/src/upgrading-to-6.md
+++ b/book/src/upgrading-to-6.md
@@ -315,7 +315,7 @@ The compatibility module is removed in zbus 7.0.
 
 ## Other changes in 6.0
 
-Seven more things break in 6.0 without being a consequence of the crate merge. They reach code
+More things break in 6.0 without being a consequence of the crate merge. They reach code
 that never mentioned `zvariant` or `zbus_names`.
 
 ### Builder setters defer their errors to `build()`
@@ -511,6 +511,52 @@ the empty string, and the sentinel now maps to `None` without being converted at
 The public `NoneValue::NoneType` associated type for each owned name type is now `String` rather
 than `&'static str`. This allows `Optional<Owned*Name>` to implement `DeserializeOwned` without
 changing its wire encoding.
+
+### `FilePath` converts back to std types with `TryFrom`
+
+`zbus::FilePath` wraps a nul-terminated byte array (D-Bus signature `ay`), because a file path
+need not be valid UTF-8. Its conversions back to the std path types used to assume otherwise:
+`From<FilePath> for OsString` built the `OsString` with `OsString::from_encoded_bytes_unchecked`,
+undefined behaviour on Windows for bytes that are not valid WTF-8; `From<&FilePath> for &Path`
+panicked on a non-UTF-8 path, the case the type exists for; and `From<FilePath> for PathBuf` went
+through `to_string_lossy()`, silently replacing invalid bytes with `U+FFFD`.
+
+The four conversions — to `OsString`, `PathBuf`, `&Path` and, new, `&OsStr` — are `TryFrom`
+impls now, with `type Error = zbus::Error` on every platform. On unix, where `OsStr` is a byte
+string like `FilePath` itself, they hand back the original bytes and never fail. Elsewhere no
+lossless mapping to `OsStr` exists, so they succeed only when the bytes are valid UTF-8 and return
+`Error::Utf8` otherwise.
+
+Before, this no longer compiles:
+
+```rust,compile_fail,noplayground
+use std::path::PathBuf;
+use zbus::FilePath;
+
+fn path_buf(file_path: FilePath<'_>) -> PathBuf {
+    PathBuf::from(file_path)
+}
+```
+
+After:
+
+```rust,noplayground
+use std::path::PathBuf;
+use zbus::FilePath;
+
+fn path_buf(file_path: FilePath<'_>) -> zbus::Result<PathBuf> {
+    PathBuf::try_from(file_path)
+}
+```
+
+The same applies to `OsString::from(file_path)`, `<&Path>::from(&file_path)` and the matching
+`.into()` calls: spell them `try_from` or `try_into` and handle the `Result`. On unix the error
+arm is unreachable in practice, but the signature is the same everywhere so that portable code
+has one form to write.
+
+Conversions into `FilePath` — `From<&Path>`, `From<PathBuf>`, `From<&OsStr>`, `From<OsString>`,
+`From<&CStr>`, `From<CString>`, `From<&str>` and so on — are unchanged, and
+`FilePath::to_string_lossy()` remains the explicit lossy option.
 
 ### Proxy and service API are separate features
 

--- a/book/src/upgrading-to-6.md
+++ b/book/src/upgrading-to-6.md
@@ -554,6 +554,10 @@ The same applies to `OsString::from(file_path)`, `<&Path>::from(&file_path)` and
 arm is unreachable in practice, but the signature is the same everywhere so that portable code
 has one form to write.
 
+Code that needs the raw path off unix has `FilePath::as_c_str()`, which is new: it returns the
+nul-terminated bytes as they are on every platform, and `FilePath` implements `AsRef<CStr>` to
+match.
+
 Conversions into `FilePath` — `From<&Path>`, `From<PathBuf>`, `From<&OsStr>`, `From<OsString>`,
 `From<&CStr>`, `From<CString>`, `From<&str>` and so on — are unchanged, and
 `FilePath::to_string_lossy()` remains the explicit lossy option.

--- a/zbus/src/wire/file_path.rs
+++ b/zbus/src/wire/file_path.rs
@@ -5,7 +5,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::Type;
+#[cfg(unix)]
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+use crate::{Error, Result, Type};
 
 /// File name represented as a nul-terminated byte array.
 ///
@@ -16,6 +19,13 @@ use crate::Type;
 ///
 /// To solve this problem, this type is provided which encodes the underlying file path as a
 /// null-terminated byte array.
+///
+/// # Converting back to standard types
+///
+/// The conversions to [`OsString`], [`PathBuf`], [`&OsStr`](OsStr) and [`&Path`](Path) are
+/// [`TryFrom`] implementations. On unix, where paths are byte strings just like this type, they
+/// preserve the bytes exactly and never fail. On other platforms no such lossless mapping exists,
+/// so they succeed only for valid UTF-8 and return [`Error::Utf8`] otherwise.
 ///
 /// # Examples:
 ///
@@ -116,27 +126,49 @@ impl<'f> AsRef<FilePath<'f>> for FilePath<'f> {
     }
 }
 
-impl From<FilePath<'_>> for OsString {
-    fn from(value: FilePath<'_>) -> Self {
-        // SAFETY: user is responsible of handling conversion from [FilePath] to [OsString]
-        // since FilePath is a set of null terminated bytes and it's interpretations mainly
-        // depends on the underlying platform.
-        // see [std::ffi::os_str::OsString::from_encoded_bytes_unchecked]
-        unsafe { OsString::from_encoded_bytes_unchecked(value.0.to_bytes().to_vec()) }
+impl<'f> TryFrom<&'f FilePath<'f>> for &'f OsStr {
+    type Error = Error;
+
+    fn try_from(value: &'f FilePath<'f>) -> Result<Self> {
+        #[cfg(unix)]
+        {
+            Ok(OsStr::from_bytes(value.0.to_bytes()))
+        }
+        #[cfg(not(unix))]
+        {
+            value.0.to_str().map(OsStr::new).map_err(Error::Utf8)
+        }
     }
 }
 
-impl<'f> From<&'f FilePath<'f>> for &'f Path {
-    fn from(value: &'f FilePath<'f>) -> Self {
-        // This method should fail if FilePath does not represent UTF-8 valid chars
-        // since [Path] is akin to [str], hence the unwrap.
-        Path::new(value.0.as_ref().to_str().unwrap())
+impl<'f> TryFrom<&'f FilePath<'f>> for &'f Path {
+    type Error = Error;
+
+    fn try_from(value: &'f FilePath<'f>) -> Result<Self> {
+        <&OsStr>::try_from(value).map(Path::new)
     }
 }
 
-impl<'f> From<FilePath<'f>> for PathBuf {
-    fn from(value: FilePath<'f>) -> Self {
-        PathBuf::from(value.0.to_string_lossy().to_string())
+impl TryFrom<FilePath<'_>> for OsString {
+    type Error = Error;
+
+    fn try_from(value: FilePath<'_>) -> Result<Self> {
+        #[cfg(unix)]
+        {
+            Ok(OsString::from_vec(value.0.into_owned().into_bytes()))
+        }
+        #[cfg(not(unix))]
+        {
+            <&OsStr>::try_from(&value).map(OsString::from)
+        }
+    }
+}
+
+impl TryFrom<FilePath<'_>> for PathBuf {
+    type Error = Error;
+
+    fn try_from(value: FilePath<'_>) -> Result<Self> {
+        OsString::try_from(value).map(PathBuf::from)
     }
 }
 
@@ -214,19 +246,49 @@ mod file_path_test {
     }
 
     #[test]
-    fn into_test() {
-        let first = PathBuf::from("/hello/world");
-        let third = OsString::from("/hello/world");
-        let fifth = Path::new("/hello/world");
-        let p = FilePath::from(first.clone());
-        let p2 = FilePath::from(third.clone());
-        let p3 = FilePath::from(fifth);
-        let second: PathBuf = p.into();
-        let forth: OsString = p2.into();
-        let sixth: &Path = (&p3).into();
-        assert_eq!(first, second);
-        assert_eq!(third, forth);
-        assert_eq!(fifth, sixth);
+    fn try_into_test() {
+        let path = Path::new("/hello/world");
+        let file_path = FilePath::from(path);
+
+        assert_eq!(<&OsStr>::try_from(&file_path).unwrap(), path.as_os_str());
+        assert_eq!(<&Path>::try_from(&file_path).unwrap(), path);
+        assert_eq!(
+            OsString::try_from(file_path.clone()).unwrap(),
+            path.as_os_str()
+        );
+        assert_eq!(PathBuf::try_from(file_path).unwrap(), path);
+    }
+
+    /// Arbitrary bytes are exactly what the unix conversions exist for, so nothing may be lost or
+    /// replaced along the way.
+    #[cfg(unix)]
+    #[test]
+    fn non_utf8_try_into_test() {
+        let os_str = OsStr::from_bytes(b"/hello/\xff\xfe/world");
+        let file_path = FilePath::from(os_str);
+
+        assert_eq!(<&OsStr>::try_from(&file_path).unwrap(), os_str);
+        assert_eq!(<&Path>::try_from(&file_path).unwrap(), Path::new(os_str));
+        assert_eq!(OsString::try_from(file_path.clone()).unwrap(), os_str);
+        assert_eq!(PathBuf::try_from(file_path).unwrap(), Path::new(os_str));
+    }
+
+    /// Off unix only UTF-8 gets through.
+    #[cfg(not(unix))]
+    #[test]
+    fn non_utf8_try_into_test() {
+        let file_path = FilePath::from(c"/hello/\xff\xfe/world");
+
+        assert!(matches!(
+            <&OsStr>::try_from(&file_path),
+            Err(Error::Utf8(_))
+        ));
+        assert!(matches!(<&Path>::try_from(&file_path), Err(Error::Utf8(_))));
+        assert!(matches!(
+            OsString::try_from(file_path.clone()),
+            Err(Error::Utf8(_))
+        ));
+        assert!(matches!(PathBuf::try_from(file_path), Err(Error::Utf8(_))));
     }
 
     #[test]

--- a/zbus/src/wire/file_path.rs
+++ b/zbus/src/wire/file_path.rs
@@ -26,6 +26,7 @@ use crate::{Error, Result, Type};
 /// [`TryFrom`] implementations. On unix, where paths are byte strings just like this type, they
 /// preserve the bytes exactly and never fail. On other platforms no such lossless mapping exists,
 /// so they succeed only for valid UTF-8 and return [`Error::Utf8`] otherwise.
+/// [`as_c_str`](Self::as_c_str) hands back the bytes as they are on every platform.
 ///
 /// # Examples:
 ///
@@ -50,6 +51,14 @@ pub struct FilePath<'f>(Cow<'f, CStr>);
 impl<'f> FilePath<'f> {
     pub fn new(cow: Cow<'f, CStr>) -> Self {
         Self(cow)
+    }
+
+    /// The path as a nul-terminated byte string.
+    ///
+    /// This is the lossless view of the path on every platform; the conversions to the standard
+    /// path types are lossless on unix only.
+    pub fn as_c_str(&self) -> &CStr {
+        &self.0
     }
 
     /// Returns a lossy UTF-8 representation of the file path.
@@ -126,6 +135,11 @@ impl<'f> AsRef<FilePath<'f>> for FilePath<'f> {
     }
 }
 
+impl AsRef<CStr> for FilePath<'_> {
+    fn as_ref(&self) -> &CStr {
+        self.as_c_str()
+    }
+}
 impl<'f> TryFrom<&'f FilePath<'f>> for &'f OsStr {
     type Error = Error;
 
@@ -235,6 +249,16 @@ mod file_path_test {
         assert_eq!(p4, p5);
         assert_eq!(p5, p6);
         assert_eq!(p5, p7);
+    }
+
+    /// The `CStr` view is lossless everywhere, UTF-8 or not.
+    #[test]
+    fn as_c_str_test() {
+        let bytes = c"/hello/\xff\xfe/world";
+        let file_path = FilePath::from(bytes);
+
+        assert_eq!(file_path.as_c_str(), bytes);
+        assert_eq!(<FilePath<'_> as AsRef<CStr>>::as_ref(&file_path), bytes);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #1906.

`FilePath` can carry arbitrary bytes, but its conversions back to the std path types assumed more than that: `From<FilePath> for OsString` used `OsString::from_encoded_bytes_unchecked` (UB reachable from safe code on Windows), `From<&FilePath> for &Path` unwrapped `CStr::to_str()` and panicked on non-UTF-8, and `From<FilePath> for PathBuf` was silently lossy.

* The conversions to `OsString`, `PathBuf`, `&Path` and (new) `&OsStr` are now `TryFrom` impls with `Error = zbus::Error` on every platform, so portable code has one form to write. On unix they hand the bytes back exactly through `std::os::unix::ffi` and never fail; no `unsafe` is left in the module. Elsewhere they succeed only for valid UTF-8 and return `Error::Utf8` otherwise. Replacing `From` with `TryFrom` is the API break, hence 6.0.
* `FilePath::as_c_str()` and `AsRef<CStr>` are added so the raw path stays reachable losslessly on every platform.
* The 6.0 upgrade guide gains a section with a before/after example and the mechanical migration.

Verified with nightly `fmt --check`, clippy `-D warnings` natively and for `x86_64-pc-windows-gnu` (including `--all-targets`, which type-checks the non-unix test), the `file_path` unit and doc tests, and rustdoc with warnings denied.

Generated by Claude Fable 5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01265dTxQRse4pUa5xBBqQ9C