### PR TITLE
🧵 zb: Add a private task scheduler and async locks

### DIFF
--- a/zbus/src/runtime/async_lock.rs
+++ b/zbus/src/runtime/async_lock.rs
@@ -1,3 +1,7 @@
+#[cfg(not(any(feature = "async-io", feature = "tokio")))]
+pub(crate) use super::sync::{Mutex, Semaphore, SemaphorePermit};
+#[cfg(all(not(any(feature = "async-io", feature = "tokio")), feature = "service"))]
+pub(crate) use super::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 #[cfg(feature = "async-io")]
 pub(crate) use async_lock::Mutex;
 #[cfg(all(feature = "async-io", feature = "service"))]
@@ -13,6 +17,7 @@ pub(crate) struct Semaphore(async_lock::Semaphore);
 #[cfg(all(feature = "tokio", not(feature = "async-io")))]
 pub(crate) struct Semaphore(tokio::sync::Semaphore);
 
+#[cfg(any(feature = "async-io", feature = "tokio"))]
 impl Semaphore {
     pub const fn new(permits: usize) -> Self {
         #[cfg(feature = "async-io")]

--- a/zbus/src/runtime/executor.rs
+++ b/zbus/src/runtime/executor.rs
@@ -1,21 +1,22 @@
+#[cfg(any(test, not(any(feature = "async-io", feature = "tokio"))))]
+use super::scheduler::{JoinHandle, Scheduler};
 #[cfg(feature = "async-io")]
 use async_executor::Executor as AsyncExecutor;
 #[cfg(feature = "async-io")]
 use async_task::Task as AsyncTask;
 #[cfg(feature = "tokio")]
 use std::io::Error;
-#[cfg(not(feature = "async-io"))]
-use std::marker::PhantomData;
-#[cfg(feature = "async-io")]
+#[cfg(any(feature = "async-io", test, not(feature = "tokio")))]
 use std::sync::Arc;
 use std::{
     future::Future,
     io::Result,
+    marker::PhantomData,
     pin::Pin,
     task::{Context, Poll},
 };
 #[cfg(feature = "tokio")]
-use tokio::task::JoinHandle;
+use tokio::task::JoinHandle as TokioJoinHandle;
 
 /// A wrapper around the underlying runtime/executor.
 ///
@@ -25,10 +26,21 @@ use tokio::task::JoinHandle;
 /// **Note:** You can (and should) completely ignore this type when the `tokio` backend is in use.
 #[derive(Debug, Clone)]
 pub struct Executor<'a> {
+    inner: Inner,
+    // The lifetime is part of the public type; nothing inside needs it since every spawned
+    // future is `'static`.
+    lifetime: PhantomData<&'a ()>,
+}
+
+#[derive(Debug, Clone)]
+enum Inner {
     #[cfg(feature = "async-io")]
-    async_io: Option<Arc<AsyncExecutor<'a>>>,
-    #[cfg(not(feature = "async-io"))]
-    phantom: PhantomData<&'a ()>,
+    AsyncExecutor(Arc<AsyncExecutor<'static>>),
+    // tokio spawns onto the ambient runtime; there is nothing to hold.
+    #[cfg(feature = "tokio")]
+    Tokio,
+    #[cfg(any(test, not(any(feature = "async-io", feature = "tokio"))))]
+    Scheduler(Arc<Scheduler>),
 }
 
 impl Executor<'_> {
@@ -39,72 +51,106 @@ impl Executor<'_> {
         future: impl Future<Output = T> + Send + 'static,
         #[allow(unused)] name: &str,
     ) -> Task<T> {
-        #[cfg(feature = "async-io")]
-        if let Some(executor) = &self.async_io {
-            return Task::from_async_io(executor.spawn(future));
+        match &self.inner {
+            #[cfg(feature = "async-io")]
+            Inner::AsyncExecutor(executor) => {
+                Task(TaskInner::AsyncExecutor(executor.spawn(future)))
+            }
+            #[cfg(feature = "tokio")]
+            Inner::Tokio => Task(TaskInner::Tokio(TokioTask::new(tokio_spawn(future, name)))),
+            #[cfg(any(test, not(any(feature = "async-io", feature = "tokio"))))]
+            Inner::Scheduler(scheduler) => Task(TaskInner::Scheduler(scheduler.spawn(future))),
         }
-
-        #[cfg(feature = "tokio")]
-        return Task::from_tokio(tokio_spawn(future, name));
-
-        #[cfg(all(feature = "async-io", not(feature = "tokio")))]
-        unreachable!("async-io executor is always `Some` when tokio is disabled")
     }
 
     /// Return `true` if there are no unfinished tasks.
     ///
     /// With the `tokio` backend in use, this always returns `true`.
     pub fn is_empty(&self) -> bool {
-        #[cfg(feature = "async-io")]
-        if let Some(executor) = &self.async_io {
-            return executor.is_empty();
+        match &self.inner {
+            #[cfg(feature = "async-io")]
+            Inner::AsyncExecutor(executor) => executor.is_empty(),
+            #[cfg(feature = "tokio")]
+            Inner::Tokio => true,
+            #[cfg(any(test, not(any(feature = "async-io", feature = "tokio"))))]
+            Inner::Scheduler(scheduler) => scheduler.is_empty(),
         }
-
-        true
     }
 
     /// Runs a single task.
     ///
     /// With the `tokio` backend in use, it's a noop and never returns.
     pub async fn tick(&self) {
-        #[cfg(feature = "async-io")]
-        if let Some(executor) = &self.async_io {
-            executor.tick().await;
-            // Skip the `tokio` branch below (only present when both backends are compiled in).
+        match &self.inner {
+            #[cfg(feature = "async-io")]
+            Inner::AsyncExecutor(executor) => executor.tick().await,
             #[cfg(feature = "tokio")]
-            return;
+            Inner::Tokio => std::future::pending().await,
+            #[cfg(any(test, not(any(feature = "async-io", feature = "tokio"))))]
+            Inner::Scheduler(scheduler) => scheduler.tick().await,
         }
-
-        #[cfg(feature = "tokio")]
-        std::future::pending::<()>().await;
     }
 
     /// Create a new `Executor`.
     pub(crate) fn new() -> Self {
-        Self {
-            #[cfg(feature = "async-io")]
-            async_io: (!super::use_tokio()).then(|| Arc::new(AsyncExecutor::new())),
-            #[cfg(not(feature = "async-io"))]
-            phantom: PhantomData,
+        #[cfg(all(feature = "async-io", feature = "tokio"))]
+        {
+            if super::use_tokio() {
+                Self::from_inner(Inner::Tokio)
+            } else {
+                Self::with_async_executor()
+            }
         }
+        #[cfg(all(feature = "async-io", not(feature = "tokio")))]
+        {
+            Self::with_async_executor()
+        }
+        #[cfg(all(feature = "tokio", not(feature = "async-io")))]
+        {
+            Self::from_inner(Inner::Tokio)
+        }
+        #[cfg(not(any(feature = "async-io", feature = "tokio")))]
+        {
+            Self::with_scheduler()
+        }
+    }
+
+    fn from_inner(inner: Inner) -> Self {
+        Self {
+            inner,
+            lifetime: PhantomData,
+        }
+    }
+
+    #[cfg(feature = "async-io")]
+    fn with_async_executor() -> Self {
+        Self::from_inner(Inner::AsyncExecutor(Arc::new(AsyncExecutor::new())))
+    }
+
+    /// An executor over zbus's own scheduler, for connections that no backend drives.
+    #[cfg(any(test, not(any(feature = "async-io", feature = "tokio"))))]
+    pub(crate) fn with_scheduler() -> Self {
+        Self::from_inner(Inner::Scheduler(Arc::new(Scheduler::new())))
     }
 
     /// Whether this executor needs an external driver thread (only the `async-io` backend does).
     #[cfg(feature = "async-io")]
     pub(crate) fn needs_internal_driver(&self) -> bool {
-        self.async_io.is_some()
+        matches!(self.inner, Inner::AsyncExecutor(_))
     }
 
     /// Runs the executor until the given future completes.
     ///
     /// With the `tokio` backend in use, it just awaits on the `future`.
     pub(crate) async fn run<T>(&self, future: impl Future<Output = T>) -> T {
-        #[cfg(feature = "async-io")]
-        if let Some(executor) = &self.async_io {
-            return executor.run(future).await;
+        match &self.inner {
+            #[cfg(feature = "async-io")]
+            Inner::AsyncExecutor(executor) => executor.run(future).await,
+            #[cfg(feature = "tokio")]
+            Inner::Tokio => future.await,
+            #[cfg(any(test, not(any(feature = "async-io", feature = "tokio"))))]
+            Inner::Scheduler(scheduler) => scheduler.run(future).await,
         }
-
-        future.await
     }
 }
 
@@ -112,7 +158,7 @@ impl Executor<'_> {
 fn tokio_spawn<T: Send + 'static>(
     future: impl Future<Output = T> + Send + 'static,
     #[allow(unused)] name: &str,
-) -> JoinHandle<T> {
+) -> TokioJoinHandle<T> {
     #[cfg(tokio_unstable)]
     {
         tokio::task::Builder::new()
@@ -136,44 +182,28 @@ fn tokio_spawn<T: Send + 'static>(
 ///   convert the task to a `FallibleTask` using the `fallible` method.
 #[doc(hidden)]
 #[derive(Debug)]
-pub struct Task<T> {
+pub struct Task<T>(TaskInner<T>);
+
+#[derive(Debug)]
+enum TaskInner<T> {
     #[cfg(feature = "async-io")]
-    async_io: Option<AsyncTask<T>>,
+    AsyncExecutor(AsyncTask<T>),
     #[cfg(feature = "tokio")]
-    tokio: Option<JoinHandle<T>>,
+    Tokio(TokioTask<T>),
+    #[cfg(any(test, not(any(feature = "async-io", feature = "tokio"))))]
+    Scheduler(JoinHandle<T>),
 }
 
 impl<T> Task<T> {
-    #[cfg(feature = "async-io")]
-    fn from_async_io(task: AsyncTask<T>) -> Self {
-        Self {
-            async_io: Some(task),
-            #[cfg(feature = "tokio")]
-            tokio: None,
-        }
-    }
-
-    #[cfg(feature = "tokio")]
-    fn from_tokio(handle: JoinHandle<T>) -> Self {
-        Self {
-            #[cfg(feature = "async-io")]
-            async_io: None,
-            tokio: Some(handle),
-        }
-    }
-
     /// Detaches the task to let it keep running in the background.
-    #[allow(unused_mut)]
-    pub fn detach(mut self) {
-        #[cfg(feature = "async-io")]
-        if let Some(task) = self.async_io.take() {
-            task.detach();
-        }
-
-        #[cfg(feature = "tokio")]
-        if let Some(handle) = self.tokio.take() {
-            // Dropping a tokio `JoinHandle` detaches it.
-            drop(handle);
+    pub fn detach(self) {
+        match self.0 {
+            #[cfg(feature = "async-io")]
+            TaskInner::AsyncExecutor(task) => task.detach(),
+            #[cfg(feature = "tokio")]
+            TaskInner::Tokio(task) => task.detach(),
+            #[cfg(any(test, not(any(feature = "async-io", feature = "tokio"))))]
+            TaskInner::Scheduler(handle) => handle.detach(),
         }
     }
 }
@@ -192,14 +222,14 @@ where
         F: FnOnce() -> T + Send + 'static,
     {
         super::select_runtime! {
-            tokio: Self::from_tokio(tokio_spawn_blocking(f, name)),
-            async_io: Self::from_async_io(blocking::unblock(f)),
+            tokio: Self(TaskInner::Tokio(TokioTask::new(tokio_spawn_blocking(f, name)))),
+            async_io: Self(TaskInner::AsyncExecutor(blocking::unblock(f))),
         }
     }
 }
 
 #[cfg(feature = "tokio")]
-fn tokio_spawn_blocking<F, T>(f: F, #[allow(unused)] name: &str) -> JoinHandle<T>
+fn tokio_spawn_blocking<F, T>(f: F, #[allow(unused)] name: &str) -> TokioJoinHandle<T>
 where
     F: FnOnce() -> T + Send + 'static,
     T: Send + 'static,
@@ -218,40 +248,85 @@ where
     }
 }
 
-impl<T> Drop for Task<T> {
-    fn drop(&mut self) {
-        #[cfg(feature = "tokio")]
-        if let Some(join_handle) = self.tokio.take() {
-            join_handle.abort();
-        }
-    }
-}
-
 impl<T> Future for Task<T> {
     type Output = Result<T>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.get_mut();
-
-        #[cfg(feature = "async-io")]
-        if let Some(task) = &mut this.async_io {
-            return Pin::new(task).poll(cx).map(Ok);
+        match &mut self.get_mut().0 {
+            #[cfg(feature = "async-io")]
+            TaskInner::AsyncExecutor(task) => Pin::new(task).poll(cx).map(Ok),
+            #[cfg(feature = "tokio")]
+            TaskInner::Tokio(task) => Pin::new(task).poll(cx),
+            #[cfg(any(test, not(any(feature = "async-io", feature = "tokio"))))]
+            TaskInner::Scheduler(handle) => Pin::new(handle).poll(cx),
         }
+    }
+}
 
-        #[cfg(feature = "tokio")]
-        if let Some(handle) = &mut this.tokio {
-            return Pin::new(handle).poll(cx).map(|r| match r {
-                Ok(v) => Ok(v),
-                Err(e) => {
-                    if e.is_cancelled() {
-                        Err(Error::other("tokio::task cancelled"))
-                    } else {
-                        panic!("tokio::task::JoinHandle error: {e}")
-                    }
+/// A tokio task handle that aborts the task when dropped, matching `async_task::Task`.
+#[cfg(feature = "tokio")]
+#[derive(Debug)]
+struct TokioTask<T>(Option<TokioJoinHandle<T>>);
+
+#[cfg(feature = "tokio")]
+impl<T> TokioTask<T> {
+    fn new(handle: TokioJoinHandle<T>) -> Self {
+        Self(Some(handle))
+    }
+
+    fn detach(mut self) {
+        // Dropping a tokio `JoinHandle` detaches it.
+        drop(self.0.take());
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl<T> Drop for TokioTask<T> {
+    fn drop(&mut self) {
+        if let Some(handle) = self.0.take() {
+            handle.abort();
+        }
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl<T> Future for TokioTask<T> {
+    type Output = Result<T>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let handle = self
+            .get_mut()
+            .0
+            .as_mut()
+            .expect("a `TokioTask` is only polled before it is detached or dropped");
+        Pin::new(handle).poll(cx).map(|r| match r {
+            Ok(v) => Ok(v),
+            Err(e) => {
+                if e.is_cancelled() {
+                    Err(Error::other("tokio::task cancelled"))
+                } else {
+                    panic!("tokio::task::JoinHandle error: {e}")
                 }
-            });
-        }
+            }
+        })
+    }
+}
 
-        unreachable!("Task always has exactly one backend")
+#[cfg(test)]
+mod tests {
+    use super::Executor;
+    use futures_lite::future::block_on;
+
+    #[test]
+    fn scheduler_backed_executor_runs_its_tasks() {
+        let executor = Executor::with_scheduler();
+        let task = executor.spawn(async { 7 }, "seven");
+        assert!(!executor.is_empty());
+        assert_eq!(block_on(executor.run(task)).unwrap(), 7);
+        assert!(executor.is_empty());
+
+        executor.spawn(async {}, "detached").detach();
+        block_on(executor.run(executor.tick()));
+        assert!(executor.is_empty());
     }
 }

--- a/zbus/src/runtime/mod.rs
+++ b/zbus/src/runtime/mod.rs
@@ -65,6 +65,8 @@ pub use async_drop::AsyncDrop;
 mod executor;
 pub use executor::{Executor, Task};
 pub(crate) mod async_lock;
+#[cfg(any(test, not(any(feature = "async-io", feature = "tokio"))))]
+pub(crate) mod sync;
 pub(crate) mod timeout;
 
 // Only the `unixexec` and `ibus` transports and, on macOS, the `launchd` one run commands.

--- a/zbus/src/runtime/mod.rs
+++ b/zbus/src/runtime/mod.rs
@@ -66,6 +66,8 @@ mod executor;
 pub use executor::{Executor, Task};
 pub(crate) mod async_lock;
 #[cfg(any(test, not(any(feature = "async-io", feature = "tokio"))))]
+pub(crate) mod scheduler;
+#[cfg(any(test, not(any(feature = "async-io", feature = "tokio"))))]
 pub(crate) mod sync;
 pub(crate) mod timeout;
 

--- a/zbus/src/runtime/mod.rs
+++ b/zbus/src/runtime/mod.rs
@@ -44,20 +44,13 @@ pub(crate) use select_runtime;
 
 /// Whether zbus should use tokio (rather than `async-io`) for its I/O.
 ///
-/// Only consulted when `async-io` is compiled in, since that's the only time there's a choice. With
-/// both backends we use tokio when a tokio runtime is active on the current thread; with only
-/// `async-io` the answer is always `false`. This keeps the features additive: enabling `tokio`
-/// elsewhere in the dependency graph doesn't force every zbus user into a tokio runtime.
-#[cfg(feature = "async-io")]
+/// Only compiled in when both backends are, since that's the only time there's a choice: we use
+/// tokio when a tokio runtime is active on the current thread. This keeps the features additive:
+/// enabling `tokio` elsewhere in the dependency graph doesn't force every zbus user into a tokio
+/// runtime.
+#[cfg(all(feature = "async-io", feature = "tokio"))]
 pub(crate) fn use_tokio() -> bool {
-    #[cfg(feature = "tokio")]
-    {
-        tokio::runtime::Handle::try_current().is_ok()
-    }
-    #[cfg(not(feature = "tokio"))]
-    {
-        false
-    }
+    tokio::runtime::Handle::try_current().is_ok()
 }
 
 mod async_drop;

--- a/zbus/src/runtime/scheduler.rs
+++ b/zbus/src/runtime/scheduler.rs
@@ -1,0 +1,616 @@
+//! The task scheduler for connections that no runtime backend drives.
+//!
+//! A connection built with an explicit reactor cannot spawn onto async-executor or Tokio: the
+//! first is a dependency an external-runtime user must not need, the second may not be compiled
+//! in at all. This is the smallest thing that runs such a connection's tasks: a ready queue that
+//! whoever polls [`Scheduler::run`] or [`Scheduler::tick`] drains in bounded batches. It has no
+//! threads of its own; the host's event loop provides every wakeup.
+
+use std::{
+    collections::VecDeque,
+    future::{Future, poll_fn},
+    io,
+    pin::{Pin, pin},
+    sync::{
+        Arc, Mutex, Weak,
+        atomic::{AtomicBool, Ordering},
+    },
+    task::{Context, Poll, Wake, Waker},
+};
+
+type BoxFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+
+/// How many ready tasks `run` polls before it lets the inner future and the host's other futures
+/// have a turn.
+const BATCH: usize = 16;
+
+#[derive(Default)]
+pub(crate) struct Scheduler {
+    ready: Mutex<VecDeque<Arc<TaskCell>>>,
+    /// Every spawned task that has neither finished nor been cancelled. Owning the cells here is
+    /// what lets dropping the scheduler drop every pending future.
+    ///
+    /// `forget` scans this linearly, which is fine for the handful of tasks a single connection
+    /// runs; a keyed map would be needed if that count ever grows large.
+    tasks: Mutex<Vec<Arc<TaskCell>>>,
+    /// Wakers of the callers currently inside `run` or `tick`.
+    ///
+    /// Bounded in practice even though wakers here are not necessarily `will_wake`-stable:
+    /// every `wake_drivers` call empties the vector, and only `run`'s self re-arm after a full
+    /// batch re-registers without an intervening wake, so it stays small.
+    drivers: Mutex<Vec<Waker>>,
+}
+
+impl Scheduler {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Queues `future` and returns the handle that joins or cancels it.
+    pub(crate) fn spawn<T>(
+        self: &Arc<Self>,
+        future: impl Future<Output = T> + Send + 'static,
+    ) -> JoinHandle<T>
+    where
+        T: Send + 'static,
+    {
+        let output = Arc::new(Mutex::new(Output::default()));
+        // Created outside the `async move` block so that a task dropped before its first poll
+        // (an async block only runs its body once polled) still drops this and wakes the joiner.
+        let finish = FinishOnDrop(output.clone());
+        let wrapped = {
+            let output = output.clone();
+            async move {
+                // Dropping this marker, on completion or cancellation alike, wakes the joiner.
+                let _finish = finish;
+                let value = future.await;
+                output.lock().expect("task output poisoned").value = Some(value);
+            }
+        };
+        let cell = Arc::new(TaskCell {
+            slot: Mutex::new(Slot::Idle(Box::pin(wrapped))),
+            scheduled: AtomicBool::new(false),
+            rerun: AtomicBool::new(false),
+            cancelled: AtomicBool::new(false),
+            scheduler: Arc::downgrade(self),
+        });
+        self.tasks
+            .lock()
+            .expect("scheduler tasks poisoned")
+            .push(cell.clone());
+        cell.wake_by_ref();
+        JoinHandle {
+            cell,
+            output,
+            detached: false,
+        }
+    }
+
+    /// Whether no spawned task is left.
+    ///
+    /// This has no wakeup source of its own, so a caller must not simply wait on it without a
+    /// notification of some kind; the `drained` test helper re-polls itself for that reason.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.tasks
+            .lock()
+            .expect("scheduler tasks poisoned")
+            .is_empty()
+    }
+
+    /// Polls the next queued task, waiting for one to be queued if none is.
+    pub(crate) async fn tick(&self) {
+        poll_fn(|cx| {
+            self.register_driver(cx.waker());
+            if self.run_one() {
+                Poll::Ready(())
+            } else {
+                Poll::Pending
+            }
+        })
+        .await
+    }
+
+    /// Drives the queued tasks until `future` completes.
+    ///
+    /// Tasks are polled in batches of [`BATCH`]; between batches the caller's waker is invoked
+    /// and `Pending` returned, so whoever polls this (a host event loop, another executor) gets
+    /// to run its own work in between.
+    ///
+    /// A panicking task propagates its panic out of `run`/`tick` and is forgotten, exactly as
+    /// if it had been cancelled.
+    pub(crate) async fn run<T>(&self, future: impl Future<Output = T>) -> T {
+        let mut future = pin!(future);
+        poll_fn(|cx| {
+            self.register_driver(cx.waker());
+            if let Poll::Ready(value) = future.as_mut().poll(cx) {
+                return Poll::Ready(value);
+            }
+            for _ in 0..BATCH {
+                if !self.run_one() {
+                    return Poll::Pending;
+                }
+            }
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        })
+        .await
+    }
+
+    /// Polls the next ready task once. Returns `false` when nothing was ready.
+    fn run_one(&self) -> bool {
+        let Some(cell) = self
+            .ready
+            .lock()
+            .expect("scheduler ready queue poisoned")
+            .pop_front()
+        else {
+            return false;
+        };
+        // Cleared before polling so that a wake arriving during the poll re-queues the task.
+        cell.scheduled.store(false, Ordering::Release);
+
+        let mut future = {
+            let mut slot = cell.slot.lock().expect("task slot poisoned");
+            match std::mem::replace(&mut *slot, Slot::Running) {
+                Slot::Idle(future) => future,
+                Slot::Running => {
+                    // Another driver is polling it; ask that driver to re-queue it afterwards.
+                    cell.rerun.store(true, Ordering::Release);
+                    return true;
+                }
+                Slot::Done => {
+                    *slot = Slot::Done;
+                    return true;
+                }
+            }
+        };
+
+        let waker = Waker::from(cell.clone());
+        let guard = PanicGuard {
+            scheduler: self,
+            cell: &cell,
+        };
+        let poll = future.as_mut().poll(&mut Context::from_waker(&waker));
+        drop(guard);
+
+        let finished = {
+            let mut slot = cell.slot.lock().expect("task slot poisoned");
+            if poll.is_ready() || cell.cancelled.load(Ordering::Acquire) {
+                *slot = Slot::Done;
+                true
+            } else {
+                *slot = Slot::Idle(future);
+                false
+            }
+        };
+        if finished {
+            self.forget(&cell);
+        }
+        if cell.rerun.swap(false, Ordering::AcqRel) {
+            cell.wake_by_ref();
+        }
+        true
+    }
+
+    fn forget(&self, cell: &Arc<TaskCell>) {
+        self.tasks
+            .lock()
+            .expect("scheduler tasks poisoned")
+            .retain(|task| !Arc::ptr_eq(task, cell));
+    }
+
+    fn register_driver(&self, waker: &Waker) {
+        let mut drivers = self.drivers.lock().expect("scheduler drivers poisoned");
+        if !drivers.iter().any(|known| known.will_wake(waker)) {
+            drivers.push(waker.clone());
+        }
+    }
+
+    fn wake_drivers(&self) {
+        let drivers = {
+            let mut drivers = self.drivers.lock().expect("scheduler drivers poisoned");
+            std::mem::take(&mut *drivers)
+        };
+        for waker in drivers {
+            waker.wake();
+        }
+    }
+}
+
+/// Cleans up after a task whose poll panicked, so the panic leaves neither a cell that is
+/// `Running` forever nor an entry in `tasks` that pins `is_empty` to `false`.
+struct PanicGuard<'a> {
+    scheduler: &'a Scheduler,
+    cell: &'a Arc<TaskCell>,
+}
+
+impl Drop for PanicGuard<'_> {
+    fn drop(&mut self) {
+        if !std::thread::panicking() {
+            return;
+        }
+        // The slot lock is never held across the poll, so it cannot be poisoned by the panic;
+        // tolerate poisoning anyway rather than panic inside a panic, which would abort.
+        let mut slot = self
+            .cell
+            .slot
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *slot = Slot::Done;
+        drop(slot);
+        self.scheduler.forget(self.cell);
+    }
+}
+
+impl Drop for Scheduler {
+    fn drop(&mut self) {
+        // The cells may outlive the scheduler through wakers a reactor still holds; emptying the
+        // slots here is what drops the futures now rather than whenever those wakers go.
+        let tasks = std::mem::take(self.tasks.get_mut().expect("scheduler tasks poisoned"));
+        for cell in tasks {
+            let future = {
+                let mut slot = cell.slot.lock().expect("task slot poisoned");
+                std::mem::replace(&mut *slot, Slot::Done)
+            };
+            drop(future);
+        }
+    }
+}
+
+impl std::fmt::Debug for Scheduler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Scheduler")
+            .field(
+                "tasks",
+                &self.tasks.lock().expect("scheduler tasks poisoned").len(),
+            )
+            .finish_non_exhaustive()
+    }
+}
+
+struct TaskCell {
+    slot: Mutex<Slot>,
+    /// Set while the cell sits in the ready queue; suppresses duplicate entries.
+    scheduled: AtomicBool,
+    /// Set by a driver that found the task being polled by another driver.
+    rerun: AtomicBool,
+    cancelled: AtomicBool,
+    scheduler: Weak<Scheduler>,
+}
+
+enum Slot {
+    Idle(BoxFuture),
+    Running,
+    Done,
+}
+
+impl Wake for TaskCell {
+    fn wake(self: Arc<Self>) {
+        self.wake_by_ref();
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        if self.scheduled.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let Some(scheduler) = self.scheduler.upgrade() else {
+            return;
+        };
+        scheduler
+            .ready
+            .lock()
+            .expect("scheduler ready queue poisoned")
+            .push_back(self.clone());
+        scheduler.wake_drivers();
+    }
+}
+
+/// Joins a spawned task; dropping it cancels the task unless [`JoinHandle::detach`] was called.
+pub(crate) struct JoinHandle<T> {
+    cell: Arc<TaskCell>,
+    output: Arc<Mutex<Output<T>>>,
+    detached: bool,
+}
+
+struct Output<T> {
+    value: Option<T>,
+    finished: bool,
+    joiner: Option<Waker>,
+}
+
+impl<T> Default for Output<T> {
+    fn default() -> Self {
+        Self {
+            value: None,
+            finished: false,
+            joiner: None,
+        }
+    }
+}
+
+struct FinishOnDrop<T>(Arc<Mutex<Output<T>>>);
+
+impl<T> Drop for FinishOnDrop<T> {
+    fn drop(&mut self) {
+        let joiner = {
+            let mut output = self.0.lock().expect("task output poisoned");
+            output.finished = true;
+            output.joiner.take()
+        };
+        if let Some(joiner) = joiner {
+            joiner.wake();
+        }
+    }
+}
+
+impl<T> JoinHandle<T> {
+    /// Lets the task run to completion on its own.
+    pub(crate) fn detach(mut self) {
+        self.detached = true;
+    }
+}
+
+impl<T> Drop for JoinHandle<T> {
+    fn drop(&mut self) {
+        if self.detached {
+            return;
+        }
+        self.cell.cancelled.store(true, Ordering::Release);
+        let idle = {
+            let mut slot = self.cell.slot.lock().expect("task slot poisoned");
+            match std::mem::replace(&mut *slot, Slot::Done) {
+                Slot::Idle(future) => Some(future),
+                // A running task is dropped by its driver once the poll returns.
+                Slot::Running => {
+                    *slot = Slot::Running;
+                    None
+                }
+                Slot::Done => None,
+            }
+        };
+        if let Some(future) = idle {
+            drop(future);
+            if let Some(scheduler) = self.cell.scheduler.upgrade() {
+                scheduler.forget(&self.cell);
+            }
+        }
+    }
+}
+
+impl<T> Future for JoinHandle<T> {
+    type Output = io::Result<T>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut output = self.output.lock().expect("task output poisoned");
+        if let Some(value) = output.value.take() {
+            return Poll::Ready(Ok(value));
+        }
+        if output.finished {
+            return Poll::Ready(Err(io::Error::other("task cancelled")));
+        }
+        output.joiner = Some(cx.waker().clone());
+        Poll::Pending
+    }
+}
+
+impl<T> std::fmt::Debug for JoinHandle<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("JoinHandle")
+            .field("detached", &self.detached)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use event_listener::Event;
+    use futures_lite::future::{block_on, yield_now};
+    use ntest::timeout;
+    use std::{
+        panic::{AssertUnwindSafe, catch_unwind},
+        sync::atomic::AtomicUsize,
+        thread,
+        time::Duration,
+    };
+
+    /// Resolves once `scheduler` has no tasks left, re-polling on every wake.
+    async fn drained(scheduler: &Scheduler) {
+        poll_fn(|cx| {
+            if scheduler.is_empty() {
+                Poll::Ready(())
+            } else {
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+        })
+        .await
+    }
+
+    #[test]
+    #[timeout(15000)]
+    fn spawn_and_join() {
+        let scheduler = Arc::new(Scheduler::new());
+        let handle = scheduler.spawn(async { 42 });
+        assert_eq!(block_on(scheduler.run(handle)).unwrap(), 42);
+        assert!(scheduler.is_empty());
+    }
+
+    #[test]
+    #[timeout(5000)]
+    fn wake_from_another_thread_reaches_the_driver() {
+        let scheduler = Arc::new(Scheduler::new());
+        let event = Arc::new(Event::new());
+        let handle = {
+            let event = event.clone();
+            scheduler.spawn(async move {
+                let listener = event.listen();
+                listener.await;
+                "woken"
+            })
+        };
+        thread::spawn(move || {
+            thread::sleep(Duration::from_millis(50));
+            event.notify(1);
+        });
+        assert_eq!(block_on(scheduler.run(handle)).unwrap(), "woken");
+    }
+
+    #[test]
+    #[timeout(15000)]
+    fn task_woken_during_its_own_poll_runs_again() {
+        struct WakeOnce(bool);
+        impl Future for WakeOnce {
+            type Output = ();
+            fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+                if self.0 {
+                    Poll::Ready(())
+                } else {
+                    self.0 = true;
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+            }
+        }
+        let scheduler = Arc::new(Scheduler::new());
+        let handle = scheduler.spawn(WakeOnce(false));
+        block_on(scheduler.run(handle)).unwrap();
+    }
+
+    #[test]
+    #[timeout(15000)]
+    fn dropping_the_handle_cancels_and_drops_the_future() {
+        struct SetOnDrop(Arc<AtomicBool>);
+        impl Drop for SetOnDrop {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::Release);
+            }
+        }
+        let scheduler = Arc::new(Scheduler::new());
+        let dropped = Arc::new(AtomicBool::new(false));
+        let handle = {
+            let marker = SetOnDrop(dropped.clone());
+            scheduler.spawn(async move {
+                let _marker = marker;
+                std::future::pending::<()>().await;
+            })
+        };
+        // Let the task register its (never-firing) wakeup so it is idle, not merely queued.
+        block_on(scheduler.run(yield_now()));
+        drop(handle);
+        assert!(dropped.load(Ordering::Acquire));
+        assert!(scheduler.is_empty());
+    }
+
+    #[test]
+    #[timeout(15000)]
+    fn detached_task_runs_to_completion() {
+        let scheduler = Arc::new(Scheduler::new());
+        let ran = Arc::new(AtomicBool::new(false));
+        {
+            let ran = ran.clone();
+            scheduler
+                .spawn(async move {
+                    yield_now().await;
+                    ran.store(true, Ordering::Release);
+                })
+                .detach();
+        }
+        block_on(scheduler.run(drained(&scheduler)));
+        assert!(ran.load(Ordering::Acquire));
+    }
+
+    #[test]
+    #[timeout(15000)]
+    fn dropping_the_scheduler_fails_pending_joins() {
+        let scheduler = Arc::new(Scheduler::new());
+        let handle = scheduler.spawn(std::future::pending::<()>());
+        drop(scheduler);
+        assert!(block_on(handle).is_err());
+    }
+
+    #[test]
+    #[timeout(15000)]
+    fn run_yields_to_the_inner_future_between_batches() {
+        let scheduler = Arc::new(Scheduler::new());
+        let polls = Arc::new(AtomicUsize::new(0));
+        // Proves the batch bound keeps an always-ready task from monopolising `run`: this task
+        // is always ready and reschedules itself, yet the inner future still gets polled.
+        scheduler
+            .spawn(async {
+                loop {
+                    yield_now().await;
+                }
+            })
+            .detach();
+        let inner = {
+            let polls = polls.clone();
+            poll_fn(move |cx| {
+                if polls.fetch_add(1, Ordering::AcqRel) >= 3 {
+                    Poll::Ready(())
+                } else {
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+            })
+        };
+        block_on(scheduler.run(inner));
+        assert!(polls.load(Ordering::Acquire) >= 4);
+    }
+
+    #[test]
+    #[timeout(5000)]
+    fn run_re_arms_itself_when_a_batch_leaves_tasks_ready() {
+        // More immediately-ready tasks than one batch: after the first batch, nothing but
+        // `run`'s own re-arm can get the rest polled, `last` (which we wait on) included.
+        let scheduler = Arc::new(Scheduler::new());
+        let total = BATCH + 4;
+        let mut handles = Vec::new();
+        for _ in 0..total {
+            handles.push(scheduler.spawn(async {}));
+        }
+        let last = handles.pop().expect("at least one task was spawned");
+        block_on(scheduler.run(last)).unwrap();
+        assert!(scheduler.is_empty());
+    }
+
+    #[test]
+    #[timeout(15000)]
+    fn tick_runs_one_task() {
+        let scheduler = Arc::new(Scheduler::new());
+        let count = Arc::new(AtomicUsize::new(0));
+        for _ in 0..2 {
+            let count = count.clone();
+            scheduler
+                .spawn(async move {
+                    count.fetch_add(1, Ordering::AcqRel);
+                })
+                .detach();
+        }
+        block_on(scheduler.tick());
+        assert_eq!(count.load(Ordering::Acquire), 1);
+        block_on(scheduler.tick());
+        assert_eq!(count.load(Ordering::Acquire), 2);
+        assert!(scheduler.is_empty());
+    }
+
+    #[test]
+    #[timeout(15000)]
+    fn panicking_task_propagates_and_is_forgotten() {
+        let scheduler = Arc::new(Scheduler::new());
+        let handle = scheduler.spawn(async { panic!("task panicked on purpose") });
+        let outcome = catch_unwind(AssertUnwindSafe(|| block_on(scheduler.tick())));
+        assert!(
+            outcome.is_err(),
+            "the panic must propagate out of the driver"
+        );
+        assert!(
+            scheduler.is_empty(),
+            "a panicked task must not stay registered"
+        );
+        assert!(
+            block_on(handle).is_err(),
+            "joining a panicked task reports cancellation"
+        );
+    }
+}

--- a/zbus/src/runtime/sync.rs
+++ b/zbus/src/runtime/sync.rs
@@ -1,0 +1,534 @@
+//! Async locks for builds without a runtime backend.
+//!
+//! With neither `async-io` nor `tokio` compiled in there is no lock crate to lean on, so these
+//! primitives are built on `event-listener`, which every `comms` build already has. They offer
+//! exactly the API the rest of the crate uses: no `try_` variants, no upgrades, no fairness
+//! guarantees beyond "a release wakes a waiter". The `RwLock` is write-preferring, so, as with
+//! `async-lock` and `tokio`, a task already holding a read guard must not call `read()` again:
+//! a writer registering in between would deadlock it.
+
+use event_listener::Event;
+use std::{
+    cell::UnsafeCell,
+    ops::{Deref, DerefMut},
+    sync::{
+        Mutex as SyncMutex,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+};
+
+/// A mutual-exclusion lock whose `lock` future waits without blocking the thread.
+pub(crate) struct Mutex<T: ?Sized> {
+    locked: AtomicBool,
+    unlocked: Event,
+    value: UnsafeCell<T>,
+}
+
+// SAFETY: the lock hands out at most one guard at a time, so a `T: Send` only ever moves between
+// the threads that take turns holding that guard; sharing the mutex grants no other access.
+unsafe impl<T: ?Sized + Send> Send for Mutex<T> {}
+unsafe impl<T: ?Sized + Send> Sync for Mutex<T> {}
+
+impl<T> Mutex<T> {
+    pub const fn new(value: T) -> Self {
+        Self {
+            locked: AtomicBool::new(false),
+            unlocked: Event::new(),
+            value: UnsafeCell::new(value),
+        }
+    }
+}
+
+impl<T: ?Sized> Mutex<T> {
+    /// Acquires the lock, waiting for the current holder to release it.
+    pub async fn lock(&self) -> MutexGuard<'_, T> {
+        loop {
+            if let Some(guard) = self.try_lock() {
+                return guard;
+            }
+            // Listen before re-checking so a release between the check and the wait is seen.
+            let listener = self.unlocked.listen();
+            if let Some(guard) = self.try_lock() {
+                return guard;
+            }
+            listener.await;
+        }
+    }
+
+    fn try_lock(&self) -> Option<MutexGuard<'_, T>> {
+        self.locked
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_ok()
+            .then(|| MutexGuard(self))
+    }
+}
+
+impl<T: Default> Default for Mutex<T> {
+    fn default() -> Self {
+        Self::new(T::default())
+    }
+}
+
+impl<T: ?Sized + std::fmt::Debug> std::fmt::Debug for Mutex<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut s = f.debug_struct("Mutex");
+        match self.try_lock() {
+            Some(guard) => s.field("value", &&*guard),
+            None => s.field("value", &format_args!("<locked>")),
+        };
+        s.finish()
+    }
+}
+
+#[must_use]
+pub(crate) struct MutexGuard<'a, T: ?Sized>(&'a Mutex<T>);
+
+// SAFETY: a guard is the unique access path to the value while it exists, so it is `Send` when
+// the value can move between threads and `Sync` when the value can be shared.
+unsafe impl<T: ?Sized + Send> Send for MutexGuard<'_, T> {}
+unsafe impl<T: ?Sized + Sync> Sync for MutexGuard<'_, T> {}
+
+impl<T: ?Sized> Deref for MutexGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        // SAFETY: `locked` is set and only this guard clears it, so nothing else touches the
+        // value.
+        unsafe { &*self.0.value.get() }
+    }
+}
+
+impl<T: ?Sized> DerefMut for MutexGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        // SAFETY: as in `deref`, plus `&mut self` rules out another reference through this
+        // guard.
+        unsafe { &mut *self.0.value.get() }
+    }
+}
+
+impl<T: ?Sized> Drop for MutexGuard<'_, T> {
+    fn drop(&mut self) {
+        self.0.locked.store(false, Ordering::Release);
+        // event-listener hands a notification on to the next listener if the notified one is
+        // dropped before it is polled, so a cancelled `lock` cannot strand the waiter after it.
+        self.0.unlocked.notify(1);
+    }
+}
+
+/// A readers-writer lock. A waiting writer blocks new readers so that a stream of readers
+/// cannot starve it.
+pub(crate) struct RwLock<T: ?Sized> {
+    state: SyncMutex<RwState>,
+    readers_may_enter: Event,
+    writer_may_enter: Event,
+    value: UnsafeCell<T>,
+}
+
+struct RwState {
+    readers: usize,
+    writer: bool,
+    writers_waiting: usize,
+}
+
+// SAFETY: readers only get shared references and a writer gets the only reference, which is the
+// same discipline as `std::sync::RwLock`; hence the same bounds.
+unsafe impl<T: ?Sized + Send> Send for RwLock<T> {}
+unsafe impl<T: ?Sized + Send + Sync> Sync for RwLock<T> {}
+
+impl<T> RwLock<T> {
+    pub const fn new(value: T) -> Self {
+        Self {
+            state: SyncMutex::new(RwState {
+                readers: 0,
+                writer: false,
+                writers_waiting: 0,
+            }),
+            readers_may_enter: Event::new(),
+            writer_may_enter: Event::new(),
+            value: UnsafeCell::new(value),
+        }
+    }
+}
+
+impl<T: ?Sized> RwLock<T> {
+    /// Acquires shared access, waiting while a writer holds or waits for the lock.
+    pub async fn read(&self) -> RwLockReadGuard<'_, T> {
+        loop {
+            if let Some(guard) = self.try_read() {
+                return guard;
+            }
+            let listener = self.readers_may_enter.listen();
+            if let Some(guard) = self.try_read() {
+                return guard;
+            }
+            listener.await;
+        }
+    }
+
+    /// Acquires exclusive access, waiting for every reader and writer to leave.
+    pub async fn write(&self) -> RwLockWriteGuard<'_, T> {
+        let waiting = WaitingWriter::register(self);
+        loop {
+            if let Some(guard) = self.try_write() {
+                waiting.granted();
+                return guard;
+            }
+            let listener = self.writer_may_enter.listen();
+            if let Some(guard) = self.try_write() {
+                waiting.granted();
+                return guard;
+            }
+            listener.await;
+        }
+    }
+
+    fn try_read(&self) -> Option<RwLockReadGuard<'_, T>> {
+        let mut state = self.state.lock().expect("RwLock state poisoned");
+        if state.writer || state.writers_waiting > 0 {
+            return None;
+        }
+        state.readers += 1;
+        Some(RwLockReadGuard(self))
+    }
+
+    fn try_write(&self) -> Option<RwLockWriteGuard<'_, T>> {
+        let mut state = self.state.lock().expect("RwLock state poisoned");
+        if state.writer || state.readers > 0 {
+            return None;
+        }
+        state.writer = true;
+        Some(RwLockWriteGuard(self))
+    }
+}
+
+impl<T: Default> Default for RwLock<T> {
+    fn default() -> Self {
+        Self::new(T::default())
+    }
+}
+
+// No `T: Debug` bound: the crate stores `RwLock<dyn Interface>`, and the `dyn` type is not
+// `Debug`, so this impl must serve unsized, non-`Debug` values too and therefore prints no
+// fields.
+impl<T: ?Sized> std::fmt::Debug for RwLock<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RwLock").finish_non_exhaustive()
+    }
+}
+
+/// Counts a `write` call as waiting for as long as its future lives, so that readers are held
+/// back only while a writer really is waiting: a cancelled `write` lets them in again.
+struct WaitingWriter<'a, T: ?Sized> {
+    lock: &'a RwLock<T>,
+    counted: bool,
+}
+
+impl<'a, T: ?Sized> WaitingWriter<'a, T> {
+    fn register(lock: &'a RwLock<T>) -> Self {
+        lock.state
+            .lock()
+            .expect("RwLock state poisoned")
+            .writers_waiting += 1;
+        Self {
+            lock,
+            counted: true,
+        }
+    }
+
+    fn granted(mut self) {
+        self.counted = false;
+        let mut state = self.lock.state.lock().expect("RwLock state poisoned");
+        state.writers_waiting -= 1;
+    }
+}
+
+impl<T: ?Sized> Drop for WaitingWriter<'_, T> {
+    fn drop(&mut self) {
+        if !self.counted {
+            return;
+        }
+        let mut state = self.lock.state.lock().expect("RwLock state poisoned");
+        state.writers_waiting -= 1;
+        if state.writers_waiting == 0 && !state.writer {
+            drop(state);
+            self.lock.readers_may_enter.notify(usize::MAX);
+        }
+    }
+}
+
+#[must_use]
+pub(crate) struct RwLockReadGuard<'a, T: ?Sized>(&'a RwLock<T>);
+
+// SAFETY: a read guard only ever yields `&T`, so it is `Send`/`Sync` exactly when `&T` is.
+unsafe impl<T: ?Sized + Sync> Send for RwLockReadGuard<'_, T> {}
+unsafe impl<T: ?Sized + Sync> Sync for RwLockReadGuard<'_, T> {}
+
+impl<T: ?Sized> Deref for RwLockReadGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        // SAFETY: `readers > 0` and no writer holds the lock while this guard exists.
+        unsafe { &*self.0.value.get() }
+    }
+}
+
+impl<T: ?Sized> Drop for RwLockReadGuard<'_, T> {
+    fn drop(&mut self) {
+        let mut state = self.0.state.lock().expect("RwLock state poisoned");
+        state.readers -= 1;
+        if state.readers == 0 {
+            drop(state);
+            self.0.writer_may_enter.notify(1);
+        }
+    }
+}
+
+#[must_use]
+pub(crate) struct RwLockWriteGuard<'a, T: ?Sized>(&'a RwLock<T>);
+
+// SAFETY: a write guard is the unique access path to the value while it exists; same bounds as
+// `MutexGuard`.
+unsafe impl<T: ?Sized + Send> Send for RwLockWriteGuard<'_, T> {}
+unsafe impl<T: ?Sized + Sync> Sync for RwLockWriteGuard<'_, T> {}
+
+impl<T: ?Sized> Deref for RwLockWriteGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        // SAFETY: `writer` is set and nobody else holds the lock while this guard exists.
+        unsafe { &*self.0.value.get() }
+    }
+}
+
+impl<T: ?Sized> DerefMut for RwLockWriteGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        // SAFETY: as in `deref`, plus `&mut self` rules out another reference through this
+        // guard.
+        unsafe { &mut *self.0.value.get() }
+    }
+}
+
+impl<T: ?Sized> Drop for RwLockWriteGuard<'_, T> {
+    fn drop(&mut self) {
+        let mut state = self.0.state.lock().expect("RwLock state poisoned");
+        state.writer = false;
+        let writers_waiting = state.writers_waiting;
+        drop(state);
+        if writers_waiting > 0 {
+            self.0.writer_may_enter.notify(1);
+        } else {
+            self.0.readers_may_enter.notify(usize::MAX);
+        }
+    }
+}
+
+/// A counting semaphore.
+pub(crate) struct Semaphore {
+    permits: AtomicUsize,
+    released: Event,
+}
+
+impl Semaphore {
+    pub const fn new(permits: usize) -> Self {
+        Self {
+            permits: AtomicUsize::new(permits),
+            released: Event::new(),
+        }
+    }
+
+    /// Takes one permit, waiting for one to be released if none is free.
+    pub async fn acquire(&self) -> SemaphorePermit<'_> {
+        loop {
+            if let Some(permit) = self.try_acquire() {
+                return permit;
+            }
+            let listener = self.released.listen();
+            if let Some(permit) = self.try_acquire() {
+                return permit;
+            }
+            listener.await;
+        }
+    }
+
+    fn try_acquire(&self) -> Option<SemaphorePermit<'_>> {
+        self.permits
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |permits| {
+                permits.checked_sub(1)
+            })
+            .is_ok()
+            .then(|| SemaphorePermit(self))
+    }
+}
+
+impl std::fmt::Debug for Semaphore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Semaphore")
+            .field("permits", &self.permits.load(Ordering::Relaxed))
+            .finish()
+    }
+}
+
+#[must_use]
+pub(crate) struct SemaphorePermit<'a>(&'a Semaphore);
+
+impl Drop for SemaphorePermit<'_> {
+    fn drop(&mut self) {
+        self.0.permits.fetch_add(1, Ordering::AcqRel);
+        // `notify_additional`, not `notify`: each released permit is one more waiter that can
+        // proceed, and `notify` would coalesce with a still-pending notification from another
+        // permit released concurrently, stranding a waiter that has a permit available to it.
+        self.0.released.notify_additional(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_lite::future::block_on;
+    use ntest::timeout;
+    use std::{
+        future::Future,
+        ops::DerefMut,
+        pin::pin,
+        sync::Arc,
+        task::{Context, Poll, Waker},
+        thread,
+    };
+
+    /// Polls `future` once with a no-op waker; the locks re-check their state on every poll, so
+    /// this is enough to observe "would wait" versus "acquired". Generic over the pointer so it
+    /// takes a `Box::pin`-ed future as readily as a `pin!`-ed one: a test that needs to cancel a
+    /// future early must own it through a `Box`, since dropping a `pin!`-ed binding only ends
+    /// that local borrow and leaves the future itself alive (and registered) until the enclosing
+    /// scope exits.
+    fn poll_once<F: Future, P: DerefMut<Target = F>>(
+        future: &mut std::pin::Pin<P>,
+    ) -> Poll<F::Output> {
+        future
+            .as_mut()
+            .poll(&mut Context::from_waker(Waker::noop()))
+    }
+
+    #[test]
+    #[timeout(15000)]
+    fn mutex_excludes_concurrent_holders() {
+        let counter = Arc::new(Mutex::new(0u32));
+        let threads: Vec<_> = (0..8)
+            .map(|_| {
+                let counter = counter.clone();
+                thread::spawn(move || {
+                    for _ in 0..1000 {
+                        block_on(async {
+                            let mut value = counter.lock().await;
+                            let seen = *value;
+                            thread::yield_now();
+                            *value = seen + 1;
+                        });
+                    }
+                })
+            })
+            .collect();
+        for thread in threads {
+            thread.join().unwrap();
+        }
+        assert_eq!(*block_on(counter.lock()), 8000);
+    }
+
+    #[test]
+    fn mutex_wakes_a_waiter_on_release() {
+        let mutex = Mutex::new(());
+        let held = block_on(mutex.lock());
+        let mut waiter = pin!(mutex.lock());
+        assert!(poll_once(&mut waiter).is_pending());
+        drop(held);
+        assert!(poll_once(&mut waiter).is_ready());
+    }
+
+    #[test]
+    fn cancelled_lock_does_not_strand_the_next_waiter() {
+        let mutex = Mutex::new(());
+        let held = block_on(mutex.lock());
+        // `Box::pin` so the `drop` below actually cancels the future, rather than just ending
+        // the borrow of a `pin!`-ed one while its storage lives on until the test returns.
+        let mut first = Box::pin(mutex.lock());
+        let mut second = pin!(mutex.lock());
+        assert!(poll_once(&mut first).is_pending());
+        assert!(poll_once(&mut second).is_pending());
+        // The release notifies `first`, which is gone; the notification must reach `second`.
+        drop(first);
+        drop(held);
+        assert!(poll_once(&mut second).is_ready());
+    }
+
+    #[test]
+    fn rwlock_shares_between_readers() {
+        let lock = RwLock::new(1u8);
+        let first = block_on(lock.read());
+        let second = block_on(lock.read());
+        assert_eq!(*first + *second, 2);
+    }
+
+    #[test]
+    fn rwlock_waiting_writer_blocks_new_readers() {
+        let lock = RwLock::new(0u8);
+        let reader = block_on(lock.read());
+        let mut writer = pin!(lock.write());
+        assert!(poll_once(&mut writer).is_pending());
+        let mut late_reader = pin!(lock.read());
+        assert!(poll_once(&mut late_reader).is_pending());
+        drop(reader);
+        let Poll::Ready(mut guard) = poll_once(&mut writer) else {
+            panic!("the writer must get the lock once the last reader leaves");
+        };
+        *guard = 7;
+        assert!(poll_once(&mut late_reader).is_pending());
+        drop(guard);
+        let Poll::Ready(value) = poll_once(&mut late_reader) else {
+            panic!("readers must get in once the writer leaves");
+        };
+        assert_eq!(*value, 7);
+    }
+
+    #[test]
+    fn cancelled_writer_lets_readers_in_again() {
+        let lock = RwLock::new(());
+        let reader = block_on(lock.read());
+        // `Box::pin` so the `drop` below actually cancels the future; see the comment on the
+        // equivalent `Mutex` test.
+        let mut writer = Box::pin(lock.write());
+        assert!(poll_once(&mut writer).is_pending());
+        let mut late_reader = pin!(lock.read());
+        assert!(poll_once(&mut late_reader).is_pending());
+        drop(writer);
+        assert!(poll_once(&mut late_reader).is_ready());
+        drop(reader);
+    }
+
+    #[test]
+    fn rwlock_coerces_to_an_unsized_value() {
+        trait Named {
+            fn name(&self) -> &'static str;
+        }
+        struct Thing;
+        impl Named for Thing {
+            fn name(&self) -> &'static str {
+                "thing"
+            }
+        }
+        let lock: Arc<RwLock<dyn Named + Send + Sync>> = Arc::new(RwLock::new(Thing));
+        assert_eq!(block_on(lock.read()).name(), "thing");
+        assert_eq!(block_on(lock.write()).name(), "thing");
+    }
+
+    #[test]
+    fn semaphore_admits_at_most_its_permits() {
+        static SEMAPHORE: Semaphore = Semaphore::new(2);
+        let first = block_on(SEMAPHORE.acquire());
+        let second = block_on(SEMAPHORE.acquire());
+        let mut third = pin!(SEMAPHORE.acquire());
+        assert!(poll_once(&mut third).is_pending());
+        drop(first);
+        assert!(poll_once(&mut third).is_ready());
+        drop(second);
+    }
+}


### PR DESCRIPTION
Second of four PRs for #1960 (design: #1961). Based on #1962, so the rename commit shows up here
until that one merges; only the last three commits are new.

- `runtime::sync`: `Mutex`, writer-preferring `RwLock` and `Semaphore` built on `event-listener`,
  with exactly the API the crate uses.
- `runtime::scheduler`: a ready-queue task scheduler with cancel-on-drop join handles, bounded
  batches that re-arm themselves, a panic guard, and no threads of its own.
- `Executor`/`Task` become enums over async-executor, tokio and the scheduler.

Both modules and the scheduler variant are selected only in a build with neither `async-io` nor
`tokio`, which stays a compile error until the reactor lands in the next PR; today they are
reachable only from their unit tests, which run in every configuration. The built-in backends are
unchanged, and neither module references any crate the `async-io` feature owns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZG5dKScVZhnycsSGwHUXZ

