### PR TITLE
💥 zx,xmlgen: Borrow strings from the introspection document

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2262,7 +2262,6 @@ version = "6.0.0"
 dependencies = [
  "codspeed-criterion-compat",
  "doc-comment",
- "serde",
  "winnow 1.0.4",
  "zbus",
 ]

--- a/book/src/upgrading-to-6.md
+++ b/book/src/upgrading-to-6.md
@@ -496,6 +496,50 @@ assert!(Option::<UniqueName<'_>>::from(name).is_none());
 
 A property getter typed as a name can therefore fail where it used to hand back a bogus name.
 
+### `zbus_xml` borrows from the document it parses
+
+`zbus_xml` no longer copies every string out of the introspection document.
+`Node::try_from(&str)` now borrows names, annotation values, argument names and Telepathy
+docstrings from the input where it can; the lifetime that `Node<'a>`, `Interface<'a>` and
+friends always carried is now meaningful.
+
+Consequently `Annotation`, `Arg` and the `telepathy` type-definition types (`TypeDef`,
+`SimpleType`, `Enum`, `EnumValue`, `Struct`, `Member`, `Mapping`) gained a lifetime parameter.
+Code that names them in a type position needs `<'_>` (or a named lifetime); code that only
+calls accessors keeps working, since they still return `&str`. A function that hands out a
+borrow from one of them now has two lifetimes to choose from, so it has to name the one it
+borrows from:
+
+```rust,noplayground
+use zbus_xml::{Arg, Node};
+
+// Was: fn describe(arg: &Arg) -> Option<&str>
+fn describe<'a>(arg: &'a Arg<'_>) -> Option<&'a str> {
+    arg.name()
+}
+
+// Keep the tree past the document it was parsed from.
+fn parse(xml: &str) -> zbus_xml::Result<Node<'static>> {
+    Ok(Node::try_from(xml)?.into_owned())
+}
+```
+
+`Node::from_reader` and `Node::from_reader_with_warnings` return `Node<'static>`: they read the
+whole input into memory, so the tree owns its strings. Callers that bound the result to
+`Node<'a>` keep compiling.
+
+To keep a borrowed tree (or part of it) past the document, use the new
+`into_owned()`/`to_owned()` methods on every tree type, mirroring `zbus::names` types. Strings
+in the tree are `zbus::Str`, the same type the name types wrap, so cloning an owned tree is
+cheap.
+
+Two leftovers of the quick-xml parser that 5.2 replaced are gone too. The tree types no longer
+implement `Serialize` and `Deserialize` (the derives described quick-xml's `@name` attribute
+convention, not a format anyone writes), and `zbus_xml::Signature` — a newtype that only
+existed to be deserialized from an owned string — is replaced by `zbus::Signature` itself.
+`Arg::ty`, `Property::ty` and the Telepathy `ty()` accessors return `&zbus::Signature`, so
+drop any `.inner()` or `.into_inner()` call on their result.
+
 ### `Optional<T>` compares the sentinel before converting
 
 `TryFrom<Value>` and `TryFrom<OwnedValue>` for `Optional<T>` check the incoming value against

--- a/docs/superpowers/specs/2026-09-10-zbus-xml-borrowed-strings-design.md
+++ b/docs/superpowers/specs/2026-09-10-zbus-xml-borrowed-strings-design.md
@@ -1,0 +1,98 @@
+# Borrowed strings in the `zbus_xml` introspection tree
+
+Design for [z-galaxy/zbus#9](https://github.com/z-galaxy/zbus/issues/9): stop allocating a
+`String` for every attribute value and docstring when parsing an introspection document.
+
+## Problem
+
+`zbus_xml` parses a D-Bus introspection document into a `Node` tree. Half of the tree already
+carries a lifetime — `Node<'a>`, `Interface<'a>`, `Method<'a>`, `Signal<'a>` and `Property<'a>`
+hold their names as `zbus::names::*Name<'a>` — but the parser never makes use of it: every
+name is copied into an owned `String`, and the remaining string fields (`Annotation` name and
+value, `Arg` name, node names, Telepathy docstrings, `tp:type` references and the Telepathy type
+definitions) are plain `String`s on lifetime-less types. A parsed tree is thus always
+`Node<'static>` and the lifetime parameter is dead weight for users, who have to spell it out
+without getting anything in return.
+
+The typical consumer (`zbus_xmlgen`, or a client inspecting a freshly introspected object) uses
+the tree once, while the document is still in hand. For them the copies are pure overhead — and
+docstrings in Telepathy-style documents can be large.
+
+## Design
+
+### `zbus::Str` for every string field
+
+All string fields become `zbus::Str<'a>` (or `Option<Str<'a>>`), not `Cow<'a, str>`:
+
+* The name fields of the same structs are `zbus::names::*Name<'a>`, which are `Str<'a>`
+  wrappers. One ownership model for the whole tree means `into_owned()`/`to_owned()` behave
+  the same for every field.
+* `Str` is what zbus uses for exactly this purpose everywhere else (`Value::Str`, the name
+  types), so users meet no new type.
+* Cloning a tree whose strings are owned is cheap (`Str` shares an `Arc<str>`), and
+  `Str::to_owned()` on already-owned data does not reallocate. `Cow` would deep-copy.
+* `Str: From<Cow<'a, str>>`, so the parser's unescaped attribute values (borrowed when the
+  value needs no unescaping, owned otherwise) slot in directly.
+
+The accessors keep returning `&str` / `Option<&str>`, so the field type is not visible in the
+common read path.
+
+### Types gaining a lifetime
+
+* `Annotation<'a>` (`name`, `value`)
+* `Arg<'a>` (`name`, `docstring`, `tp_type`, `annotations: Vec<Annotation<'a>>`)
+* `telepathy::TypeDef<'a>`, `SimpleType<'a>`, `Enum<'a>`, `EnumValue<'a>`, `Struct<'a>`,
+  `Member<'a>`, `Mapping<'a>`
+* The already parameterised types switch their `String` fields (node `name`, `docstring`,
+  `tp_type`) to `Str<'a>` and their `Vec<Annotation>`/`Vec<Arg>`/`Vec<TypeDef>` fields to
+  the `'a` variants.
+
+`Signature`, `ArgDirection`, `PropertyAccess`, `Warning`, `Error` and `XmlError` are
+unchanged. `Warning` is a diagnostic handed back next to the tree, not part of it, and it
+carries a formatted message anyway.
+
+The `Serialize`/`Deserialize` derives on the tree types, with their quick-xml `@name` field
+renames, and the `Signature` newtype (which only existed to be deserialized from an owned
+string) are leftovers of the quick-xml parser that 5.2 replaced. Rather than teach them to
+borrow, drop them along with the `serde` dependency; the `ty()` accessors return
+`&zbus::Signature` directly.
+
+### Parsing borrows, reading owns
+
+* `impl TryFrom<&'a str> for Node<'a>` borrows from the document: attribute values that need
+  no unescaping and docstrings are `&'a str` slices, everything else is owned. This is the
+  zero-copy path.
+* `Node::from_reader` and `Node::from_reader_with_warnings` read the input into a local
+  `String`, so they cannot borrow. They return `Node<'static>` (previously the vacuous
+  `Node<'a>`): parse borrowing from the local buffer, then `into_owned()`. Same number of
+  allocations as today, and `Node<'static>` coerces to any `Node<'a>` (all types are
+  covariant in `'a`).
+* Internally, the parser functions' `'static` return types become `'i` (the input lifetime).
+
+### Owning a tree
+
+Every type with a lifetime gets, in the style of the name types:
+
+```rust
+/// Creates an owned clone of `self`.
+pub fn to_owned(&self) -> Self<'static>;
+/// Converts `self` into an owned tree, copying the strings it borrows.
+pub fn into_owned(self) -> Self<'static>;
+```
+
+so that a user who parsed with `TryFrom<&str>` and wants to keep (part of) the tree past the
+document can, and one holding `&Node<'a>` can extract an `Interface<'static>`.
+
+## Consumers
+
+* `zbus_xmlgen`: `TypeDef` → `TypeDef<'_>` in signatures; `Types<'i>` holds
+  `&'i TypeDef<'i>`. No behavioural change.
+* `zbus` integration tests: use `Node::from_reader`, unchanged.
+* Book: an "Other changes in 6.0" entry in `upgrading-to-6.md`.
+
+## Testing
+
+* Existing tests exercise both parse paths and the round trip.
+* New: `Node::try_from(&str)` borrows (a `Node` built from a `String` must not outlive it —
+  checked through `into_owned()` making it outlive the buffer), `from_reader` yields a
+  `Node<'static>`, `to_owned()`/`into_owned()` compare equal to the source.

--- a/zbus_xml/Cargo.toml
+++ b/zbus_xml/Cargo.toml
@@ -13,7 +13,6 @@ categories = ["parsing"]
 readme = "README.md"
 
 [dependencies]
-serde.workspace = true
 zbus = { path = "../zbus", version = "6.0.0", default-features = false }
 winnow.workspace = true
 

--- a/zbus_xml/src/lib.rs
+++ b/zbus_xml/src/lib.rs
@@ -19,15 +19,13 @@ use xml::escape;
 
 pub mod telepathy;
 
-use serde::{Deserialize, Serialize};
 use std::{
     fmt,
     io::{BufWriter, Read, Write},
-    ops::Deref,
 };
 
 use zbus::{
-    Str,
+    Signature, Str,
     names::{InterfaceName, MemberName, PropertyName},
 };
 
@@ -97,11 +95,9 @@ impl fmt::Display for Warning {
 }
 
 /// Annotations are generic key/value pairs of metadata.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Annotation<'a> {
-    #[serde(rename = "@name", borrow)]
     name: Str<'a>,
-    #[serde(rename = "@value", borrow)]
     value: Str<'a>,
 }
 
@@ -140,11 +136,9 @@ impl Annotation<'_> {
 }
 
 /// A direction of an argument
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ArgDirection {
-    #[serde(rename = "in")]
     In,
-    #[serde(rename = "out")]
     Out,
 }
 
@@ -158,19 +152,13 @@ impl ArgDirection {
 }
 
 /// An argument
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Arg<'a> {
-    #[serde(rename = "@name", borrow)]
     name: Option<Str<'a>>,
-    #[serde(rename = "@type")]
     ty: Signature,
-    #[serde(rename = "@direction")]
     direction: Option<ArgDirection>,
-    #[serde(rename = "annotation", default, borrow)]
     annotations: Vec<Annotation<'a>>,
-    #[serde(skip)]
     docstring: Option<Str<'a>>,
-    #[serde(skip)]
     tp_type: Option<Str<'a>>,
 }
 
@@ -254,15 +242,11 @@ impl<'a> Arg<'a> {
 }
 
 /// A method
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Method<'a> {
-    #[serde(rename = "@name", borrow)]
     name: MemberName<'a>,
-    #[serde(rename = "arg", default, borrow)]
     args: Vec<Arg<'a>>,
-    #[serde(rename = "annotation", default, borrow)]
     annotations: Vec<Annotation<'a>>,
-    #[serde(skip)]
     docstring: Option<Str<'a>>,
 }
 
@@ -327,16 +311,12 @@ impl<'a> Method<'a> {
 }
 
 /// A signal
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Signal<'a> {
-    #[serde(rename = "@name", borrow)]
     name: MemberName<'a>,
 
-    #[serde(rename = "arg", default, borrow)]
     args: Vec<Arg<'a>>,
-    #[serde(rename = "annotation", default, borrow)]
     annotations: Vec<Annotation<'a>>,
-    #[serde(skip)]
     docstring: Option<Str<'a>>,
 }
 
@@ -401,13 +381,10 @@ impl<'a> Signal<'a> {
 }
 
 /// The possible property access types
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PropertyAccess {
-    #[serde(rename = "read")]
     Read,
-    #[serde(rename = "write")]
     Write,
-    #[serde(rename = "readwrite")]
     ReadWrite,
 }
 
@@ -430,21 +407,15 @@ impl PropertyAccess {
 }
 
 /// A property
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Property<'a> {
-    #[serde(rename = "@name", borrow)]
     name: PropertyName<'a>,
 
-    #[serde(rename = "@type")]
     ty: Signature,
-    #[serde(rename = "@access")]
     access: PropertyAccess,
 
-    #[serde(rename = "annotation", default, borrow)]
     annotations: Vec<Annotation<'a>>,
-    #[serde(skip)]
     docstring: Option<Str<'a>>,
-    #[serde(skip)]
     tp_type: Option<Str<'a>>,
 }
 
@@ -527,22 +498,15 @@ impl<'a> Property<'a> {
 }
 
 /// An interface
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Interface<'a> {
-    #[serde(rename = "@name", borrow)]
     name: InterfaceName<'a>,
 
-    #[serde(rename = "method", default)]
     methods: Vec<Method<'a>>,
-    #[serde(rename = "property", default)]
     properties: Vec<Property<'a>>,
-    #[serde(rename = "signal", default)]
     signals: Vec<Signal<'a>>,
-    #[serde(rename = "annotation", default, borrow)]
     annotations: Vec<Annotation<'a>>,
-    #[serde(skip)]
     docstring: Option<Str<'a>>,
-    #[serde(skip)]
     telepathy_types: Vec<telepathy::TypeDef<'a>>,
 }
 
@@ -643,18 +607,13 @@ impl<'a> Interface<'a> {
 }
 
 /// An introspection tree node (typically the root of the XML document).
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Node<'a> {
-    #[serde(rename = "@name", borrow)]
     name: Option<Str<'a>>,
 
-    #[serde(rename = "interface", default, borrow)]
     interfaces: Vec<Interface<'a>>,
-    #[serde(rename = "node", default, borrow)]
     nodes: Vec<Node<'a>>,
-    #[serde(skip)]
     docstring: Option<Str<'a>>,
-    #[serde(skip)]
     telepathy_types: Vec<telepathy::TypeDef<'a>>,
 }
 
@@ -824,51 +783,5 @@ impl<'a> TryFrom<&'a str> for Node<'a> {
     /// it. Call [`Node::into_owned`] to detach the tree from `s` and keep it around for longer.
     fn try_from(s: &'a str) -> Result<Node<'a>> {
         xml::parse(s)
-    }
-}
-
-/// A thin wrapper around [`zbus::Signature`].
-///
-/// This is to allow `Signature` to be deserialized from an owned string, which is what XML
-/// deserializers typically produce.
-#[derive(Debug, Serialize, Clone, PartialEq)]
-pub struct Signature(zbus::Signature);
-
-impl Signature {
-    /// The inner [`zbus::Signature`].
-    pub fn inner(&self) -> &zbus::Signature {
-        &self.0
-    }
-
-    /// Convert this `Signature` into the inner [`zbus::Signature`].
-    pub fn into_inner(self) -> zbus::Signature {
-        self.0
-    }
-}
-
-impl<'de> serde::de::Deserialize<'de> for Signature {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: serde::de::Deserializer<'de>,
-    {
-        String::deserialize(deserializer).and_then(|s| {
-            zbus::Signature::try_from(s.as_bytes())
-                .map_err(serde::de::Error::custom)
-                .map(Signature)
-        })
-    }
-}
-
-impl Deref for Signature {
-    type Target = zbus::Signature;
-
-    fn deref(&self) -> &Self::Target {
-        self.inner()
-    }
-}
-
-impl PartialEq<str> for Signature {
-    fn eq(&self, other: &str) -> bool {
-        self.0 == other
     }
 }

--- a/zbus_xml/src/lib.rs
+++ b/zbus_xml/src/lib.rs
@@ -26,7 +26,10 @@ use std::{
     ops::Deref,
 };
 
-use zbus::names::{InterfaceName, MemberName, PropertyName};
+use zbus::{
+    Str,
+    names::{InterfaceName, MemberName, PropertyName},
+};
 
 /// A warning about document content that was ignored during parsing.
 ///
@@ -95,14 +98,14 @@ impl fmt::Display for Warning {
 
 /// Annotations are generic key/value pairs of metadata.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub struct Annotation {
-    #[serde(rename = "@name")]
-    name: String,
-    #[serde(rename = "@value")]
-    value: String,
+pub struct Annotation<'a> {
+    #[serde(rename = "@name", borrow)]
+    name: Str<'a>,
+    #[serde(rename = "@value", borrow)]
+    value: Str<'a>,
 }
 
-impl Annotation {
+impl Annotation<'_> {
     /// Return the annotation name/key.
     pub fn name(&self) -> &str {
         &self.name
@@ -111,6 +114,19 @@ impl Annotation {
     /// Return the annotation value.
     pub fn value(&self) -> &str {
         &self.value
+    }
+
+    /// Creates an owned clone of `self`.
+    pub fn to_owned(&self) -> Annotation<'static> {
+        self.clone().into_owned()
+    }
+
+    /// Converts `self` into an owned tree, copying the strings it borrows.
+    pub fn into_owned(self) -> Annotation<'static> {
+        Annotation {
+            name: self.name.into_owned(),
+            value: self.value.into_owned(),
+        }
     }
 
     fn write_xml<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
@@ -143,22 +159,22 @@ impl ArgDirection {
 
 /// An argument
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
-pub struct Arg {
-    #[serde(rename = "@name")]
-    name: Option<String>,
+pub struct Arg<'a> {
+    #[serde(rename = "@name", borrow)]
+    name: Option<Str<'a>>,
     #[serde(rename = "@type")]
     ty: Signature,
     #[serde(rename = "@direction")]
     direction: Option<ArgDirection>,
-    #[serde(rename = "annotation", default)]
-    annotations: Vec<Annotation>,
+    #[serde(rename = "annotation", default, borrow)]
+    annotations: Vec<Annotation<'a>>,
     #[serde(skip)]
-    docstring: Option<String>,
+    docstring: Option<Str<'a>>,
     #[serde(skip)]
-    tp_type: Option<String>,
+    tp_type: Option<Str<'a>>,
 }
 
-impl Arg {
+impl<'a> Arg<'a> {
     /// Return the argument name, if any.
     pub fn name(&self) -> Option<&str> {
         self.name.as_deref()
@@ -175,7 +191,7 @@ impl Arg {
     }
 
     /// Return the associated annotations.
-    pub fn annotations(&self) -> &[Annotation] {
+    pub fn annotations(&self) -> &[Annotation<'a>] {
         &self.annotations
     }
 
@@ -194,6 +210,27 @@ impl Arg {
     /// suffix per level of array nesting (e. g. `Playlist[]`).
     pub fn tp_type(&self) -> Option<&str> {
         self.tp_type.as_deref()
+    }
+
+    /// Creates an owned clone of `self`.
+    pub fn to_owned(&self) -> Arg<'static> {
+        self.clone().into_owned()
+    }
+
+    /// Converts `self` into an owned tree, copying the strings it borrows.
+    pub fn into_owned(self) -> Arg<'static> {
+        Arg {
+            name: self.name.map(Str::into_owned),
+            ty: self.ty,
+            direction: self.direction,
+            annotations: self
+                .annotations
+                .into_iter()
+                .map(Annotation::into_owned)
+                .collect(),
+            docstring: self.docstring.map(Str::into_owned),
+            tp_type: self.tp_type.map(Str::into_owned),
+        }
     }
 
     fn write_xml<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
@@ -221,27 +258,27 @@ impl Arg {
 pub struct Method<'a> {
     #[serde(rename = "@name", borrow)]
     name: MemberName<'a>,
-    #[serde(rename = "arg", default)]
-    args: Vec<Arg>,
-    #[serde(rename = "annotation", default)]
-    annotations: Vec<Annotation>,
+    #[serde(rename = "arg", default, borrow)]
+    args: Vec<Arg<'a>>,
+    #[serde(rename = "annotation", default, borrow)]
+    annotations: Vec<Annotation<'a>>,
     #[serde(skip)]
-    docstring: Option<String>,
+    docstring: Option<Str<'a>>,
 }
 
-impl Method<'_> {
+impl<'a> Method<'a> {
     /// Return the method name.
     pub fn name(&self) -> MemberName<'_> {
         self.name.as_ref()
     }
 
     /// Return the method arguments.
-    pub fn args(&self) -> &[Arg] {
+    pub fn args(&self) -> &[Arg<'a>] {
         &self.args
     }
 
     /// Return the method annotations.
-    pub fn annotations(&self) -> &[Annotation] {
+    pub fn annotations(&self) -> &[Annotation<'a>] {
         &self.annotations
     }
 
@@ -252,6 +289,25 @@ impl Method<'_> {
     /// the writer does not emit them.
     pub fn docstring(&self) -> Option<&str> {
         self.docstring.as_deref()
+    }
+
+    /// Creates an owned clone of `self`.
+    pub fn to_owned(&self) -> Method<'static> {
+        self.clone().into_owned()
+    }
+
+    /// Converts `self` into an owned tree, copying the strings it borrows.
+    pub fn into_owned(self) -> Method<'static> {
+        Method {
+            name: self.name.into_owned(),
+            args: self.args.into_iter().map(Arg::into_owned).collect(),
+            annotations: self
+                .annotations
+                .into_iter()
+                .map(Annotation::into_owned)
+                .collect(),
+            docstring: self.docstring.map(Str::into_owned),
+        }
     }
 
     fn write_xml<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
@@ -276,27 +332,27 @@ pub struct Signal<'a> {
     #[serde(rename = "@name", borrow)]
     name: MemberName<'a>,
 
-    #[serde(rename = "arg", default)]
-    args: Vec<Arg>,
-    #[serde(rename = "annotation", default)]
-    annotations: Vec<Annotation>,
+    #[serde(rename = "arg", default, borrow)]
+    args: Vec<Arg<'a>>,
+    #[serde(rename = "annotation", default, borrow)]
+    annotations: Vec<Annotation<'a>>,
     #[serde(skip)]
-    docstring: Option<String>,
+    docstring: Option<Str<'a>>,
 }
 
-impl Signal<'_> {
+impl<'a> Signal<'a> {
     /// Return the signal name.
     pub fn name(&self) -> MemberName<'_> {
         self.name.as_ref()
     }
 
     /// Return the signal arguments.
-    pub fn args(&self) -> &[Arg] {
+    pub fn args(&self) -> &[Arg<'a>] {
         &self.args
     }
 
     /// Return the signal annotations.
-    pub fn annotations(&self) -> &[Annotation] {
+    pub fn annotations(&self) -> &[Annotation<'a>] {
         &self.annotations
     }
 
@@ -307,6 +363,25 @@ impl Signal<'_> {
     /// the writer does not emit them.
     pub fn docstring(&self) -> Option<&str> {
         self.docstring.as_deref()
+    }
+
+    /// Creates an owned clone of `self`.
+    pub fn to_owned(&self) -> Signal<'static> {
+        self.clone().into_owned()
+    }
+
+    /// Converts `self` into an owned tree, copying the strings it borrows.
+    pub fn into_owned(self) -> Signal<'static> {
+        Signal {
+            name: self.name.into_owned(),
+            args: self.args.into_iter().map(Arg::into_owned).collect(),
+            annotations: self
+                .annotations
+                .into_iter()
+                .map(Annotation::into_owned)
+                .collect(),
+            docstring: self.docstring.map(Str::into_owned),
+        }
     }
 
     fn write_xml<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
@@ -365,15 +440,15 @@ pub struct Property<'a> {
     #[serde(rename = "@access")]
     access: PropertyAccess,
 
-    #[serde(rename = "annotation", default)]
-    annotations: Vec<Annotation>,
+    #[serde(rename = "annotation", default, borrow)]
+    annotations: Vec<Annotation<'a>>,
     #[serde(skip)]
-    docstring: Option<String>,
+    docstring: Option<Str<'a>>,
     #[serde(skip)]
-    tp_type: Option<String>,
+    tp_type: Option<Str<'a>>,
 }
 
-impl Property<'_> {
+impl<'a> Property<'a> {
     /// Returns the property name.
     pub fn name(&self) -> PropertyName<'_> {
         self.name.as_ref()
@@ -390,7 +465,7 @@ impl Property<'_> {
     }
 
     /// Return the associated annotations.
-    pub fn annotations(&self) -> &[Annotation] {
+    pub fn annotations(&self) -> &[Annotation<'a>] {
         &self.annotations
     }
 
@@ -409,6 +484,27 @@ impl Property<'_> {
     /// suffix per level of array nesting (e. g. `Playlist[]`).
     pub fn tp_type(&self) -> Option<&str> {
         self.tp_type.as_deref()
+    }
+
+    /// Creates an owned clone of `self`.
+    pub fn to_owned(&self) -> Property<'static> {
+        self.clone().into_owned()
+    }
+
+    /// Converts `self` into an owned tree, copying the strings it borrows.
+    pub fn into_owned(self) -> Property<'static> {
+        Property {
+            name: self.name.into_owned(),
+            ty: self.ty,
+            access: self.access,
+            annotations: self
+                .annotations
+                .into_iter()
+                .map(Annotation::into_owned)
+                .collect(),
+            docstring: self.docstring.map(Str::into_owned),
+            tp_type: self.tp_type.map(Str::into_owned),
+        }
     }
 
     fn write_xml<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
@@ -442,12 +538,12 @@ pub struct Interface<'a> {
     properties: Vec<Property<'a>>,
     #[serde(rename = "signal", default)]
     signals: Vec<Signal<'a>>,
-    #[serde(rename = "annotation", default)]
-    annotations: Vec<Annotation>,
+    #[serde(rename = "annotation", default, borrow)]
+    annotations: Vec<Annotation<'a>>,
     #[serde(skip)]
-    docstring: Option<String>,
+    docstring: Option<Str<'a>>,
     #[serde(skip)]
-    telepathy_types: Vec<telepathy::TypeDef>,
+    telepathy_types: Vec<telepathy::TypeDef<'a>>,
 }
 
 impl<'a> Interface<'a> {
@@ -467,12 +563,12 @@ impl<'a> Interface<'a> {
     }
 
     /// Returns the interface properties.
-    pub fn properties(&self) -> &[Property<'_>] {
+    pub fn properties(&self) -> &[Property<'a>] {
         &self.properties
     }
 
     /// Return the associated annotations.
-    pub fn annotations(&self) -> &[Annotation] {
+    pub fn annotations(&self) -> &[Annotation<'a>] {
         &self.annotations
     }
 
@@ -486,8 +582,38 @@ impl<'a> Interface<'a> {
     }
 
     /// Return the Telepathy type definitions on this interface.
-    pub fn telepathy_types(&self) -> &[telepathy::TypeDef] {
+    pub fn telepathy_types(&self) -> &[telepathy::TypeDef<'a>] {
         &self.telepathy_types
+    }
+
+    /// Creates an owned clone of `self`.
+    pub fn to_owned(&self) -> Interface<'static> {
+        self.clone().into_owned()
+    }
+
+    /// Converts `self` into an owned tree, copying the strings it borrows.
+    pub fn into_owned(self) -> Interface<'static> {
+        Interface {
+            name: self.name.into_owned(),
+            methods: self.methods.into_iter().map(Method::into_owned).collect(),
+            properties: self
+                .properties
+                .into_iter()
+                .map(Property::into_owned)
+                .collect(),
+            signals: self.signals.into_iter().map(Signal::into_owned).collect(),
+            annotations: self
+                .annotations
+                .into_iter()
+                .map(Annotation::into_owned)
+                .collect(),
+            docstring: self.docstring.map(Str::into_owned),
+            telepathy_types: self
+                .telepathy_types
+                .into_iter()
+                .map(telepathy::TypeDef::into_owned)
+                .collect(),
+        }
     }
 
     fn write_xml<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
@@ -519,25 +645,29 @@ impl<'a> Interface<'a> {
 /// An introspection tree node (typically the root of the XML document).
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct Node<'a> {
-    #[serde(rename = "@name")]
-    name: Option<String>,
+    #[serde(rename = "@name", borrow)]
+    name: Option<Str<'a>>,
 
     #[serde(rename = "interface", default, borrow)]
     interfaces: Vec<Interface<'a>>,
     #[serde(rename = "node", default, borrow)]
     nodes: Vec<Node<'a>>,
     #[serde(skip)]
-    docstring: Option<String>,
+    docstring: Option<Str<'a>>,
     #[serde(skip)]
-    telepathy_types: Vec<telepathy::TypeDef>,
+    telepathy_types: Vec<telepathy::TypeDef<'a>>,
 }
 
 impl<'a> Node<'a> {
     /// Parse the introspection XML document from reader.
     ///
+    /// The whole reader is buffered into memory before parsing, so the returned tree owns its
+    /// data and is not tied to the reader's lifetime. For a zero-copy parse that borrows from a
+    /// document already in memory, parse it with `Node::try_from(&str)` instead.
+    ///
     /// Note that `reader` is consumed until end-of-stream before parsing, so this must not be
     /// used with a reader that stays open past the end of the document (e.g. a socket).
-    pub fn from_reader<R: Read>(reader: R) -> Result<Node<'a>> {
+    pub fn from_reader<R: Read>(reader: R) -> Result<Node<'static>> {
         Ok(Node::from_reader_with_warnings(reader)?.0)
     }
 
@@ -548,15 +678,23 @@ impl<'a> Node<'a> {
     /// see [`Interface::docstring`]) and was therefore ignored, e. g. the type-definition
     /// elements of the Telepathy extensions (`tp:enum`, `tp:struct`, …).
     ///
+    /// The whole reader is buffered into memory before parsing, so the returned tree owns its
+    /// data and is not tied to the reader's lifetime. For a zero-copy parse that borrows from a
+    /// document already in memory, parse it with `Node::try_from(&str)` instead.
+    ///
     /// Note that `reader` is consumed until end-of-stream before parsing, so this must not be
     /// used with a reader that stays open past the end of the document (e.g. a socket).
     ///
     /// [introspection format]: https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format
-    pub fn from_reader_with_warnings<R: Read>(mut reader: R) -> Result<(Node<'a>, Vec<Warning>)> {
+    pub fn from_reader_with_warnings<R: Read>(
+        mut reader: R,
+    ) -> Result<(Node<'static>, Vec<Warning>)> {
         let mut input = String::new();
         reader.read_to_string(&mut input)?;
 
-        xml::parse_with_warnings(&input)
+        let (node, warnings) = xml::parse_with_warnings(&input)?;
+
+        Ok((node.into_owned(), warnings))
     }
 
     /// Write the XML document to writer.
@@ -597,8 +735,65 @@ impl<'a> Node<'a> {
     }
 
     /// Return the Telepathy type definitions on this node.
-    pub fn telepathy_types(&self) -> &[telepathy::TypeDef] {
+    pub fn telepathy_types(&self) -> &[telepathy::TypeDef<'a>] {
         &self.telepathy_types
+    }
+
+    /// Creates an owned clone of `self`.
+    pub fn to_owned(&self) -> Node<'static> {
+        self.clone().into_owned()
+    }
+
+    /// Converts `self` into an owned tree, copying the strings it borrows.
+    ///
+    /// Nested `<node>`s — the one axis on which a tree can nest arbitrarily deep — are walked
+    /// iteratively on an explicit stack, as the parser does, so converting a deeply nested tree
+    /// does not grow the call stack.
+    pub fn into_owned(self) -> Node<'static> {
+        // A node whose own data is converted, paired with the children still to convert.
+        struct Pending<'a> {
+            node: Node<'static>,
+            children: std::vec::IntoIter<Node<'a>>,
+        }
+
+        impl<'a> Pending<'a> {
+            fn new(node: Node<'a>) -> Self {
+                let children = node.nodes.into_iter();
+                let node = Node {
+                    name: node.name.map(Str::into_owned),
+                    interfaces: node
+                        .interfaces
+                        .into_iter()
+                        .map(Interface::into_owned)
+                        .collect(),
+                    nodes: Vec::with_capacity(children.len()),
+                    docstring: node.docstring.map(Str::into_owned),
+                    telepathy_types: node
+                        .telepathy_types
+                        .into_iter()
+                        .map(telepathy::TypeDef::into_owned)
+                        .collect(),
+                };
+
+                Pending { node, children }
+            }
+        }
+
+        let mut open = vec![Pending::new(self)];
+        loop {
+            let pending = open
+                .last_mut()
+                .expect("the root is popped only by returning");
+            if let Some(child) = pending.children.next() {
+                open.push(Pending::new(child));
+                continue;
+            }
+            let finished = open.pop().expect("non-empty").node;
+            match open.last_mut() {
+                Some(parent) => parent.node.nodes.push(finished),
+                None => return finished,
+            }
+        }
     }
 
     fn write_xml<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
@@ -623,7 +818,10 @@ impl<'a> Node<'a> {
 impl<'a> TryFrom<&'a str> for Node<'a> {
     type Error = Error;
 
-    /// Parse the introspection XML document from `s`.
+    /// Parse the introspection XML document from `s`, borrowing from it where possible.
+    ///
+    /// The returned tree borrows attribute values and docstrings from `s`, so it cannot outlive
+    /// it. Call [`Node::into_owned`] to detach the tree from `s` and keep it around for longer.
     fn try_from(s: &'a str) -> Result<Node<'a>> {
         xml::parse(s)
     }

--- a/zbus_xml/src/telepathy.rs
+++ b/zbus_xml/src/telepathy.rs
@@ -23,8 +23,7 @@
 //!
 //! [Telepathy D-Bus introspection extensions]: https://telepathy.freedesktop.org/spec/
 
-use crate::Signature;
-use zbus::Str;
+use zbus::{Signature, Str};
 
 /// A named type defined through the Telepathy introspection extensions.
 #[derive(Debug, Clone, PartialEq)]
@@ -61,10 +60,10 @@ impl TypeDef<'_> {
     }
 
     /// The D-Bus signature of the defined type.
-    pub fn signature(&self) -> zbus::Signature {
+    pub fn signature(&self) -> Signature {
         match self {
-            TypeDef::SimpleType(t) => t.ty().inner().clone(),
-            TypeDef::Enum(e) => e.ty().inner().clone(),
+            TypeDef::SimpleType(t) => t.ty().clone(),
+            TypeDef::Enum(e) => e.ty().clone(),
             TypeDef::Struct(s) => s.signature(),
             TypeDef::Mapping(m) => m.signature(),
         }
@@ -235,11 +234,11 @@ impl<'a> Struct<'a> {
     }
 
     /// The D-Bus signature of the structure.
-    pub fn signature(&self) -> zbus::Signature {
-        zbus::Signature::structure(
+    pub fn signature(&self) -> Signature {
+        Signature::structure(
             self.members
                 .iter()
-                .map(|m| m.ty().inner().clone())
+                .map(|m| m.ty().clone())
                 .collect::<Vec<_>>(),
         )
     }
@@ -336,11 +335,8 @@ impl<'a> Mapping<'a> {
     }
 
     /// The D-Bus signature of the dictionary.
-    pub fn signature(&self) -> zbus::Signature {
-        zbus::Signature::dict(
-            self.key.ty().inner().clone(),
-            self.value.ty().inner().clone(),
-        )
+    pub fn signature(&self) -> Signature {
+        Signature::dict(self.key.ty().clone(), self.value.ty().clone())
     }
 
     /// Creates an owned clone of `self`.
@@ -361,9 +357,9 @@ impl<'a> Mapping<'a> {
 
 /// Whether `ty` is a basic (i. e. non-container) D-Bus type, as required for dictionary keys.
 pub(crate) fn is_basic(ty: &Signature) -> bool {
-    use zbus::Signature as S;
+    use Signature as S;
 
-    match ty.inner() {
+    match ty {
         S::U8
         | S::Bool
         | S::I16

--- a/zbus_xml/src/telepathy.rs
+++ b/zbus_xml/src/telepathy.rs
@@ -24,21 +24,22 @@
 //! [Telepathy D-Bus introspection extensions]: https://telepathy.freedesktop.org/spec/
 
 use crate::Signature;
+use zbus::Str;
 
 /// A named type defined through the Telepathy introspection extensions.
 #[derive(Debug, Clone, PartialEq)]
-pub enum TypeDef {
+pub enum TypeDef<'a> {
     /// A name given to a plain D-Bus type (`<tp:simple-type>`).
-    SimpleType(SimpleType),
+    SimpleType(SimpleType<'a>),
     /// An enumeration of the values of a type (`<tp:enum>`).
-    Enum(Enum),
+    Enum(Enum<'a>),
     /// A named structure (`<tp:struct>`).
-    Struct(Struct),
+    Struct(Struct<'a>),
     /// A named dictionary type (`<tp:mapping>`).
-    Mapping(Mapping),
+    Mapping(Mapping<'a>),
 }
 
-impl TypeDef {
+impl TypeDef<'_> {
     /// The name of the defined type, as referenced by `tp:type` attributes.
     pub fn name(&self) -> &str {
         match self {
@@ -68,17 +69,32 @@ impl TypeDef {
             TypeDef::Mapping(m) => m.signature(),
         }
     }
+
+    /// Creates an owned clone of `self`.
+    pub fn to_owned(&self) -> TypeDef<'static> {
+        self.clone().into_owned()
+    }
+
+    /// Converts `self` into an owned tree, copying the strings it borrows.
+    pub fn into_owned(self) -> TypeDef<'static> {
+        match self {
+            TypeDef::SimpleType(t) => TypeDef::SimpleType(t.into_owned()),
+            TypeDef::Enum(e) => TypeDef::Enum(e.into_owned()),
+            TypeDef::Struct(s) => TypeDef::Struct(s.into_owned()),
+            TypeDef::Mapping(m) => TypeDef::Mapping(m.into_owned()),
+        }
+    }
 }
 
 /// A name given to a plain D-Bus type (`<tp:simple-type>`).
 #[derive(Debug, Clone, PartialEq)]
-pub struct SimpleType {
-    pub(crate) name: String,
+pub struct SimpleType<'a> {
+    pub(crate) name: Str<'a>,
     pub(crate) ty: Signature,
-    pub(crate) docstring: Option<String>,
+    pub(crate) docstring: Option<Str<'a>>,
 }
 
-impl SimpleType {
+impl SimpleType<'_> {
     /// The name of the type.
     pub fn name(&self) -> &str {
         &self.name
@@ -93,18 +109,32 @@ impl SimpleType {
     pub fn docstring(&self) -> Option<&str> {
         self.docstring.as_deref()
     }
+
+    /// Creates an owned clone of `self`.
+    pub fn to_owned(&self) -> SimpleType<'static> {
+        self.clone().into_owned()
+    }
+
+    /// Converts `self` into an owned tree, copying the strings it borrows.
+    pub fn into_owned(self) -> SimpleType<'static> {
+        SimpleType {
+            name: self.name.into_owned(),
+            ty: self.ty,
+            docstring: self.docstring.map(Str::into_owned),
+        }
+    }
 }
 
 /// An enumeration of the values of a type (`<tp:enum>`).
 #[derive(Debug, Clone, PartialEq)]
-pub struct Enum {
-    pub(crate) name: String,
+pub struct Enum<'a> {
+    pub(crate) name: Str<'a>,
     pub(crate) ty: Signature,
-    pub(crate) values: Vec<EnumValue>,
-    pub(crate) docstring: Option<String>,
+    pub(crate) values: Vec<EnumValue<'a>>,
+    pub(crate) docstring: Option<Str<'a>>,
 }
 
-impl Enum {
+impl<'a> Enum<'a> {
     /// The name of the type.
     pub fn name(&self) -> &str {
         &self.name
@@ -116,7 +146,7 @@ impl Enum {
     }
 
     /// The values of the enumeration.
-    pub fn values(&self) -> &[EnumValue] {
+    pub fn values(&self) -> &[EnumValue<'a>] {
         &self.values
     }
 
@@ -124,17 +154,32 @@ impl Enum {
     pub fn docstring(&self) -> Option<&str> {
         self.docstring.as_deref()
     }
+
+    /// Creates an owned clone of `self`.
+    pub fn to_owned(&self) -> Enum<'static> {
+        self.clone().into_owned()
+    }
+
+    /// Converts `self` into an owned tree, copying the strings it borrows.
+    pub fn into_owned(self) -> Enum<'static> {
+        Enum {
+            name: self.name.into_owned(),
+            ty: self.ty,
+            values: self.values.into_iter().map(EnumValue::into_owned).collect(),
+            docstring: self.docstring.map(Str::into_owned),
+        }
+    }
 }
 
 /// A single value of an [`Enum`] (`<tp:enumvalue>`).
 #[derive(Debug, Clone, PartialEq)]
-pub struct EnumValue {
-    pub(crate) suffix: String,
-    pub(crate) value: String,
-    pub(crate) docstring: Option<String>,
+pub struct EnumValue<'a> {
+    pub(crate) suffix: Str<'a>,
+    pub(crate) value: Str<'a>,
+    pub(crate) docstring: Option<Str<'a>>,
 }
 
-impl EnumValue {
+impl EnumValue<'_> {
     /// The name of the value.
     pub fn suffix(&self) -> &str {
         &self.suffix
@@ -149,24 +194,38 @@ impl EnumValue {
     pub fn docstring(&self) -> Option<&str> {
         self.docstring.as_deref()
     }
+
+    /// Creates an owned clone of `self`.
+    pub fn to_owned(&self) -> EnumValue<'static> {
+        self.clone().into_owned()
+    }
+
+    /// Converts `self` into an owned tree, copying the strings it borrows.
+    pub fn into_owned(self) -> EnumValue<'static> {
+        EnumValue {
+            suffix: self.suffix.into_owned(),
+            value: self.value.into_owned(),
+            docstring: self.docstring.map(Str::into_owned),
+        }
+    }
 }
 
 /// A named structure (`<tp:struct>`).
 #[derive(Debug, Clone, PartialEq)]
-pub struct Struct {
-    pub(crate) name: String,
-    pub(crate) members: Vec<Member>,
-    pub(crate) docstring: Option<String>,
+pub struct Struct<'a> {
+    pub(crate) name: Str<'a>,
+    pub(crate) members: Vec<Member<'a>>,
+    pub(crate) docstring: Option<Str<'a>>,
 }
 
-impl Struct {
+impl<'a> Struct<'a> {
     /// The name of the type.
     pub fn name(&self) -> &str {
         &self.name
     }
 
     /// The members of the structure.
-    pub fn members(&self) -> &[Member] {
+    pub fn members(&self) -> &[Member<'a>] {
         &self.members
     }
 
@@ -184,18 +243,32 @@ impl Struct {
                 .collect::<Vec<_>>(),
         )
     }
+
+    /// Creates an owned clone of `self`.
+    pub fn to_owned(&self) -> Struct<'static> {
+        self.clone().into_owned()
+    }
+
+    /// Converts `self` into an owned tree, copying the strings it borrows.
+    pub fn into_owned(self) -> Struct<'static> {
+        Struct {
+            name: self.name.into_owned(),
+            members: self.members.into_iter().map(Member::into_owned).collect(),
+            docstring: self.docstring.map(Str::into_owned),
+        }
+    }
 }
 
 /// A member of a [`Struct`] or [`Mapping`] (`<tp:member>`).
 #[derive(Debug, Clone, PartialEq)]
-pub struct Member {
-    pub(crate) name: String,
+pub struct Member<'a> {
+    pub(crate) name: Str<'a>,
     pub(crate) ty: Signature,
-    pub(crate) tp_type: Option<String>,
-    pub(crate) docstring: Option<String>,
+    pub(crate) tp_type: Option<Str<'a>>,
+    pub(crate) docstring: Option<Str<'a>>,
 }
 
-impl Member {
+impl Member<'_> {
     /// The name of the member.
     pub fn name(&self) -> &str {
         &self.name
@@ -215,30 +288,45 @@ impl Member {
     pub fn docstring(&self) -> Option<&str> {
         self.docstring.as_deref()
     }
+
+    /// Creates an owned clone of `self`.
+    pub fn to_owned(&self) -> Member<'static> {
+        self.clone().into_owned()
+    }
+
+    /// Converts `self` into an owned tree, copying the strings it borrows.
+    pub fn into_owned(self) -> Member<'static> {
+        Member {
+            name: self.name.into_owned(),
+            ty: self.ty,
+            tp_type: self.tp_type.map(Str::into_owned),
+            docstring: self.docstring.map(Str::into_owned),
+        }
+    }
 }
 
 /// A named dictionary type (`<tp:mapping>`).
 #[derive(Debug, Clone, PartialEq)]
-pub struct Mapping {
-    pub(crate) name: String,
-    pub(crate) key: Member,
-    pub(crate) value: Member,
-    pub(crate) docstring: Option<String>,
+pub struct Mapping<'a> {
+    pub(crate) name: Str<'a>,
+    pub(crate) key: Member<'a>,
+    pub(crate) value: Member<'a>,
+    pub(crate) docstring: Option<Str<'a>>,
 }
 
-impl Mapping {
+impl<'a> Mapping<'a> {
     /// The name of the type.
     pub fn name(&self) -> &str {
         &self.name
     }
 
     /// The key member of the dictionary.
-    pub fn key(&self) -> &Member {
+    pub fn key(&self) -> &Member<'a> {
         &self.key
     }
 
     /// The value member of the dictionary.
-    pub fn value(&self) -> &Member {
+    pub fn value(&self) -> &Member<'a> {
         &self.value
     }
 
@@ -253,6 +341,21 @@ impl Mapping {
             self.key.ty().inner().clone(),
             self.value.ty().inner().clone(),
         )
+    }
+
+    /// Creates an owned clone of `self`.
+    pub fn to_owned(&self) -> Mapping<'static> {
+        self.clone().into_owned()
+    }
+
+    /// Converts `self` into an owned tree, copying the strings it borrows.
+    pub fn into_owned(self) -> Mapping<'static> {
+        Mapping {
+            name: self.name.into_owned(),
+            key: self.key.into_owned(),
+            value: self.value.into_owned(),
+            docstring: self.docstring.map(Str::into_owned),
+        }
     }
 }
 

--- a/zbus_xml/src/xml.rs
+++ b/zbus_xml/src/xml.rs
@@ -19,13 +19,13 @@ use winnow::{
     token::{any, take_till, take_until, take_while},
 };
 use zbus::{
-    Str,
+    Signature, Str,
     names::{InterfaceName, MemberName, PropertyName},
 };
 
 use crate::{
     Annotation, Arg, ArgDirection, Interface, Method, Node, Property, PropertyAccess, Signal,
-    Signature, Warning,
+    Warning,
     error::{Error, Result, XmlError},
     telepathy::{self, TypeDef},
 };
@@ -662,12 +662,12 @@ impl SignatureAttr {
     fn parse(value: Option<&str>) -> Self {
         match value {
             None => SignatureAttr::Missing,
-            Some(value) => match zbus::Signature::try_from(value.as_bytes()) {
+            Some(value) => match Signature::try_from(value.as_bytes()) {
                 // The empty signature parses as `Unit`, which is only valid as a top-level
                 // signature — inside a composed signature (`Struct`/`Mapping::signature`) it
                 // produces invalid signatures.
-                Ok(zbus::Signature::Unit) | Err(_) => SignatureAttr::Invalid,
-                Ok(signature) => SignatureAttr::Value(Signature(signature)),
+                Ok(Signature::Unit) | Err(_) => SignatureAttr::Invalid,
+                Ok(signature) => SignatureAttr::Value(signature),
             },
         }
     }
@@ -1078,8 +1078,7 @@ impl<'i> Attrs<'i> {
 
     /// The required `type` attribute, parsed as a signature.
     fn signature(&self) -> PResult<Signature> {
-        zbus::Signature::try_from(self.required("type")?.as_bytes())
-            .map(Signature)
+        Signature::try_from(self.required("type")?.as_bytes())
             .map_err(|e| ParseError::domain(zbus::Error::from(e).into()))
     }
 

--- a/zbus_xml/src/xml.rs
+++ b/zbus_xml/src/xml.rs
@@ -18,7 +18,10 @@ use winnow::{
     stream::{Location, Stateful},
     token::{any, take_till, take_until, take_while},
 };
-use zbus::names::{InterfaceName, MemberName, PropertyName};
+use zbus::{
+    Str,
+    names::{InterfaceName, MemberName, PropertyName},
+};
 
 use crate::{
     Annotation, Arg, ArgDirection, Interface, Method, Node, Property, PropertyAccess, Signal,
@@ -36,12 +39,12 @@ use crate::{
 const MAX_DEPTH: usize = 1024;
 
 /// Parse a D-Bus introspection document into its [`Node`] tree.
-pub(crate) fn parse<'a>(document: &str) -> Result<Node<'a>> {
+pub(crate) fn parse<'i>(document: &'i str) -> Result<Node<'i>> {
     parse_with_warnings(document).map(|(node, _)| node)
 }
 
 /// Parse a D-Bus introspection document, also returning the warnings collected on the way.
-pub(crate) fn parse_with_warnings<'a>(document: &str) -> Result<(Node<'a>, Vec<Warning>)> {
+pub(crate) fn parse_with_warnings<'i>(document: &'i str) -> Result<(Node<'i>, Vec<Warning>)> {
     let mut input = Input {
         input: LocatingSlice::new(document),
         state: State {
@@ -50,7 +53,6 @@ pub(crate) fn parse_with_warnings<'a>(document: &str) -> Result<(Node<'a>, Vec<W
         },
     };
     match document_node(&mut input) {
-        // The tree owns its data, so it outlives `document` and satisfies any caller lifetime.
         Ok(node) => Ok((node, input.state.warnings)),
         Err(ErrMode::Backtrack(error) | ErrMode::Cut(error)) => Err(error.into_error()),
         Err(ErrMode::Incomplete(_)) => Err(Error::Xml(XmlError::new(
@@ -64,7 +66,7 @@ pub(crate) fn parse_with_warnings<'a>(document: &str) -> Result<(Node<'a>, Vec<W
 ///
 /// The root element's name is not checked, for compatibility with servers that don't name it
 /// `node` and with how previous (quick-xml-based) versions of this crate behaved.
-fn document_node<'i>(input: &mut Input<'i>) -> PResult<Node<'static>> {
+fn document_node<'i>(input: &mut Input<'i>) -> PResult<Node<'i>> {
     ignorable(input)?;
     if opt(eof).parse_next(input)?.is_some() {
         return Err(error("missing root element", input));
@@ -159,13 +161,13 @@ fn node<'i>(
     tag: &'i str,
     attrs: Attrs<'i>,
     self_closing: bool,
-) -> PResult<Node<'static>> {
+) -> PResult<Node<'i>> {
     let root = empty_node(&attrs);
     if self_closing {
         return Ok(root);
     }
 
-    let mut open: Vec<(&'i str, Node<'static>)> = vec![(tag, root)];
+    let mut open: Vec<(&'i str, Node<'i>)> = vec![(tag, root)];
     loop {
         ignorable(input)?;
         let tag = open.last().expect("the root is popped only by returning").0;
@@ -231,9 +233,9 @@ fn node<'i>(
 }
 
 /// A `<node>` with only its `name`, ready to be filled in.
-fn empty_node(attrs: &Attrs<'_>) -> Node<'static> {
+fn empty_node<'i>(attrs: &Attrs<'i>) -> Node<'i> {
     Node {
-        name: attrs.optional("name").map(str::to_owned),
+        name: attrs.optional_str("name"),
         interfaces: Vec::new(),
         nodes: Vec::new(),
         docstring: None,
@@ -247,7 +249,7 @@ fn interface<'i>(
     tag: &'i str,
     attrs: Attrs<'i>,
     self_closing: bool,
-) -> PResult<Interface<'static>> {
+) -> PResult<Interface<'i>> {
     let name = attrs.name(|n| InterfaceName::try_from(n).map_err(Error::Zbus))?;
     let mut methods = Vec::new();
     let mut properties = Vec::new();
@@ -306,7 +308,7 @@ fn method<'i>(
     tag: &'i str,
     attrs: Attrs<'i>,
     self_closing: bool,
-) -> PResult<Method<'static>> {
+) -> PResult<Method<'i>> {
     let name = attrs.name(|n| MemberName::try_from(n).map_err(Error::Zbus))?;
     let mut args = Vec::new();
     let mut annotations = Vec::new();
@@ -342,7 +344,7 @@ fn signal<'i>(
     tag: &'i str,
     attrs: Attrs<'i>,
     self_closing: bool,
-) -> PResult<Signal<'static>> {
+) -> PResult<Signal<'i>> {
     let name = attrs.name(|n| MemberName::try_from(n).map_err(Error::Zbus))?;
     let mut args = Vec::new();
     let mut annotations = Vec::new();
@@ -378,7 +380,7 @@ fn property<'i>(
     tag: &'i str,
     attrs: Attrs<'i>,
     self_closing: bool,
-) -> PResult<Property<'static>> {
+) -> PResult<Property<'i>> {
     let name = attrs.name(|n| PropertyName::try_from(n).map_err(Error::Zbus))?;
     let ty = attrs.signature()?;
     let access = match attrs.required("access")? {
@@ -387,7 +389,7 @@ fn property<'i>(
         "readwrite" => PropertyAccess::ReadWrite,
         other => return Err(error(format!("invalid property access `{other}`"), input)),
     };
-    let tp_type = attrs.tp_type().map(str::to_owned);
+    let tp_type = attrs.tp_type();
     let mut annotations = Vec::new();
     let mut docstring = None;
     children(
@@ -419,8 +421,8 @@ fn arg<'i>(
     tag: &'i str,
     attrs: Attrs<'i>,
     self_closing: bool,
-) -> PResult<Arg> {
-    let name = attrs.optional("name").map(str::to_owned);
+) -> PResult<Arg<'i>> {
+    let name = attrs.optional_str("name");
     let ty = attrs.signature()?;
     let direction = match attrs.optional("direction") {
         Some("in") => Some(ArgDirection::In),
@@ -433,7 +435,7 @@ fn arg<'i>(
         }
         None => None,
     };
-    let tp_type = attrs.tp_type().map(str::to_owned);
+    let tp_type = attrs.tp_type();
     let mut annotations = Vec::new();
     let mut docstring = None;
     children(
@@ -465,9 +467,9 @@ fn annotation<'i>(
     tag: &'i str,
     attrs: Attrs<'i>,
     self_closing: bool,
-) -> PResult<Annotation> {
-    let name = attrs.required("name")?.to_owned();
-    let value = attrs.required("value")?.to_owned();
+) -> PResult<Annotation<'i>> {
+    let name = attrs.required_str("name")?;
+    let value = attrs.required_str("value")?;
     children(input, tag, self_closing, |input, child, attrs, sc| {
         skip_unsupported(input, child, &attrs, sc)?;
         Ok(true)
@@ -566,7 +568,7 @@ fn docstring_or_skip<'i>(
     child: &'i str,
     attrs: &Attrs<'i>,
     self_closing: bool,
-    slot: &mut Option<String>,
+    slot: &mut Option<Str<'i>>,
 ) -> PResult<bool> {
     if is_docstring(child) {
         *slot = capture_docstring(input, child, self_closing)?.or(slot.take());
@@ -584,7 +586,7 @@ fn capture_docstring<'i>(
     input: &mut Input<'i>,
     tag: &'i str,
     self_closing: bool,
-) -> PResult<Option<String>> {
+) -> PResult<Option<Str<'i>>> {
     if self_closing {
         return Ok(None);
     }
@@ -592,7 +594,7 @@ fn capture_docstring<'i>(
     let end = skip_to_close(input, tag)?;
     let content = input.state.document[start..end].trim();
 
-    Ok((!content.is_empty()).then(|| content.to_owned()))
+    Ok((!content.is_empty()).then(|| Str::from(content)))
 }
 
 /// Consume an element's subtree, returning the byte offset of the `<` of its matching closing
@@ -680,7 +682,7 @@ fn telepathy_type_def<'i>(
     tag: &'i str,
     attrs: &Attrs<'i>,
     self_closing: bool,
-) -> PResult<Option<TypeDef>> {
+) -> PResult<Option<TypeDef<'i>>> {
     match local_name(tag) {
         "simple-type" => simple_type(input, tag, attrs, self_closing),
         "enum" => enum_def(input, tag, attrs, self_closing),
@@ -710,9 +712,9 @@ fn simple_type<'i>(
     tag: &'i str,
     attrs: &Attrs<'i>,
     self_closing: bool,
-) -> PResult<Option<TypeDef>> {
+) -> PResult<Option<TypeDef<'i>>> {
     let position = attrs.offset - 1;
-    let name = attrs.optional("name").map(str::to_owned);
+    let name = attrs.optional_str("name");
     let ty = SignatureAttr::parse(attrs.optional("type"));
     let mut docstring = None;
     children(input, tag, self_closing, |input, child, attrs, sc| {
@@ -745,9 +747,9 @@ fn enum_def<'i>(
     tag: &'i str,
     attrs: &Attrs<'i>,
     self_closing: bool,
-) -> PResult<Option<TypeDef>> {
+) -> PResult<Option<TypeDef<'i>>> {
     let position = attrs.offset - 1;
-    let name = attrs.optional("name").map(str::to_owned);
+    let name = attrs.optional_str("name");
     let ty = SignatureAttr::parse(attrs.optional("type"));
     let mut values = Vec::new();
     let mut incomplete_value = false;
@@ -795,9 +797,9 @@ fn enum_value<'i>(
     tag: &'i str,
     attrs: &Attrs<'i>,
     self_closing: bool,
-) -> PResult<Option<telepathy::EnumValue>> {
-    let suffix = attrs.optional("suffix").map(str::to_owned);
-    let value = attrs.optional("value").map(str::to_owned);
+) -> PResult<Option<telepathy::EnumValue<'i>>> {
+    let suffix = attrs.optional_str("suffix");
+    let value = attrs.optional_str("value");
     let mut docstring = None;
     children(input, tag, self_closing, |input, child, attrs, sc| {
         docstring_or_skip(input, child, &attrs, sc, &mut docstring)
@@ -818,9 +820,9 @@ fn struct_def<'i>(
     tag: &'i str,
     attrs: &Attrs<'i>,
     self_closing: bool,
-) -> PResult<Option<TypeDef>> {
+) -> PResult<Option<TypeDef<'i>>> {
     let position = attrs.offset - 1;
-    let name = attrs.optional("name").map(str::to_owned);
+    let name = attrs.optional_str("name");
     let (members, incomplete_member, docstring) = members(input, tag, self_closing)?;
 
     let Some(name) = name else {
@@ -846,9 +848,9 @@ fn mapping_def<'i>(
     tag: &'i str,
     attrs: &Attrs<'i>,
     self_closing: bool,
-) -> PResult<Option<TypeDef>> {
+) -> PResult<Option<TypeDef<'i>>> {
     let position = attrs.offset - 1;
-    let name = attrs.optional("name").map(str::to_owned);
+    let name = attrs.optional_str("name");
     let (members, incomplete_member, docstring) = members(input, tag, self_closing)?;
 
     let Some(name) = name else {
@@ -884,7 +886,7 @@ fn members<'i>(
     input: &mut Input<'i>,
     tag: &'i str,
     self_closing: bool,
-) -> PResult<(Vec<telepathy::Member>, bool, Option<String>)> {
+) -> PResult<(Vec<telepathy::Member<'i>>, bool, Option<Str<'i>>)> {
     let mut members = Vec::new();
     let mut incomplete_member = false;
     let mut docstring = None;
@@ -910,10 +912,10 @@ fn member<'i>(
     tag: &'i str,
     attrs: &Attrs<'i>,
     self_closing: bool,
-) -> PResult<Option<telepathy::Member>> {
-    let name = attrs.optional("name").map(str::to_owned);
+) -> PResult<Option<telepathy::Member<'i>>> {
+    let name = attrs.optional_str("name");
     let ty = SignatureAttr::parse(attrs.optional("type"));
-    let tp_type = attrs.tp_type().map(str::to_owned);
+    let tp_type = attrs.tp_type();
     let mut docstring = None;
     children(input, tag, self_closing, |input, child, attrs, sc| {
         docstring_or_skip(input, child, &attrs, sc, &mut docstring)
@@ -1051,9 +1053,27 @@ impl<'i> Attrs<'i> {
         })
     }
 
+    /// The value of `key` as a string that borrows from the document where possible.
+    fn optional_str(&self, key: &str) -> Option<Str<'i>> {
+        self.pairs
+            .iter()
+            .find(|(name, _)| *name == key)
+            .map(|(_, value)| Str::from(value.clone()))
+    }
+
+    /// Like [`Self::required`], but as a string that borrows from the document where possible.
+    fn required_str(&self, key: &str) -> PResult<Str<'i>> {
+        self.optional_str(key).ok_or_else(|| {
+            ParseError::xml(
+                format!("missing attribute `{key}` on `<{}>`", self.element),
+                self.offset,
+            )
+        })
+    }
+
     /// The required `name` attribute, validated by `parse` (e. g. into an [`InterfaceName`]).
-    fn name<T>(&self, parse: impl FnOnce(String) -> std::result::Result<T, Error>) -> PResult<T> {
-        parse(self.required("name")?.to_owned()).map_err(ParseError::domain)
+    fn name<T>(&self, parse: impl FnOnce(Str<'i>) -> std::result::Result<T, Error>) -> PResult<T> {
+        parse(self.required_str("name")?).map_err(ParseError::domain)
     }
 
     /// The required `type` attribute, parsed as a signature.
@@ -1064,11 +1084,11 @@ impl<'i> Attrs<'i> {
     }
 
     /// The value of the Telepathy `tp:type` attribute, if present.
-    fn tp_type(&self) -> Option<&str> {
+    fn tp_type(&self) -> Option<Str<'i>> {
         self.pairs
             .iter()
             .find(|(name, _)| is_tp_type(name))
-            .map(|(_, value)| value.as_ref())
+            .map(|(_, value)| Str::from(value.clone()))
     }
 }
 

--- a/zbus_xml/tests/tests.rs
+++ b/zbus_xml/tests/tests.rs
@@ -4,7 +4,7 @@ use zbus::Signature;
 use zbus_xml::{Arg, ArgDirection, Interface, Node, PropertyAccess};
 
 #[test]
-fn serde() -> Result<(), Box<dyn Error>> {
+fn sample_object() -> Result<(), Box<dyn Error>> {
     let example = include_str!("data/sample_object0.xml");
     let node_r = Node::from_reader(example.as_bytes())?;
     let node = Node::try_from(example)?;
@@ -59,7 +59,7 @@ fn multi_complete_arg_type() -> Result<(), Box<dyn Error>> {
 
     let node = Node::try_from(input)?;
     let arg = &node.interfaces()[0].methods()[0].args()[0];
-    let Signature::Structure(fields) = arg.ty().inner() else {
+    let Signature::Structure(fields) = arg.ty() else {
         panic!("expected `tt` to parse as a structure");
     };
 
@@ -928,7 +928,7 @@ fn telepathy_type_definitions() -> Result<(), Box<dyn Error>> {
         panic!("expected a simple type on the node");
     };
     assert_eq!(id.name(), "Playlist_Id");
-    assert_eq!(*id.ty().inner(), Signature::ObjectPath);
+    assert_eq!(*id.ty(), Signature::ObjectPath);
     assert_eq!(id.docstring(), Some("Unique playlist identifier."));
 
     // Interface-level definitions.
@@ -943,7 +943,7 @@ fn telepathy_type_definitions() -> Result<(), Box<dyn Error>> {
     };
 
     assert_eq!(ordering.name(), "Playlist_Ordering");
-    assert_eq!(*ordering.ty().inner(), Signature::Str);
+    assert_eq!(*ordering.ty(), Signature::Str);
     assert_eq!(ordering.docstring(), Some("The way to order playlists."));
     assert_eq!(ordering.values().len(), 2);
     assert_eq!(ordering.values()[0].suffix(), "Alphabetical");
@@ -963,7 +963,7 @@ fn telepathy_type_definitions() -> Result<(), Box<dyn Error>> {
     );
     assert_eq!(playlist.members().len(), 2);
     assert_eq!(playlist.members()[0].name(), "Id");
-    assert_eq!(*playlist.members()[0].ty().inner(), Signature::ObjectPath);
+    assert_eq!(*playlist.members()[0].ty(), Signature::ObjectPath);
     assert_eq!(playlist.members()[0].tp_type(), Some("Playlist_Id"));
     assert_eq!(
         playlist.members()[0].docstring(),

--- a/zbus_xml/tests/tests.rs
+++ b/zbus_xml/tests/tests.rs
@@ -205,7 +205,7 @@ fn interface<'n, 'a>(node: &'n Node<'a>, name: &str) -> &'n Interface<'a> {
 
 /// Assert that `args` matches `expected` exactly — count, and every name, signature and
 /// direction.
-fn assert_args(context: &str, args: &[Arg], expected: &[ArgSpec]) {
+fn assert_args(context: &str, args: &[Arg<'_>], expected: &[ArgSpec]) {
     assert_eq!(
         args.len(),
         expected.len(),
@@ -675,6 +675,11 @@ fn deeply_nested_documents() -> Result<(), Box<dyn Error>> {
             }
             assert_eq!(depth, 1024);
 
+            // Detaching the tree from the document walks the same axis and must not recurse
+            // either, and neither must the reader path, which detaches every tree it parses.
+            let owned = Node::try_from(deep_nodes.as_str()).unwrap().into_owned();
+            assert_eq!(owned, Node::from_reader(deep_nodes.as_bytes()).unwrap());
+
             Node::try_from(deep_foreign.as_str()).unwrap();
         })?
         .join()
@@ -1086,6 +1091,57 @@ fn unknown_children_of_telepathy_definitions() -> Result<(), Box<dyn Error>> {
 
     let elements: Vec<_> = warnings.iter().map(|w| w.element()).collect();
     assert_eq!(elements, ["tp:added", "tp:changed", "bogus"]);
+
+    Ok(())
+}
+
+#[test]
+fn borrowed_and_owned_trees() -> Result<(), Box<dyn Error>> {
+    let input = include_str!("data/sample_object0.xml");
+
+    // The zero-copy parse borrows from `input`.
+    let borrowed = Node::try_from(input)?;
+
+    // `to_owned` (borrowing) and `into_owned` (consuming) both detach the tree, and neither
+    // changes the content.
+    let owned: Node<'static> = borrowed.to_owned();
+    assert_eq!(borrowed, owned);
+    let into_owned: Node<'static> = borrowed.clone().into_owned();
+    assert_eq!(borrowed, into_owned);
+
+    // `from_reader` parses the same document into an owned tree directly.
+    let from_reader = Node::from_reader(input.as_bytes())?;
+    assert_eq!(borrowed, from_reader);
+
+    // A tree obtained through `into_owned` does not borrow from the buffer it was parsed from,
+    // so it can be returned from a function that drops that buffer.
+    fn parse_owned(xml: String) -> Node<'static> {
+        Node::try_from(xml.as_str()).unwrap().into_owned()
+    }
+    let owned_from_string = parse_owned(input.to_owned());
+    assert_eq!(borrowed, owned_from_string);
+
+    Ok(())
+}
+
+#[test]
+fn from_reader_is_owned() -> Result<(), Box<dyn Error>> {
+    // A document with escaped attribute values (which unescaping copies into owned strings) and
+    // a Telepathy docstring (which the zero-copy parse path borrows from the document).
+    let input = r#"
+        <node xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
+            <interface name="org.test.testinterface">
+                <tp:docstring>Some &amp; documentation.</tp:docstring>
+                <annotation name="org.test.Escapes" value="&lt;b&gt;old&lt;/b&gt;"/>
+            </interface>
+        </node>
+    "#;
+
+    let node: Node<'static> = Node::from_reader(input.as_bytes())?;
+    let interface = &node.interfaces()[0];
+    // Docstrings are captured verbatim (not unescaped).
+    assert_eq!(interface.docstring(), Some("Some &amp; documentation."));
+    assert_eq!(interface.annotations()[0].value(), "<b>old</b>");
 
     Ok(())
 }

--- a/zbus_xmlgen/src/lib.rs
+++ b/zbus_xmlgen/src/lib.rs
@@ -735,7 +735,7 @@ enum EnumRepr {
 }
 
 fn enum_repr(e: &telepathy::Enum<'_>) -> Option<EnumRepr> {
-    match e.ty().inner() {
+    match e.ty() {
         Signature::U8 => Some(EnumRepr::Int("u8")),
         Signature::I16 => Some(EnumRepr::Int("i16")),
         Signature::U16 => Some(EnumRepr::Int("u16")),
@@ -754,7 +754,7 @@ fn passed_by_value(def: &TypeDef<'_>) -> bool {
         // Generated enums are `Copy`.
         TypeDef::Enum(_) => true,
         TypeDef::SimpleType(t) => matches!(
-            t.ty().inner(),
+            t.ty(),
             Signature::U8
                 | Signature::Bool
                 | Signature::I16
@@ -1003,7 +1003,7 @@ fn inputs_output_from_args(args: &[Arg<'_>], types: &Types<'_>) -> (String, Stri
                 let ty = types
                     .resolve(a.tp_type(), a.ty(), false)
                     .unwrap_or_else(|| to_rust_type(a.ty(), false, false));
-                let is_struct = matches!(a.ty().inner(), Signature::Structure(_));
+                let is_struct = matches!(a.ty(), Signature::Structure(_));
                 output.push(OutputArg { ty, is_struct });
             }
         }

--- a/zbus_xmlgen/src/lib.rs
+++ b/zbus_xmlgen/src/lib.rs
@@ -17,7 +17,7 @@ fn write_doc_header<W: std::fmt::Write>(
     w: &mut W,
     interfaces: &[Interface<'_>],
     standard_interfaces: &[Interface<'_>],
-    node_types: &[TypeDef],
+    node_types: &[TypeDef<'_>],
     input_src: &str,
     cargo_bin_name: &str,
     cargo_bin_version: &str,
@@ -120,7 +120,7 @@ fn write_doc_header<W: std::fmt::Write>(
 /// [Telepathy type definitions]: zbus_xml::telepathy::TypeDef
 #[derive(Debug, Default, Clone)]
 pub struct CodeGenerator<'i> {
-    node_types: &'i [TypeDef],
+    node_types: &'i [TypeDef<'i>],
     service: Option<&'i BusName<'i>>,
     path: Option<&'i ObjectPath<'i>>,
     format: bool,
@@ -138,7 +138,7 @@ impl<'i> CodeGenerator<'i> {
     ///
     /// The ones an interface references get a Rust definition generated alongside the
     /// definitions from the interface itself.
-    pub fn with_node_types(mut self, node_types: &'i [TypeDef]) -> Self {
+    pub fn with_node_types(mut self, node_types: &'i [TypeDef<'i>]) -> Self {
         self.node_types = node_types;
         self
     }
@@ -164,7 +164,7 @@ impl<'i> CodeGenerator<'i> {
     }
 
     /// The Telepathy type definitions from the enclosing `<node>`.
-    pub fn node_types(&self) -> &'i [TypeDef] {
+    pub fn node_types(&self) -> &'i [TypeDef<'i>] {
         self.node_types
     }
 
@@ -469,7 +469,7 @@ fn decode_entity(entity: &str) -> Option<char> {
 fn write_member_docs<W: Write>(
     w: &mut W,
     docstring: Option<&str>,
-    args: &[Arg],
+    args: &[Arg<'_>],
 ) -> std::fmt::Result {
     if let Some(docstring) = docstring {
         writeln!(w, "    ///")?;
@@ -514,14 +514,14 @@ struct Types<'i> {
     ///
     /// Only these are used when resolving `tp:type` references; anything else falls back to
     /// the structural Rust type.
-    generated: HashMap<&'i str, &'i TypeDef>,
+    generated: HashMap<&'i str, &'i TypeDef<'i>>,
     /// The same definitions in emission order (the interface's own first, then the
     /// referenced node-level ones).
-    emit: Vec<&'i TypeDef>,
+    emit: Vec<&'i TypeDef<'i>>,
 }
 
 impl<'i> Types<'i> {
-    fn new(interface: &'i Interface<'i>, node_types: &'i [TypeDef]) -> Self {
+    fn new(interface: &'i Interface<'i>, node_types: &'i [TypeDef<'i>]) -> Self {
         // All definitions in scope, the interface's own shadowing same-named node-level ones.
         let mut by_name = HashMap::new();
         for def in node_types.iter().chain(interface.telepathy_types()) {
@@ -645,7 +645,7 @@ impl<'i> Types<'i> {
 }
 
 /// Push the `tp:type` references of `def`'s members, if any, onto `pending`.
-fn member_references<'i>(def: &'i TypeDef, pending: &mut Vec<&'i str>) {
+fn member_references<'i>(def: &'i TypeDef<'i>, pending: &mut Vec<&'i str>) {
     match def {
         TypeDef::Struct(s) => pending.extend(s.members().iter().filter_map(|m| m.tp_type())),
         TypeDef::Mapping(m) => {
@@ -667,7 +667,7 @@ fn strip_arrays(reference: &str) -> (&str, usize) {
 }
 
 /// Whether a Rust definition can be generated for `def`.
-fn generatable(def: &TypeDef) -> bool {
+fn generatable(def: &TypeDef<'_>) -> bool {
     if !is_valid_ident(&type_name(def.name())) {
         return false;
     }
@@ -734,7 +734,7 @@ enum EnumRepr {
     Str,
 }
 
-fn enum_repr(e: &telepathy::Enum) -> Option<EnumRepr> {
+fn enum_repr(e: &telepathy::Enum<'_>) -> Option<EnumRepr> {
     match e.ty().inner() {
         Signature::U8 => Some(EnumRepr::Int("u8")),
         Signature::I16 => Some(EnumRepr::Int("i16")),
@@ -749,7 +749,7 @@ fn enum_repr(e: &telepathy::Enum) -> Option<EnumRepr> {
 }
 
 /// Whether values of the generated type are cheap enough to pass inputs by value.
-fn passed_by_value(def: &TypeDef) -> bool {
+fn passed_by_value(def: &TypeDef<'_>) -> bool {
     match def {
         // Generated enums are `Copy`.
         TypeDef::Enum(_) => true,
@@ -775,7 +775,7 @@ fn type_name(name: &str) -> String {
 }
 
 /// The Rust name for an enum variant, from the value's `suffix`.
-fn variant_name(value: &telepathy::EnumValue) -> String {
+fn variant_name(value: &telepathy::EnumValue<'_>) -> String {
     to_identifier(&pascal_case(value.suffix()))
 }
 
@@ -830,7 +830,7 @@ fn write_type_defs<W: Write>(
     Ok(())
 }
 
-fn write_simple_type<W: Write>(w: &mut W, t: &telepathy::SimpleType) -> std::fmt::Result {
+fn write_simple_type<W: Write>(w: &mut W, t: &telepathy::SimpleType<'_>) -> std::fmt::Result {
     if let Some(docstring) = t.docstring() {
         write_doc_lines(w, docstring, "")?;
     }
@@ -842,7 +842,7 @@ fn write_simple_type<W: Write>(w: &mut W, t: &telepathy::SimpleType) -> std::fmt
     )
 }
 
-fn write_enum<W: Write>(w: &mut W, e: &telepathy::Enum) -> std::fmt::Result {
+fn write_enum<W: Write>(w: &mut W, e: &telepathy::Enum<'_>) -> std::fmt::Result {
     if let Some(docstring) = e.docstring() {
         write_doc_lines(w, docstring, "")?;
     }
@@ -894,7 +894,11 @@ fn write_enum<W: Write>(w: &mut W, e: &telepathy::Enum) -> std::fmt::Result {
     writeln!(w, "}}")
 }
 
-fn write_struct<W: Write>(w: &mut W, s: &telepathy::Struct, types: &Types<'_>) -> std::fmt::Result {
+fn write_struct<W: Write>(
+    w: &mut W,
+    s: &telepathy::Struct<'_>,
+    types: &Types<'_>,
+) -> std::fmt::Result {
     if let Some(docstring) = s.docstring() {
         write_doc_lines(w, docstring, "")?;
     }
@@ -919,7 +923,7 @@ fn write_struct<W: Write>(w: &mut W, s: &telepathy::Struct, types: &Types<'_>) -
 
 fn write_mapping<W: Write>(
     w: &mut W,
-    m: &telepathy::Mapping,
+    m: &telepathy::Mapping<'_>,
     types: &Types<'_>,
 ) -> std::fmt::Result {
     if let Some(docstring) = m.docstring() {
@@ -973,7 +977,7 @@ fn hide_clippy_type_complexity_lint<W: Write>(
     Ok(())
 }
 
-fn inputs_output_from_args(args: &[Arg], types: &Types<'_>) -> (String, String) {
+fn inputs_output_from_args(args: &[Arg<'_>], types: &Types<'_>) -> (String, String) {
     let mut inputs = vec!["&self".to_string()];
     let mut output: Vec<OutputArg> = vec![];
     let mut n = 0;
@@ -1041,7 +1045,7 @@ struct OutputArg {
     is_struct: bool,
 }
 
-fn parse_signal_args(args: &[Arg], types: &Types<'_>) -> String {
+fn parse_signal_args(args: &[Arg<'_>], types: &Types<'_>) -> String {
     let mut inputs = vec!["&self".to_string()];
     let mut n = 0;
     let mut gen_name = || {


### PR DESCRIPTION
Fixes #9.

`zbus_xml` copied every attribute value and docstring out of the document into a `String`, even though half of the tree already carried a lifetime through the name types that the parser never made use of. The tree now borrows from the document where it can, and the leftovers of the quick-xml parser go with it.

## What changes

- **Zero-copy parsing.** `Node::try_from(&str)` borrows names, argument and node names, annotation values, `tp:type` references and Telepathy docstrings from the input. Only values containing character references are unescaped into owned strings. The string fields are `zbus::Str`, the type the name types in the same structs wrap, so the whole tree has one ownership model and cloning an owned tree is cheap.
- **Lifetimes.** `Annotation`, `Arg` and the `telepathy` type-definition types gain a lifetime parameter. Accessors still return `&str`, so only code naming these types in a type position changes.
- **Owned trees.** `Node::from_reader` and `from_reader_with_warnings` buffer the reader, so they return `Node<'static>`, which coerces to the `Node<'a>` they used to promise. Every tree type gets `to_owned()` and `into_owned()`, in the style of the name types.
- **quick-xml leftovers dropped.** The `Serialize`/`Deserialize` derives (with their `@name` attribute renames) and the `Signature` newtype are gone, along with the `serde` dependency. `ty()` accessors return `&zbus::Signature` directly.
- `zbus_xmlgen` is adapted with no behavioural change, and the 6.0 upgrade guide documents all of the above.

The design doc is in `docs/superpowers/specs/`.

Generated by Claude Fable 5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186dzKdk9GmKGnxVGgKYfET

---
_Generated by [Claude Code](https://claude.ai/code/session_0186dzKdk9GmKGnxVGgKYfET)_